### PR TITLE
fix: mage heal button threshold (#117)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1022,7 +1022,7 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
           {!gameOver && !attackPhase && (
             <div className="ability-bar">
               {spec.heroClass === 'mage' && (
-                <button className="btn btn-ability" disabled={(spec.heroMana ?? 0) < 2 || heroHP >= 80}
+                <button className="btn btn-ability" disabled={(spec.heroMana ?? 0) < 2 || heroHP >= maxHeroHP}
                   onClick={() => onAttack('hero', 0)}>
                   <PixelIcon name="heal" size={12} /> Heal
                 </button>


### PR DESCRIPTION
Closes #117

Heal button was disabled at heroHP >= 80 for all classes. Mage max HP is 120, so this blocked healing for 33% of the health range. Fixed to disable at class-appropriate max HP.

The `maxHeroHP` variable already existed in the component (used for the HP bar display), so the fix replaces the hardcoded `80` with `maxHeroHP`. This correctly handles all three classes:
- Warrior: 200 HP
- Mage: 120 HP
- Rogue: 150 HP

The backend heal handler already correctly caps healing at 120 for mage — no backend change needed.