### PR TITLE
Issue #77: Disable all actions after victory or defeat

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -561,7 +561,7 @@ function DungeonView({ cr, onBack, onAttack, events, showLoot, onOpenLoot, onClo
               const label = isPotion ? 'Use' : alreadyEquipped ? 'Swap' : 'Equip'
               return (
                 <Tooltip key={i} text={`${item.replace(/-/g, ' ')} — click to ${label.toLowerCase()}`}>
-                  <button className="item-btn" disabled={!!attackPhase}
+                  <button className="item-btn" disabled={gameOver || !!attackPhase}
                     style={{ borderColor: RARITY_COLOR[rarity] || '#aaa' }}
                     onClick={() => onAttack(isPotion ? `use-${item}` : `equip-${item}`, 0)}>
                     <ItemSprite id={item} size={24} />
@@ -585,7 +585,7 @@ function DungeonView({ cr, onBack, onAttack, events, showLoot, onOpenLoot, onClo
           if (state === 'alive' && animPhase === 'enemy-attack') mAction = 'attack'
           return (
             <EntityCard key={mName} name={mName} entity="monster"
-              state={state} hp={hp} maxHP={maxMonsterHP} diceFormula={status?.diceFormula || "2d10+8"} onAttack={onAttack} disabled={isDefeated || !!attackPhase}
+              state={state} hp={hp} maxHP={maxMonsterHP} diceFormula={status?.diceFormula || "2d10+8"} onAttack={onAttack} disabled={gameOver || !!attackPhase}
               spriteType={mSprite} spriteAction={mAction}
               floatingDmg={floatingDmg?.target === mName ? floatingDmg.amount : null}
               heroClass={spec.heroClass} backstabCooldown={spec.backstabCooldown}
@@ -602,7 +602,7 @@ function DungeonView({ cr, onBack, onAttack, events, showLoot, onOpenLoot, onClo
         if (bossState === 'ready' && animPhase === 'enemy-attack' && attackTarget?.includes('boss')) bAction = 'attack'
         if (status?.victory) bAction = 'dead'
         return <EntityCard name={`${dungeonName}-boss`} entity="boss"
-          state={bossState} hp={spec.bossHP} maxHP={maxBossHP} diceFormula={status?.diceFormula || "2d10+8"} onAttack={onAttack} disabled={isDefeated || !!attackPhase}
+          state={bossState} hp={spec.bossHP} maxHP={maxBossHP} diceFormula={status?.diceFormula || "2d10+8"} onAttack={onAttack} disabled={gameOver || !!attackPhase}
           spriteType="dragon" spriteAction={bAction}
           floatingDmg={floatingDmg?.target?.includes('boss') ? floatingDmg.amount : null}
           heroClass={spec.heroClass} backstabCooldown={spec.backstabCooldown}

--- a/manifests/rgds/attack-graph.yaml
+++ b/manifests/rgds/attack-graph.yaml
@@ -49,6 +49,13 @@ spec:
                       for i in 1 2 3 4 5; do
                         DUNGEON_JSON=$(kubectl get dungeon "$DUNGEON" -n "$DUNGEON_NS" -o json)
                         HERO_HP=$(echo "$DUNGEON_JSON" | jq -r '.spec.heroHP // 100')
+
+                        # Reject actions on finished dungeons
+                        BOSS_HP_CHK=$(echo "$DUNGEON_JSON" | jq -r '.spec.bossHP // 1')
+                        ALIVE_CHK=$(echo "$DUNGEON_JSON" | jq '[.spec.monsterHP[] | select(. > 0)] | length')
+                        if [ "$HERO_HP" -le 0 ]; then echo "Dungeon over: hero defeated"; exit 0; fi
+                        if [ "$BOSS_HP_CHK" -le 0 ] && [ "$ALIVE_CHK" -eq 0 ]; then echo "Dungeon over: victory"; exit 0; fi
+
                         HERO_CLASS=$(echo "$DUNGEON_JSON" | jq -r '.spec.heroClass // "warrior"')
                         HERO_MANA=$(echo "$DUNGEON_JSON" | jq -r '.spec.heroMana // 0')
                         DIFFICULTY=$(echo "$DUNGEON_JSON" | jq -r '.spec.difficulty // "normal"')


### PR DESCRIPTION
**Attack Job**: rejects all actions on finished dungeons (heroHP<=0 or boss+monsters dead). Exits cleanly.

**Frontend**: all buttons check `gameOver` (victory OR defeat), not just `isDefeated`.

Closes #77