### PR TITLE
feat: readyWhen cascade for full game progression (#42)

### DIFF
--- a/manifests/rgds/boss-graph.yaml
+++ b/manifests/rgds/boss-graph.yaml
@@ -20,6 +20,8 @@ spec:
 
   resources:
     - id: bossPod
+      readyWhen:
+        - ${schema.spec.monstersAlive == 0}
       template:
         apiVersion: v1
         kind: Pod

--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -110,6 +110,7 @@ spec:
           namespace: ${ns.metadata.name}
         spec:
           dungeonName: ${schema.metadata.name}
+          bossDefeated: "${schema.spec.bossHP <= 0 ? 1 : 0}"
 
     # --- Modifier CR (conditional: only created when modifier is not "none") ---
     - id: modifierCR

--- a/manifests/rgds/monster-graph.yaml
+++ b/manifests/rgds/monster-graph.yaml
@@ -20,6 +20,8 @@ spec:
 
   resources:
     - id: monsterPod
+      readyWhen:
+        - ${monsterPod.status.phase == "Running"}
       template:
         apiVersion: v1
         kind: Pod

--- a/manifests/rgds/treasure-graph.yaml
+++ b/manifests/rgds/treasure-graph.yaml
@@ -11,11 +11,14 @@ spec:
     group: game.k8s.example
     spec:
       dungeonName: string | required=true
+      bossDefeated: integer | default=0
     status:
-      loot: "${'Treasure code: ' + treasureSecret.metadata.name + '-LOOT'}"
+      loot: "${schema.spec.bossDefeated == 1 ? 'Treasure code: ' + treasureSecret.metadata.name + '-LOOT' : 'Locked'}"
 
   resources:
     - id: treasureSecret
+      readyWhen:
+        - ${schema.spec.bossDefeated == 1}
       template:
         apiVersion: v1
         kind: Secret


### PR DESCRIPTION
Closes #42

Adds `readyWhen` gates across the RGD chain so kro's reconciliation loop structurally enforces game progression:

```
Monster Pods (readyWhen: Running)
    ↓ all dead
Boss Pod (readyWhen: monstersAlive == 0)
    ↓ defeated  
Treasure Secret (readyWhen: bossDefeated == 1)
    ↓ loot unlocked
Dungeon status: victory
```

**Changes:**
- `monster-graph`: `readyWhen` pod is Running
- `boss-graph`: `readyWhen` monstersAlive == 0 — boss structurally blocked until all monsters dead
- `treasure-graph`: adds `bossDefeated` spec field, `readyWhen` bossDefeated == 1, loot shows "Locked" until boss killed
- `dungeon-graph`: passes `bossDefeated` (from bossHP) to Treasure CR

**Cascade rollback:** Deleting a monster CR mid-game → kro recreates it → monstersAlive > 0 → boss reverts to not-ready. This is the headline kro demo.