### PR TITLE
Issue #48: Server-side dice rolling, cosmetic frontend animation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,7 +51,11 @@ export default function App() {
     try {
       setDungeons(await listDungeons())
       const sel = selectedRef.current
-      if (sel) setDetail(await getDungeon(sel.ns, sel.name))
+      if (sel) {
+        const d = await getDungeon(sel.ns, sel.name)
+        setDetail(d)
+        prevInventoryRef.current = d.spec.inventory || ''
+      }
     } catch {}
   }, [])
 
@@ -242,7 +246,7 @@ export default function App() {
           attackTarget={attackTarget}
           floatingDmg={floatingDmg}
           lootDrop={lootDrop}
-          onDismissLoot={() => setLootDrop(null)}
+          onDismissLoot={() => { setLootDrop(null); prevInventoryRef.current = detail?.spec.inventory || '' }}
           events={events}
           showLoot={showLoot}
           onOpenLoot={() => setShowLoot(true)}


### PR DESCRIPTION
## Changes
- Attack Job rolls dice server-side based on difficulty (2d8+5 / 2d10+8 / 3d10+10)
- Boss gets upgraded dice (+1 die, +2 sides, +2 mod) computed in the Job
- Frontend submits `damage: 0` — dice animation is purely cosmetic
- Floating damage number shows real value parsed from CR `lastHeroAction`
- Backstab submits `damage: 0` (server applies 3x to rolled dice)
- Backend removes damage validation (all damage computed server-side)
- kubectl users can still pass `damage > 0` for manual override

Closes #48