### PR TITLE
fix: UI smoke test uses wrong namespace (#62)

### DIFF
--- a/tests/e2e/smoke-test.js
+++ b/tests/e2e/smoke-test.js
@@ -76,7 +76,7 @@ async function runTests() {
 
     // Navigate to dungeon
     await page.waitForTimeout(5000); // kro reconciliation
-    await page.goto(`${BASE_URL}/dungeon/tests/${dName}`, { timeout: TIMEOUT });
+    await page.goto(`${BASE_URL}/dungeon/default/${dName}`, { timeout: TIMEOUT });
     await page.waitForTimeout(3000);
 
     // === SECTION 5: Dungeon View ===


### PR DESCRIPTION
Closes #62

One-line fix: dungeon created via UI form defaults to `default` namespace, but the test navigated to `/dungeon/tests/`. Changed to `/dungeon/default/`.