### PR TITLE
fix: flaky rate limit test (#56)

### DIFF
--- a/tests/backend-api.sh
+++ b/tests/backend-api.sh
@@ -108,13 +108,11 @@ CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/tes
 
 # --- Test 10: Rate limiting ---
 log "Test 10: Rate limiting"
-# Fire two attacks simultaneously — second should be rate limited
+# Fire first attack and wait for it to complete, then fire second within rate limit window
 curl -s -o /dev/null -X POST "$BASE/api/v1/dungeons/tests/$DUNGEON/attacks" \
-  -H "Content-Type: application/json" -d "{\"target\":\"${DUNGEON}-monster-1\",\"damage\":10}" &
-sleep 0.1
+  -H "Content-Type: application/json" -d "{\"target\":\"${DUNGEON}-monster-1\",\"damage\":10}"
 CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/tests/$DUNGEON/attacks" \
   -H "Content-Type: application/json" -d "{\"target\":\"${DUNGEON}-monster-1\",\"damage\":10}")
-wait
 [ "$CODE" = "429" ] && pass "Rate limited -> 429" || fail "Rate limit not enforced -> $CODE"
 
 # --- Test 11: Metrics after operations ---


### PR DESCRIPTION
Closes #56

First request was backgrounded with `sleep 0.1` before the second, causing a race where the rate limiter sometimes didn't register the first request's timestamp before the second arrived.

Now fires sequentially: first request completes, second fires immediately within the 300ms rate limit window → guaranteed 429.