### PR TITLE
Fix #67: Revert test namespace — kro cross-namespace owner refs unsupported

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,8 +50,6 @@ jobs:
             sleep 5
           done
 
-      - name: Ensure tests namespace
-        run: kubectl create ns tests --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Run integration tests
         run: ./tests/run.sh

--- a/tests/backend-api.sh
+++ b/tests/backend-api.sh
@@ -4,7 +4,6 @@
 set -euo pipefail
 
 BASE="http://localhost:8080"
-TEST_NS="tests"
 DUNGEON="api-test-$(date +%s)"
 PASS=0
 FAIL=0
@@ -16,7 +15,7 @@ fail() { echo "  ❌ $1"; FAIL=$((FAIL+1)); TESTS+=("FAIL: $1"); }
 
 cleanup() {
   log "Cleanup"
-  kubectl delete dungeon "$DUNGEON" -n tests --ignore-not-found --wait=false 2>/dev/null || true
+  kubectl delete dungeon "$DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
   kubectl delete attacks --all --ignore-not-found --wait=false 2>/dev/null || true
 }
 trap cleanup EXIT
@@ -45,7 +44,7 @@ curl -s "$BASE/metrics" | grep -q "k8s_rpg_dungeons_created_total" \
 log "Test 3: Create dungeon"
 RESP=$(curl -s -w "\n%{http_code}" -X POST "$BASE/api/v1/dungeons" \
   -H "Content-Type: application/json" \
-  -d "{\"name\":\"$DUNGEON\",\"monsters\":2,\"difficulty\":\"easy\",\"heroClass\":\"warrior\",\"namespace\":\"tests\"}")
+  -d "{\"name\":\"$DUNGEON\",\"monsters\":2,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}")
 CODE=$(echo "$RESP" | tail -1)
 [ "$CODE" = "201" ] && pass "POST /dungeons -> 201" || fail "POST /dungeons -> $CODE"
 
@@ -69,9 +68,9 @@ echo "$RESP" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(x
 # --- Test 6: Get dungeon ---
 log "Test 6: Get dungeon response shape"
 sleep 15  # wait for kro
-RESP=$(curl -s "$BASE/api/v1/dungeons/tests/$DUNGEON")
-CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/v1/dungeons/tests/$DUNGEON")
-[ "$CODE" = "200" ] && pass "GET /dungeons/tests/$DUNGEON -> 200" || fail "GET dungeon -> $CODE"
+RESP=$(curl -s "$BASE/api/v1/dungeons/default/$DUNGEON")
+CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/v1/dungeons/default/$DUNGEON")
+[ "$CODE" = "200" ] && pass "GET /dungeons/default/$DUNGEON -> 200" || fail "GET dungeon -> $CODE"
 
 # Verify response is a raw Dungeon CR (has metadata.name, spec, not wrapped in {dungeon:...})
 echo "$RESP" | python3 -c "
@@ -91,27 +90,27 @@ print('OK')
 
 # --- Test 7: Get nonexistent dungeon ---
 log "Test 7: Get nonexistent dungeon"
-CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/v1/dungeons/tests/nonexistent-xyz")
+CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/v1/dungeons/default/nonexistent-xyz")
 [ "$CODE" = "404" ] && pass "GET nonexistent -> 404" || fail "GET nonexistent -> $CODE"
 
 # --- Test 8: Submit attack ---
 log "Test 8: Submit attack"
-CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/tests/$DUNGEON/attacks" \
+CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$DUNGEON/attacks" \
   -H "Content-Type: application/json" -d "{\"target\":\"${DUNGEON}-monster-0\",\"damage\":30}")
 [ "$CODE" = "202" ] && pass "POST attack -> 202" || fail "POST attack -> $CODE"
 
 # --- Test 9: Attack validation ---
 log "Test 9: Attack validation"
-CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/tests/validation-test/attacks" \
+CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/validation-test/attacks" \
   -H "Content-Type: application/json" -d '{"target":"","damage":0}')
 [ "$CODE" = "400" ] && pass "Invalid attack rejected -> 400" || fail "Invalid attack -> $CODE"
 
 # --- Test 10: Rate limiting ---
 log "Test 10: Rate limiting"
 # Fire first attack and wait for it to complete, then fire second within rate limit window
-curl -s -o /dev/null -X POST "$BASE/api/v1/dungeons/tests/$DUNGEON/attacks" \
+curl -s -o /dev/null -X POST "$BASE/api/v1/dungeons/default/$DUNGEON/attacks" \
   -H "Content-Type: application/json" -d "{\"target\":\"${DUNGEON}-monster-1\",\"damage\":10}"
-CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/tests/$DUNGEON/attacks" \
+CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$DUNGEON/attacks" \
   -H "Content-Type: application/json" -d "{\"target\":\"${DUNGEON}-monster-1\",\"damage\":10}")
 [ "$CODE" = "429" ] && pass "Rate limited -> 429" || fail "Rate limit not enforced -> $CODE"
 

--- a/tests/e2e/smoke-test.js
+++ b/tests/e2e/smoke-test.js
@@ -76,7 +76,7 @@ async function runTests() {
 
     // Navigate to dungeon
     await page.waitForTimeout(5000); // kro reconciliation
-    await page.goto(`${BASE_URL}/dungeon/tests/${dName}`, { timeout: TIMEOUT });
+    await page.goto(`${BASE_URL}/dungeon/default/${dName}`, { timeout: TIMEOUT });
     await page.waitForTimeout(3000);
 
     // === SECTION 5: Dungeon View ===
@@ -185,14 +185,14 @@ async function runTests() {
     const mageRes = await page.evaluate(async (name) => {
       const r = await fetch('/api/v1/dungeons', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, monsters: 1, difficulty: 'easy', heroClass: 'mage', namespace: 'tests' }),
+        body: JSON.stringify({ name, monsters: 1, difficulty: 'easy', heroClass: 'mage' }),
       });
       return { ok: r.ok };
     }, mName);
     mageRes.ok ? ok('Mage dungeon created via API') : fail('Mage dungeon creation failed');
 
     await page.waitForTimeout(6000);
-    await page.goto(`${BASE_URL}/dungeon/tests/${mName}`, { timeout: TIMEOUT });
+    await page.goto(`${BASE_URL}/dungeon/default/${mName}`, { timeout: TIMEOUT });
     await page.waitForTimeout(3000);
     const mageText = await page.textContent('body');
     mageText.includes('MAGE') ? ok('Mage class displayed') : fail('Mage class missing');
@@ -207,14 +207,14 @@ async function runTests() {
     const rogueRes = await page.evaluate(async (name) => {
       const r = await fetch('/api/v1/dungeons', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, monsters: 1, difficulty: 'easy', heroClass: 'rogue', namespace: 'tests' }),
+        body: JSON.stringify({ name, monsters: 1, difficulty: 'easy', heroClass: 'rogue' }),
       });
       return { ok: r.ok };
     }, rName);
     rogueRes.ok ? ok('Rogue dungeon created via API') : fail('Rogue dungeon creation failed');
 
     await page.waitForTimeout(6000);
-    await page.goto(`${BASE_URL}/dungeon/tests/${rName}`, { timeout: TIMEOUT });
+    await page.goto(`${BASE_URL}/dungeon/default/${rName}`, { timeout: TIMEOUT });
     await page.waitForTimeout(3000);
     const rogueText = await page.textContent('body');
     rogueText.includes('ROGUE') ? ok('Rogue class displayed') : fail('Rogue class missing');
@@ -226,7 +226,7 @@ async function runTests() {
 
     // === SECTION 11: Client-side Routing ===
     console.log('\n=== Routing ===');
-    await page.goto(`${BASE_URL}/dungeon/tests/nonexistent`, { timeout: TIMEOUT });
+    await page.goto(`${BASE_URL}/dungeon/default/nonexistent`, { timeout: TIMEOUT });
     await page.waitForLoadState('domcontentloaded');
     ok('Nonexistent dungeon route loads without crash');
 
@@ -242,7 +242,7 @@ async function runTests() {
     await page.evaluate(async (name) => {
       await fetch('/api/v1/dungeons', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, monsters: 1, difficulty: 'easy', heroClass: 'warrior', namespace: 'tests' }),
+        body: JSON.stringify({ name, monsters: 1, difficulty: 'easy', heroClass: 'warrior' }),
       });
     }, iName);
     await page.waitForTimeout(8000);
@@ -250,11 +250,11 @@ async function runTests() {
     // Patch dungeon to have known modifier and inventory
     await page.evaluate(async (name) => {
       // Use attack API to equip items (or just check what we get)
-      const r = await fetch(`/api/v1/dungeons/tests/${name}`);
+      const r = await fetch(`/api/v1/dungeons/default/${name}`);
       return r.json();
     }, iName);
 
-    await page.goto(`${BASE_URL}/dungeon/tests/${iName}`, { timeout: TIMEOUT });
+    await page.goto(`${BASE_URL}/dungeon/default/${iName}`, { timeout: TIMEOUT });
     await page.waitForTimeout(3000);
     const itemsText = await page.textContent('body');
 
@@ -287,7 +287,7 @@ async function runTests() {
     console.log('\n=== Cleanup ===');
     for (const name of [dName, mName, rName, iName]) {
       await page.evaluate(async (n) => {
-        try { await fetch(`/api/v1/dungeons/tests/${n}`, { method: 'DELETE' }); } catch {}
+        try { await fetch(`/api/v1/dungeons/default/${n}`, { method: 'DELETE' }); } catch {}
       }, name);
     }
     // Also delete via kubectl

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -152,12 +152,12 @@ fi
 TEST_NAME="guardrail-$(date +%s)"
 curl -s -X POST http://localhost:$GUARDRAIL_PORT/api/v1/dungeons \
   -H "Content-Type: application/json" \
-  -d "{\"name\":\"$TEST_NAME\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\",\"namespace\":\"tests\"}" -o /dev/null
+  -d "{\"name\":\"$TEST_NAME\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 
 sleep 10
 
 # GetDungeon response must be a raw CR (not wrapped)
-RESP=$(curl -s http://localhost:$GUARDRAIL_PORT/api/v1/dungeons/tests/$TEST_NAME)
+RESP=$(curl -s http://localhost:$GUARDRAIL_PORT/api/v1/dungeons/default/$TEST_NAME)
 echo "$RESP" | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
@@ -171,7 +171,7 @@ assert 'loot' not in d or isinstance(d.get('loot'), str), 'loot at top level'
   || fail "GetDungeon response has wrong shape"
 
 # Cleanup
-kubectl delete dungeon "$TEST_NAME" -n tests --ignore-not-found --wait=false &>/dev/null
+kubectl delete dungeon "$TEST_NAME" --ignore-not-found --wait=false &>/dev/null
 [ -n "$PF_PID" ] && kill "$PF_PID" 2>/dev/null
 
 # --- Summary ---

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,7 +4,6 @@
 set -euo pipefail
 
 DUNGEON_NAME="test-$(date +%s)"
-TEST_NS="tests"
 PASS=0
 FAIL=0
 TESTS=()
@@ -27,8 +26,8 @@ wait_for() {
 
 cleanup() {
   log "Cleanup"
-  kubectl delete attacks --all -n "$TEST_NS" --ignore-not-found --wait=false 2>/dev/null || true
-  kubectl delete dungeons --all -n "$TEST_NS" --ignore-not-found --wait=false 2>/dev/null || true
+  kubectl delete attacks --all --ignore-not-found --wait=false 2>/dev/null || true
+  kubectl delete dungeons -l app.kubernetes.io/part-of=test --ignore-not-found --wait=false 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -37,7 +36,6 @@ trap cleanup EXIT
 log "Pre-flight checks"
 
 # Ensure tests namespace exists
-kubectl create ns "$TEST_NS" --dry-run=client -o yaml | kubectl apply -f - 2>/dev/null
 
 # Wait for RGDs to be functional (CRDs exist = kro accepted the RGDs)
 wait_for "Dungeon CRD available" \
@@ -59,7 +57,6 @@ apiVersion: game.k8s.example/v1alpha1
 kind: Dungeon
 metadata:
   name: $DUNGEON_NAME
-  namespace: tests
 spec:
   monsters: 2
   difficulty: easy
@@ -117,14 +114,14 @@ kubectl get resourcequota dungeon-quota -n "$DUNGEON_NAME" &>/dev/null \
 log "Test 2: Verify initial state"
 
 wait_for "livingMonsters=2" \
-  "[ \$(kubectl get dungeon $DUNGEON_NAME -n $TEST_NS -o jsonpath='{.status.livingMonsters}' 2>/dev/null) = '2' ]" 30 \
+  "[ \$(kubectl get dungeon $DUNGEON_NAME  -o jsonpath='{.status.livingMonsters}' 2>/dev/null) = '2' ]" 30 \
   && pass "livingMonsters=2" || fail "livingMonsters!=2"
 
 wait_for "bossState=pending" \
-  "[ \$(kubectl get dungeon $DUNGEON_NAME -n $TEST_NS -o jsonpath='{.status.bossState}' 2>/dev/null) = 'pending' ]" 30 \
+  "[ \$(kubectl get dungeon $DUNGEON_NAME  -o jsonpath='{.status.bossState}' 2>/dev/null) = 'pending' ]" 30 \
   && pass "bossState=pending" || fail "bossState!=pending"
 
-VICTORY=$(kubectl get dungeon "$DUNGEON_NAME" -n "$TEST_NS" -o jsonpath='{.status.victory}')
+VICTORY=$(kubectl get dungeon "$DUNGEON_NAME"  -o jsonpath='{.status.victory}')
 [ "$VICTORY" = "false" ] && pass "victory=false" || fail "victory=$VICTORY (expected false)"
 
 M0_STATE=$(kubectl get pod "${DUNGEON_NAME}-monster-0" -n "$DUNGEON_NAME" -o jsonpath='{.metadata.labels.game\.k8s\.example/state}')
@@ -146,7 +143,7 @@ metadata:
     test-dungeon: $DUNGEON_NAME
 spec:
   dungeonName: $DUNGEON_NAME
-  dungeonNamespace: tests
+  dungeonNamespace: default
   target: ${DUNGEON_NAME}-monster-0
   damage: 15
 EOF
@@ -157,9 +154,9 @@ wait_for "attack-1 job complete" \
   || fail "Attack job did not complete"
 
 wait_for "monster-0 HP updated" \
-  "[ \$(kubectl get dungeon $DUNGEON_NAME -n $TEST_NS -o jsonpath='{.spec.monsterHP[0]}' 2>/dev/null) = '15' ]" 30
+  "[ \$(kubectl get dungeon $DUNGEON_NAME  -o jsonpath='{.spec.monsterHP[0]}' 2>/dev/null) = '15' ]" 30
 
-M0_HP=$(kubectl get dungeon "$DUNGEON_NAME" -n "$TEST_NS" -o jsonpath='{.spec.monsterHP[0]}')
+M0_HP=$(kubectl get dungeon "$DUNGEON_NAME"  -o jsonpath='{.spec.monsterHP[0]}')
 [ "$M0_HP" = "15" ] && pass "monster-0 HP=15 after 15 damage" || fail "monster-0 HP=$M0_HP (expected 15)"
 
 M0_STATE=$(kubectl get pod "${DUNGEON_NAME}-monster-0" -n "$DUNGEON_NAME" -o jsonpath='{.metadata.labels.game\.k8s\.example/state}')
@@ -178,7 +175,7 @@ metadata:
     test-dungeon: $DUNGEON_NAME
 spec:
   dungeonName: $DUNGEON_NAME
-  dungeonNamespace: tests
+  dungeonNamespace: default
   target: ${DUNGEON_NAME}-monster-0
   damage: 15
 EOF
@@ -187,9 +184,9 @@ wait_for "attack-2 job complete" \
   "kubectl get job ${DUNGEON_NAME}-atk2 -o jsonpath='{.status.succeeded}' 2>/dev/null | grep -q 1" 60
 
 wait_for "monster-0 HP=0" \
-  "[ \$(kubectl get dungeon $DUNGEON_NAME -n $TEST_NS -o jsonpath='{.spec.monsterHP[0]}' 2>/dev/null) = '0' ]" 30
+  "[ \$(kubectl get dungeon $DUNGEON_NAME  -o jsonpath='{.spec.monsterHP[0]}' 2>/dev/null) = '0' ]" 30
 
-M0_HP=$(kubectl get dungeon "$DUNGEON_NAME" -n "$TEST_NS" -o jsonpath='{.spec.monsterHP[0]}')
+M0_HP=$(kubectl get dungeon "$DUNGEON_NAME"  -o jsonpath='{.spec.monsterHP[0]}')
 [ "$M0_HP" = "0" ] && pass "monster-0 HP=0" || fail "monster-0 HP=$M0_HP (expected 0)"
 
 wait_for "monster-0 dead label" \
@@ -198,7 +195,7 @@ wait_for "monster-0 dead label" \
   || fail "monster-0 not marked dead"
 
 wait_for "livingMonsters=1" \
-  "[ \$(kubectl get dungeon $DUNGEON_NAME -n $TEST_NS -o jsonpath='{.status.livingMonsters}' 2>/dev/null) = '1' ]" 30 \
+  "[ \$(kubectl get dungeon $DUNGEON_NAME  -o jsonpath='{.status.livingMonsters}' 2>/dev/null) = '1' ]" 30 \
   && pass "livingMonsters=1" || fail "livingMonsters!=1"
 
 # --- Test 5: Kill monster-1, boss should become ready ---
@@ -214,7 +211,7 @@ metadata:
     test-dungeon: $DUNGEON_NAME
 spec:
   dungeonName: $DUNGEON_NAME
-  dungeonNamespace: tests
+  dungeonNamespace: default
   target: ${DUNGEON_NAME}-monster-1
   damage: 30
 EOF
@@ -223,7 +220,7 @@ wait_for "attack-3 job complete" \
   "kubectl get job ${DUNGEON_NAME}-atk3 -o jsonpath='{.status.succeeded}' 2>/dev/null | grep -q 1" 60
 
 wait_for "livingMonsters=0" \
-  "[ \$(kubectl get dungeon $DUNGEON_NAME -n $TEST_NS -o jsonpath='{.status.livingMonsters}' 2>/dev/null) = '0' ]" 30 \
+  "[ \$(kubectl get dungeon $DUNGEON_NAME  -o jsonpath='{.status.livingMonsters}' 2>/dev/null) = '0' ]" 30 \
   && pass "livingMonsters=0" || fail "livingMonsters!=0"
 
 wait_for "boss ready" \
@@ -232,7 +229,7 @@ wait_for "boss ready" \
   || fail "boss not ready"
 
 wait_for "dungeon bossState=ready" \
-  "[ \$(kubectl get dungeon $DUNGEON_NAME -n $TEST_NS -o jsonpath='{.status.bossState}' 2>/dev/null) = 'ready' ]" 30 \
+  "[ \$(kubectl get dungeon $DUNGEON_NAME  -o jsonpath='{.status.bossState}' 2>/dev/null) = 'ready' ]" 30 \
   && pass "dungeon bossState=ready" || fail "dungeon bossState!=ready"
 
 # --- Test 6: Defeat boss, victory ---
@@ -248,7 +245,7 @@ metadata:
     test-dungeon: $DUNGEON_NAME
 spec:
   dungeonName: $DUNGEON_NAME
-  dungeonNamespace: tests
+  dungeonNamespace: default
   target: ${DUNGEON_NAME}-boss
   damage: 200
 EOF
@@ -262,7 +259,7 @@ wait_for "boss defeated" \
   || fail "boss not defeated"
 
 wait_for "victory=true" \
-  "[ \$(kubectl get dungeon $DUNGEON_NAME -n $TEST_NS -o jsonpath='{.status.victory}' 2>/dev/null) = 'true' ]" 30 \
+  "[ \$(kubectl get dungeon $DUNGEON_NAME  -o jsonpath='{.status.victory}' 2>/dev/null) = 'true' ]" 30 \
   && pass "victory=true" || fail "victory!=true"
 
 # --- Test 7: Drift correction ---
@@ -271,7 +268,7 @@ log "Test 7: Drift correction (delete alive pod, kro recreates)"
 
 # First reset: create a fresh dungeon for drift test
 kubectl delete attack -l test-dungeon="$DUNGEON_NAME" --ignore-not-found --wait=false 2>/dev/null || true
-kubectl delete dungeon "$DUNGEON_NAME" -n "$TEST_NS" --ignore-not-found --wait=false 2>/dev/null || true
+kubectl delete dungeon "$DUNGEON_NAME"  --ignore-not-found --wait=false 2>/dev/null || true
 wait_for "old namespace gone" "! kubectl get ns $DUNGEON_NAME 2>/dev/null" 60
 
 DUNGEON_NAME="test-drift-$(date +%s)"
@@ -281,7 +278,6 @@ apiVersion: game.k8s.example/v1alpha1
 kind: Dungeon
 metadata:
   name: $DUNGEON_NAME
-  namespace: tests
 spec:
   monsters: 1
   difficulty: easy
@@ -323,7 +319,6 @@ apiVersion: game.k8s.example/v1alpha1
 kind: Dungeon
 metadata:
   name: $ABILITY_DUNGEON
-  namespace: tests
 spec:
   monsters: 1
   difficulty: easy
@@ -336,7 +331,7 @@ spec:
 EOF
 
 wait_for "ability dungeon ready" \
-  "kubectl get dungeon $ABILITY_DUNGEON -n $TEST_NS -o jsonpath='{.status.livingMonsters}' 2>/dev/null | grep -q 1" 60
+  "kubectl get dungeon $ABILITY_DUNGEON  -o jsonpath='{.status.livingMonsters}' 2>/dev/null | grep -q 1" 60
 
 # Mage heal test
 cat <<EOF | kubectl apply -f -
@@ -346,7 +341,7 @@ metadata:
   name: ${ABILITY_DUNGEON}-heal
 spec:
   dungeonName: $ABILITY_DUNGEON
-  dungeonNamespace: tests
+  dungeonNamespace: default
   target: hero
   damage: 0
 EOF
@@ -355,8 +350,8 @@ wait_for "heal job complete" \
   "kubectl get job ${ABILITY_DUNGEON}-heal -o jsonpath='{.status.succeeded}' 2>/dev/null | grep -q 1" 60
 sleep 5
 
-HEAL_HP=$(kubectl get dungeon "$ABILITY_DUNGEON" -n "$TEST_NS" -o jsonpath='{.spec.heroHP}')
-HEAL_MANA=$(kubectl get dungeon "$ABILITY_DUNGEON" -n "$TEST_NS" -o jsonpath='{.spec.heroMana}')
+HEAL_HP=$(kubectl get dungeon "$ABILITY_DUNGEON"  -o jsonpath='{.spec.heroHP}')
+HEAL_MANA=$(kubectl get dungeon "$ABILITY_DUNGEON"  -o jsonpath='{.spec.heroMana}')
 [ "$HEAL_HP" = "80" ] && pass "Mage heal: HP 50->80 (capped at max)" || fail "Mage heal HP=$HEAL_HP (expected 80)"
 [ "$HEAL_MANA" = "3" ] && pass "Mage heal: mana 5->3 (costs 2)" || fail "Mage heal mana=$HEAL_MANA (expected 3)"
 
@@ -367,7 +362,6 @@ apiVersion: game.k8s.example/v1alpha1
 kind: Dungeon
 metadata:
   name: $TAUNT_DUNGEON
-  namespace: tests
 spec:
   monsters: 1
   difficulty: easy
@@ -378,7 +372,7 @@ spec:
   modifier: none
 EOF
 wait_for "taunt dungeon ready" \
-  "kubectl get dungeon $TAUNT_DUNGEON -n $TEST_NS -o jsonpath='{.status.livingMonsters}' 2>/dev/null | grep -q 1" 60
+  "kubectl get dungeon $TAUNT_DUNGEON  -o jsonpath='{.status.livingMonsters}' 2>/dev/null | grep -q 1" 60
 
 cat <<EOF | kubectl apply -f -
 apiVersion: game.k8s.example/v1alpha1
@@ -387,7 +381,7 @@ metadata:
   name: ${TAUNT_DUNGEON}-taunt
 spec:
   dungeonName: $TAUNT_DUNGEON
-  dungeonNamespace: tests
+  dungeonNamespace: default
   target: activate-taunt
   damage: 0
 EOF
@@ -396,10 +390,10 @@ wait_for "taunt job complete" \
   "kubectl get job ${TAUNT_DUNGEON}-taunt -o jsonpath='{.status.succeeded}' 2>/dev/null | grep -q 1" 60
 
 wait_for "taunt active" \
-  "[ \$(kubectl get dungeon $TAUNT_DUNGEON -n $TEST_NS -o jsonpath='{.spec.tauntActive}' 2>/dev/null) = '1' ]" 15 \
+  "[ \$(kubectl get dungeon $TAUNT_DUNGEON  -o jsonpath='{.spec.tauntActive}' 2>/dev/null) = '1' ]" 15 \
   && pass "Warrior taunt: tauntActive=1" || fail "Warrior taunt failed"
 
-kubectl delete dungeon "$TAUNT_DUNGEON" -n "$TEST_NS" --ignore-not-found --wait=false 2>/dev/null || true
+kubectl delete dungeon "$TAUNT_DUNGEON"  --ignore-not-found --wait=false 2>/dev/null || true
 
 # Rogue backstab test
 BACKSTAB_DUNGEON="test-backstab-$(date +%s)"
@@ -408,7 +402,6 @@ apiVersion: game.k8s.example/v1alpha1
 kind: Dungeon
 metadata:
   name: $BACKSTAB_DUNGEON
-  namespace: tests
 spec:
   monsters: 1
   difficulty: easy
@@ -419,7 +412,7 @@ spec:
   modifier: none
 EOF
 wait_for "backstab dungeon ready" \
-  "kubectl get dungeon $BACKSTAB_DUNGEON -n $TEST_NS -o jsonpath='{.status.livingMonsters}' 2>/dev/null | grep -q 1" 60
+  "kubectl get dungeon $BACKSTAB_DUNGEON  -o jsonpath='{.status.livingMonsters}' 2>/dev/null | grep -q 1" 60
 
 cat <<EOF | kubectl apply -f -
 apiVersion: game.k8s.example/v1alpha1
@@ -428,7 +421,7 @@ metadata:
   name: ${BACKSTAB_DUNGEON}-backstab
 spec:
   dungeonName: $BACKSTAB_DUNGEON
-  dungeonNamespace: tests
+  dungeonNamespace: default
   target: ${BACKSTAB_DUNGEON}-monster-0-backstab
   damage: 15
 EOF
@@ -437,14 +430,14 @@ wait_for "backstab job complete" \
   "kubectl get job ${BACKSTAB_DUNGEON}-backstab -o jsonpath='{.status.succeeded}' 2>/dev/null | grep -q 1" 60
 
 wait_for "backstab applied" \
-  "[ \$(kubectl get dungeon $BACKSTAB_DUNGEON -n $TEST_NS -o jsonpath='{.spec.backstabCooldown}' 2>/dev/null) = '3' ]" 15
+  "[ \$(kubectl get dungeon $BACKSTAB_DUNGEON  -o jsonpath='{.spec.backstabCooldown}' 2>/dev/null) = '3' ]" 15
 
-BS_CD=$(kubectl get dungeon "$BACKSTAB_DUNGEON" -n "$TEST_NS" -o jsonpath='{.spec.backstabCooldown}')
-BS_HP=$(kubectl get dungeon "$BACKSTAB_DUNGEON" -n "$TEST_NS" -o jsonpath='{.spec.monsterHP[0]}')
+BS_CD=$(kubectl get dungeon "$BACKSTAB_DUNGEON"  -o jsonpath='{.spec.backstabCooldown}')
+BS_HP=$(kubectl get dungeon "$BACKSTAB_DUNGEON"  -o jsonpath='{.spec.monsterHP[0]}')
 [ "$BS_CD" = "3" ] && pass "Rogue backstab: cooldown=3" || fail "Backstab cooldown=$BS_CD (expected 3)"
 [ "$BS_HP" = "0" ] && pass "Rogue backstab: 3x damage kills monster" || fail "Backstab monster HP=$BS_HP (expected 0)"
 
-kubectl delete dungeon "$BACKSTAB_DUNGEON" -n "$TEST_NS" --ignore-not-found --wait=false 2>/dev/null || true
+kubectl delete dungeon "$BACKSTAB_DUNGEON"  --ignore-not-found --wait=false 2>/dev/null || true
 
 # --- Test 10: Dungeon modifiers ---
 
@@ -457,7 +450,6 @@ apiVersion: game.k8s.example/v1alpha1
 kind: Dungeon
 metadata:
   name: $MOD_DUNGEON
-  namespace: tests
 spec:
   monsters: 1
   difficulty: easy
@@ -469,9 +461,9 @@ spec:
 EOF
 
 wait_for "modifier dungeon ready" \
-  "kubectl get dungeon $MOD_DUNGEON -n $TEST_NS -o jsonpath='{.status.modifierType}' 2>/dev/null | grep -q blessing-strength" 60
+  "kubectl get dungeon $MOD_DUNGEON  -o jsonpath='{.status.modifierType}' 2>/dev/null | grep -q blessing-strength" 60
 
-MOD_STATUS=$(kubectl get dungeon "$MOD_DUNGEON" -n "$TEST_NS" -o jsonpath='{.status.modifier}')
+MOD_STATUS=$(kubectl get dungeon "$MOD_DUNGEON"  -o jsonpath='{.status.modifier}')
 echo "$MOD_STATUS" | grep -q "damage" \
   && pass "Modifier CR: status shows effect description" \
   || fail "Modifier status=$MOD_STATUS"
@@ -482,7 +474,7 @@ wait_for "modifier CR exists" \
   && pass "Modifier CR created in dungeon namespace" \
   || fail "Modifier CR missing"
 
-kubectl delete dungeon "$MOD_DUNGEON" -n "$TEST_NS" --ignore-not-found --wait=false 2>/dev/null || true
+kubectl delete dungeon "$MOD_DUNGEON"  --ignore-not-found --wait=false 2>/dev/null || true
 
 # --- Test 11: Status effects ---
 
@@ -495,7 +487,6 @@ apiVersion: game.k8s.example/v1alpha1
 kind: Dungeon
 metadata:
   name: $FX_DUNGEON
-  namespace: tests
 spec:
   monsters: 1
   difficulty: easy
@@ -510,7 +501,7 @@ spec:
 EOF
 
 wait_for "fx dungeon ready" \
-  "kubectl get dungeon $FX_DUNGEON -n $TEST_NS -o jsonpath='{.status.livingMonsters}' 2>/dev/null | grep -q 1" 60
+  "kubectl get dungeon $FX_DUNGEON  -o jsonpath='{.status.livingMonsters}' 2>/dev/null | grep -q 1" 60
 
 cat <<EOF | kubectl apply -f -
 apiVersion: game.k8s.example/v1alpha1
@@ -519,7 +510,7 @@ metadata:
   name: ${FX_DUNGEON}-atk1
 spec:
   dungeonName: $FX_DUNGEON
-  dungeonNamespace: tests
+  dungeonNamespace: default
   target: ${FX_DUNGEON}-monster-0
   damage: 10
 EOF
@@ -529,13 +520,13 @@ wait_for "fx attack complete" \
 
 # Wait for the patch to propagate
 wait_for "fx dungeon patched" \
-  "[ \$(kubectl get dungeon $FX_DUNGEON -n $TEST_NS -o jsonpath='{.spec.poisonTurns}') != '2' ]" 30
+  "[ \$(kubectl get dungeon $FX_DUNGEON  -o jsonpath='{.spec.poisonTurns}') != '2' ]" 30
 
-FX_HP=$(kubectl get dungeon "$FX_DUNGEON" -n "$TEST_NS" -o jsonpath='{.spec.heroHP}')
-FX_POISON=$(kubectl get dungeon "$FX_DUNGEON" -n "$TEST_NS" -o jsonpath='{.spec.poisonTurns}')
-FX_BURN=$(kubectl get dungeon "$FX_DUNGEON" -n "$TEST_NS" -o jsonpath='{.spec.burnTurns}')
-FX_STUN=$(kubectl get dungeon "$FX_DUNGEON" -n "$TEST_NS" -o jsonpath='{.spec.stunTurns}')
-FX_MONSTER=$(kubectl get dungeon "$FX_DUNGEON" -n "$TEST_NS" -o jsonpath='{.spec.monsterHP[0]}')
+FX_HP=$(kubectl get dungeon "$FX_DUNGEON"  -o jsonpath='{.spec.heroHP}')
+FX_POISON=$(kubectl get dungeon "$FX_DUNGEON"  -o jsonpath='{.spec.poisonTurns}')
+FX_BURN=$(kubectl get dungeon "$FX_DUNGEON"  -o jsonpath='{.spec.burnTurns}')
+FX_STUN=$(kubectl get dungeon "$FX_DUNGEON"  -o jsonpath='{.spec.stunTurns}')
+FX_MONSTER=$(kubectl get dungeon "$FX_DUNGEON"  -o jsonpath='{.spec.monsterHP[0]}')
 
 # HP should be 150 - 5 (poison) - 8 (burn) - counter = ~136
 [ "$FX_HP" -lt 150 ] && pass "DoT applied: HP reduced from 150 to $FX_HP" || fail "DoT not applied: HP=$FX_HP"
@@ -545,7 +536,7 @@ FX_MONSTER=$(kubectl get dungeon "$FX_DUNGEON" -n "$TEST_NS" -o jsonpath='{.spec
 # Stun means 0 damage dealt
 [ "$FX_MONSTER" = "30" ] && pass "Stun: hero dealt 0 damage" || fail "Stun: monster HP=$FX_MONSTER (expected 30)"
 
-kubectl delete dungeon "$FX_DUNGEON" -n "$TEST_NS" --ignore-not-found --wait=false 2>/dev/null || true
+kubectl delete dungeon "$FX_DUNGEON"  --ignore-not-found --wait=false 2>/dev/null || true
 
 # --- Test 12: Loot system ---
 
@@ -558,7 +549,6 @@ apiVersion: game.k8s.example/v1alpha1
 kind: Dungeon
 metadata:
   name: $LOOT_DUNGEON
-  namespace: tests
 spec:
   monsters: 1
   difficulty: easy
@@ -571,7 +561,7 @@ spec:
 EOF
 
 wait_for "loot dungeon ready" \
-  "kubectl get dungeon $LOOT_DUNGEON -n $TEST_NS -o jsonpath='{.status.livingMonsters}' 2>/dev/null | grep -q 1" 60
+  "kubectl get dungeon $LOOT_DUNGEON  -o jsonpath='{.status.livingMonsters}' 2>/dev/null | grep -q 1" 60
 
 # Test item usage
 cat <<EOF | kubectl apply -f -
@@ -581,7 +571,7 @@ metadata:
   name: ${LOOT_DUNGEON}-use
 spec:
   dungeonName: $LOOT_DUNGEON
-  dungeonNamespace: tests
+  dungeonNamespace: default
   target: use-hppotion-rare
   damage: 0
 EOF
@@ -590,7 +580,7 @@ wait_for "use item job complete" \
   "kubectl get job ${LOOT_DUNGEON}-use -o jsonpath='{.status.succeeded}' 2>/dev/null | grep -q 1" 60
 sleep 5
 
-LOOT_INV=$(kubectl get dungeon "$LOOT_DUNGEON" -n "$TEST_NS" -o jsonpath='{.spec.inventory}')
+LOOT_INV=$(kubectl get dungeon "$LOOT_DUNGEON"  -o jsonpath='{.spec.inventory}')
 [ -z "$LOOT_INV" ] && pass "Item consumed: inventory empty" || fail "Item not consumed: inv=$LOOT_INV"
 
 # Kill monster (1 HP) — may drop loot
@@ -601,7 +591,7 @@ metadata:
   name: ${LOOT_DUNGEON}-kill
 spec:
   dungeonName: $LOOT_DUNGEON
-  dungeonNamespace: tests
+  dungeonNamespace: default
   target: ${LOOT_DUNGEON}-monster-0
   damage: 10
 EOF
@@ -610,12 +600,12 @@ wait_for "kill job complete" \
   "kubectl get job ${LOOT_DUNGEON}-kill -o jsonpath='{.status.succeeded}' 2>/dev/null | grep -q 1" 60
 sleep 5
 
-LOOT_ACTION=$(kubectl get dungeon "$LOOT_DUNGEON" -n "$TEST_NS" -o jsonpath='{.spec.lastHeroAction}')
+LOOT_ACTION=$(kubectl get dungeon "$LOOT_DUNGEON"  -o jsonpath='{.spec.lastHeroAction}')
 echo "$LOOT_ACTION" | grep -q "monster-0" \
   && pass "Monster killed, action logged" \
   || fail "Kill action missing: $LOOT_ACTION"
 
-kubectl delete dungeon "$LOOT_DUNGEON" -n "$TEST_NS" --ignore-not-found --wait=false 2>/dev/null || true
+kubectl delete dungeon "$LOOT_DUNGEON"  --ignore-not-found --wait=false 2>/dev/null || true
 
 # --- Test 13: 7 RGDs all Active ---
 


### PR DESCRIPTION
## Root Cause
Dungeons in `tests` namespace caused kro to silently fail. The dungeon-graph RGD creates a child namespace per dungeon with an owner reference back to the Dungeon CR. Kubernetes doesn't support cross-namespace owner references, so dungeons MUST be in `default`.

## Fix
Reverted all test scripts to use `default` namespace for dungeons. Test dungeons use timestamp-based names to avoid collisions.

## Also fixes
- #66 (PR #60 same attack job timeout)
- Unblocks PR #63 (metrics)

Closes #67