### PR TITLE
test: add loot-graph Secret drop guard and ability rejection tests (#133, #123)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ A turn-based dungeon RPG where the entire game state lives in Kubernetes, orches
 
 - **NEVER run applications locally** — all builds via Docker/CI only
 - **NEVER push directly to main as an agent** — always use a feature branch + PR (see Git Workflow below)
-- **Pre-push hook runs ALL 4 test suites** — integration (32), guardrails (28), backend API (17), UI smoke (59) + journeys (88). Push blocked if any fail. Use `--no-verify` only when RGD schema changes require deploy-first
+- **Pre-push hook runs ALL 4 test suites** — integration (32), guardrails (34), backend API (21), UI smoke (59) + journeys (88). Push blocked if any fail. Use `--no-verify` only when RGD schema changes require deploy-first
 - **To deploy**: push to main → CI builds image → CI rollout restarts both backend+frontend
 - **When RGD schema changes**: `kubectl delete rgd <name>` → Argo CD recreates
 - **Avoid `${BASH_VAR}` in RGD YAML** — kro parses `${}` as CEL; use `$(BASH_VAR)` instead
@@ -147,8 +147,8 @@ If tests fail: check output → review logs → check `test-failure.png` screens
 |---|---|---|---|
 | All suites | `tests/run-all.sh` | — | Runs all 4 sequentially |
 | Game engine integration | `tests/run.sh` | 32 | Core lifecycle, abilities, features, infra via `kubectl apply` |
-| Architecture guardrails | `tests/guardrails.sh` | 28 | No game logic leaks, RBAC, API shape, loot guards, animation guards |
-| Backend API | `tests/backend-api.sh` | 17 | REST endpoint correctness, validation, response shape, rate limiting |
+| Architecture guardrails | `tests/guardrails.sh` | 34 | No game logic leaks, RBAC, API shape, loot guards, animation guards |
+| Backend API | `tests/backend-api.sh` | 21 | REST endpoint correctness, validation, response shape, rate limiting, ability rejections |
 | UI smoke | `tests/e2e/smoke-test.js` | 59 | Playwright headless browser tests |
 | Journey tests | `tests/e2e/journeys/` | 88 | Full UI gameplay sessions |
 

--- a/tests/backend-api.sh
+++ b/tests/backend-api.sh
@@ -125,6 +125,81 @@ echo "$METRICS" | grep -q 'k8s_rpg_active_dungeons' \
 echo "$METRICS" | grep -q 'k8s_rpg_victories' \
   && pass "Victories gauge present" || fail "Victories gauge missing"
 
+# --- Test 12: Ability rejection — backstab on cooldown ---
+log "Test 12: Backstab-on-cooldown rejection"
+ROGUE_DUNGEON="api-test-rogue-$(date +%s)"
+curl -s -X POST "$BASE/api/v1/dungeons" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$ROGUE_DUNGEON\",\"monsters\":2,\"difficulty\":\"easy\",\"heroClass\":\"rogue\"}" -o /dev/null
+sleep 15  # wait for kro
+# Use backstab once to set cooldown=3
+curl -s -o /dev/null -X POST "$BASE/api/v1/dungeons/default/$ROGUE_DUNGEON/attacks" \
+  -H "Content-Type: application/json" \
+  -d "{\"target\":\"${ROGUE_DUNGEON}-monster-0-backstab\",\"damage\":20}"
+sleep 3
+# Immediately try backstab again — should be rejected with 400 (cooldown active)
+CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$ROGUE_DUNGEON/attacks" \
+  -H "Content-Type: application/json" \
+  -d "{\"target\":\"${ROGUE_DUNGEON}-monster-0-backstab\",\"damage\":20}")
+[ "$CODE" = "400" ] && pass "Backstab-on-cooldown rejected -> 400" || fail "Backstab-on-cooldown -> $CODE (expected 400)"
+kubectl delete dungeon "$ROGUE_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
+
+# --- Test 13: Ability rejection — mage heal with insufficient mana ---
+log "Test 13: Mage heal no-mana rejection"
+MAGE_DUNGEON="api-test-mage-$(date +%s)"
+curl -s -X POST "$BASE/api/v1/dungeons" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$MAGE_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"mage\"}" -o /dev/null
+sleep 15
+# Drain mage mana to 0 by patching the dungeon CR directly
+kubectl patch dungeon "$MAGE_DUNGEON" -n default --type=merge -p '{"spec":{"heroMana":0}}' &>/dev/null || true
+sleep 3
+# Attempt heal with 0 mana — should be 400
+CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$MAGE_DUNGEON/attacks" \
+  -H "Content-Type: application/json" \
+  -d "{\"target\":\"mage-heal\",\"damage\":0}")
+[ "$CODE" = "400" ] && pass "Mage heal with 0 mana rejected -> 400" || fail "Mage heal no-mana -> $CODE (expected 400)"
+kubectl delete dungeon "$MAGE_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
+
+# --- Test 14: Ability rejection — taunt by non-warrior class ---
+log "Test 14: Taunt by non-warrior rejection"
+MAGE_TAUNT="api-test-taunt-$(date +%s)"
+curl -s -X POST "$BASE/api/v1/dungeons" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$MAGE_TAUNT\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"mage\"}" -o /dev/null
+sleep 15
+# Mage tries to activate taunt — should be 400
+CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$MAGE_TAUNT/attacks" \
+  -H "Content-Type: application/json" \
+  -d "{\"target\":\"activate-taunt\",\"damage\":0}")
+[ "$CODE" = "400" ] && pass "Non-warrior taunt attempt rejected -> 400" || fail "Non-warrior taunt -> $CODE (expected 400)"
+kubectl delete dungeon "$MAGE_TAUNT" --ignore-not-found --wait=false 2>/dev/null || true
+
+# --- Test 15: lastLootDrop field present in spec after kill ---
+log "Test 15: lastLootDrop field present after kill"
+LOOT_TEST="api-test-loot-$(date +%s)"
+curl -s -X POST "$BASE/api/v1/dungeons" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$LOOT_TEST\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
+sleep 15
+# Kill monster-0 with lethal damage
+curl -s -o /dev/null -X POST "$BASE/api/v1/dungeons/default/$LOOT_TEST/attacks" \
+  -H "Content-Type: application/json" \
+  -d "{\"target\":\"${LOOT_TEST}-monster-0\",\"damage\":100}"
+sleep 5
+RESP=$(curl -s "$BASE/api/v1/dungeons/default/$LOOT_TEST")
+echo "$RESP" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+spec=d.get('spec',{})
+assert 'lastLootDrop' in spec, 'lastLootDrop field missing from spec'
+# lastLootDrop is either empty string (no drop) or an item name — both are valid
+print('lastLootDrop:', repr(spec['lastLootDrop']))
+" 2>/dev/null \
+  && pass "lastLootDrop field present in spec after kill (may be empty if no drop)" \
+  || fail "lastLootDrop field missing from dungeon spec after kill"
+kubectl delete dungeon "$LOOT_TEST" --ignore-not-found --wait=false 2>/dev/null || true
+
 # --- Summary ---
 echo ""
 echo "========================================"

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -196,6 +196,58 @@ ITEM_CLEAR=$(grep -c 'lastLootDrop.*""' backend/internal/handlers/handlers.go 2>
 
 grep -q 'return.*Items done' frontend/src/App.tsx && pass "Item actions early-return (no loot fallthrough)" || fail "Item actions missing early return"
 
+# Guard: monster-graph RGD gates Loot CR on hp==0 (includeWhen)
+# This ensures the kro engine never creates a Loot CR for a living monster.
+MONSTER_LOOT_GUARD=$(grep -c 'schema.spec.hp == 0' manifests/rgds/monster-graph.yaml 2>/dev/null || echo 0)
+[ "$MONSTER_LOOT_GUARD" -ge 1 ] && pass "monster-graph RGD gates Loot CR on hp==0 (includeWhen)" || fail "monster-graph missing includeWhen hp==0 guard"
+
+# Guard: boss-graph RGD gates Loot CR on hp==0 (includeWhen)
+BOSS_LOOT_GUARD=$(grep -c 'schema.spec.hp == 0\|bossHP.*== 0\|hp.*==.*0' manifests/rgds/boss-graph.yaml 2>/dev/null || echo 0)
+[ "$BOSS_LOOT_GUARD" -ge 1 ] && pass "boss-graph RGD gates Loot CR/resources on hp==0" || fail "boss-graph missing hp==0 guard"
+
+# Guard: Go handler has a no-drop path (computeMonsterLoot can return false — majority of kills)
+NO_DROP_PATH=$(grep -c 'dropped.*false\|!dropped\|if dropped' backend/internal/handlers/handlers.go 2>/dev/null || echo 0)
+[ "$NO_DROP_PATH" -ge 1 ] && pass "Go handler has no-drop path (loot not always awarded on kill)" || fail "Go handler missing no-drop path"
+
+# Live cluster guard: Loot Secret must NOT exist while monster is alive, MUST exist after kill
+echo "=== Loot Secret live guard"
+LOOT_TEST="loot-guard-$(date +%s)"
+PF_LOOT_PID=""
+LOOT_PORT=8085
+if ! curl -s http://localhost:$LOOT_PORT/healthz &>/dev/null; then
+  kubectl port-forward svc/rpg-backend -n rpg-system ${LOOT_PORT}:8080 &
+  PF_LOOT_PID=$!
+  sleep 3
+fi
+
+# Create a 1-monster easy dungeon so we can kill it in one shot (easy=30 HP, warrior hits ~12-22)
+curl -s -X POST http://localhost:$LOOT_PORT/api/v1/dungeons \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$LOOT_TEST\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
+sleep 10  # wait for kro to reconcile
+
+# Verify no Loot Secret exists while monster-0 is alive (hp > 0)
+LOOT_SECRET_BEFORE=$(kubectl get secret "${LOOT_TEST}-monster-0-loot" -n default --ignore-not-found 2>/dev/null || true)
+[ -z "$LOOT_SECRET_BEFORE" ] && pass "No Loot Secret while monster is alive (hp > 0)" || fail "Loot Secret exists before monster killed"
+
+# Kill monster-0 with lethal damage (easy monster has 30 HP; send 100 damage to guarantee kill)
+curl -s -X POST http://localhost:$LOOT_PORT/api/v1/dungeons/default/$LOOT_TEST/attacks \
+  -H "Content-Type: application/json" \
+  -d "{\"target\":\"${LOOT_TEST}-monster-0\",\"damage\":100}" -o /dev/null
+sleep 8  # wait for kro to reconcile Loot CR and Secret
+
+# Verify Loot Secret exists now that monster-0 is dead (hp == 0)
+LOOT_SECRET_AFTER=$(kubectl get secret "${LOOT_TEST}-monster-0-loot" -n default --ignore-not-found 2>/dev/null || true)
+[ -n "$LOOT_SECRET_AFTER" ] && pass "Loot Secret exists after monster killed (hp == 0)" || fail "Loot Secret missing after monster killed"
+
+# Verify lastLootDrop field is present in dungeon spec (may be empty if no drop — that is valid)
+LOOT_DROP_FIELD=$(kubectl get dungeon "$LOOT_TEST" -n default -o jsonpath='{.spec.lastLootDrop}' 2>/dev/null || echo "__missing__")
+[ "$LOOT_DROP_FIELD" != "__missing__" ] && pass "lastLootDrop field present in dungeon spec after kill" || fail "lastLootDrop field missing from dungeon spec"
+
+# Cleanup loot test dungeon
+kubectl delete dungeon "$LOOT_TEST" --ignore-not-found --wait=false &>/dev/null
+[ -n "$PF_LOOT_PID" ] && kill "$PF_LOOT_PID" 2>/dev/null
+
 # --- Combat/Action separation guardrails ---
 echo "=== Combat/Action separation"
 # After #110: attack-graph and action-graph are no-op stubs (resources: []).


### PR DESCRIPTION
## Summary
- **Guardrails (+6 tests)**: static checks that `monster-graph` and `boss-graph` RGDs gate Loot CR creation on `hp==0` via `includeWhen`; Go handler has a no-drop path; live cluster test that no Loot Secret exists while a monster is alive, but does exist after it's killed; `lastLootDrop` field present in spec after kill
- **Backend API (+4 tests)**: backstab-on-cooldown → 400; mage heal with 0 mana → 400; non-warrior taunt → 400; `lastLootDrop` field present in spec after kill
- Updates AGENTS.md test counts (guardrails 28→34, backend API 17→21)

Closes #133
Closes #123