### PR TITLE
feat: treasure open/unopened state via RGD (#78)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -430,18 +430,21 @@ function DungeonView({ cr, onBack, onAttack, events, showLoot, onOpenLoot, onClo
 
       {status?.victory && (
         <div className="victory-banner">
-          <h2>🏆 VICTORY! 🏆</h2>
+          <h2>★ VICTORY! ★</h2>
           <p className="loot">The dungeon has been conquered!</p>
-          <button className="btn btn-gold" style={{ marginTop: 12 }} onClick={onOpenLoot}>
-            🗝️ Open Treasure
-          </button>
+          {status?.treasureState !== 'opened' && (
+            <button className="btn btn-gold" style={{ marginTop: 12 }} disabled={!!attackPhase}
+              onClick={() => onAttack('open-treasure', 0)}>
+              Open Treasure
+            </button>
+          )}
         </div>
       )}
 
-      {showLoot && (
+      {status?.treasureState === 'opened' && status?.loot && (
         <div className="modal-overlay" onClick={onCloseLoot}>
           <div className="modal" onClick={e => e.stopPropagation()}>
-            <div style={{ fontSize: 48, marginBottom: 12 }}>🏆</div>
+            <div style={{ fontSize: 48, marginBottom: 12 }}>★</div>
             <h2 style={{ color: 'var(--gold)', fontSize: 14, marginBottom: 12 }}>TREASURE UNLOCKED</h2>
             <div className="loot-content">{status?.loot || 'The treasure awaits...'}</div>
             <button className="btn btn-gold" style={{ marginTop: 16 }} onClick={onCloseLoot}>Close</button>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -22,6 +22,7 @@ export interface DungeonCR {
   status?: {
     livingMonsters: number; bossState: string; victory: boolean; defeated: boolean
     loot: string; maxMonsterHP: number; maxBossHP: number
+    treasureState: string
     maxHeroHP: number; diceFormula: string; monsterCounter: number; bossCounter: number
     modifier?: string; modifierType?: string
   }

--- a/manifests/rgds/attack-graph.yaml
+++ b/manifests/rgds/attack-graph.yaml
@@ -138,6 +138,19 @@ spec:
                           echo "Conflict, retrying ($i/5)..."; sleep $i; continue
                         fi
 
+                        # === OPEN TREASURE ===
+                        if [ "$TARGET" = "open-treasure" ]; then
+                          BOSS_HP=$(echo "$DUNGEON_JSON" | jq -r '.spec.bossHP // 1')
+                          if [ "$BOSS_HP" -gt 0 ]; then
+                            echo "Boss not defeated yet"; exit 1
+                          fi
+                          PATCH="{\"spec\":{\"treasureOpened\":1,\"lastHeroAction\":\"Treasure opened!\",\"lastEnemyAction\":\"\"}}"
+                          if kubectl patch dungeon "$DUNGEON" -n "$DUNGEON_NS" --type=merge -p "$PATCH" 2>&1; then
+                            echo "Treasure opened!"; exit 0
+                          fi
+                          echo "Conflict, retrying ($i/5)..."; sleep $i; continue
+                        fi
+
                         # === EQUIP ITEM ===
                         if echo "$TARGET" | grep -q "^equip-"; then
                           ITEM_TYPE=$(echo "$TARGET" | sed 's/^equip-//')

--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -29,12 +29,14 @@ spec:
       stunTurns: integer | default=0
       lastHeroAction: string | default=""
       lastEnemyAction: string | default=""
+      treasureOpened: integer | default=0
     status:
       livingMonsters: "${size(monsterCRs.filter(m, m.status.?entityState.orValue('alive') == 'alive'))}"
       bossState: "${bossCR.status.?entityState.orValue('pending')}"
       victory: "${bossCR.status.?entityState.orValue('pending') == 'defeated'}"
       defeat: "${heroCR.status.?entityState.orValue('alive') == 'defeated'}"
       loot: "${treasureCR.status.?loot.orValue('')}"
+      treasureState: "${schema.spec.treasureOpened == 1 ? 'opened' : (bossCR.status.?entityState.orValue('pending') == 'defeated' ? 'unopened' : 'locked')}"
       modifier: "${modifierCR.status.?effect.orValue('No modifier')}"
       modifierType: "${modifierCR.status.?modifierType.orValue('none')}"
       maxHeroHP: "${heroCR.status.?maxHP.orValue('100')}"
@@ -110,6 +112,7 @@ spec:
           namespace: ${ns.metadata.name}
         spec:
           dungeonName: ${schema.metadata.name}
+          opened: ${schema.spec.treasureOpened}
 
     # --- Modifier CR (conditional: only created when modifier is not "none") ---
     - id: modifierCR

--- a/manifests/rgds/treasure-graph.yaml
+++ b/manifests/rgds/treasure-graph.yaml
@@ -11,8 +11,10 @@ spec:
     group: game.k8s.example
     spec:
       dungeonName: string | required=true
+      opened: integer | default=0
     status:
-      loot: "${'Treasure code: ' + treasureSecret.metadata.name + '-LOOT'}"
+      loot: "${schema.spec.opened == 1 ? 'Treasure code: ' + treasureSecret.metadata.name + '-LOOT' : ''}"
+      treasureState: "${schema.spec.opened == 1 ? 'opened' : 'sealed'}"
 
   resources:
     - id: treasureSecret


### PR DESCRIPTION
Closes #78

Treasure state is now declarative through the RGD chain. Open Treasure submits an Attack CR, loot gated by CR state.