### PR TITLE
security: gate treasure Secret loot field on opened==1 (#116)

### DIFF
--- a/manifests/rgds/treasure-graph.yaml
+++ b/manifests/rgds/treasure-graph.yaml
@@ -42,4 +42,4 @@ spec:
             game.k8s.example/dungeon: ${schema.spec.dungeonName}
             game.k8s.example/entity: treasure
         stringData:
-          loot: "${'Key: ' + schema.spec.dungeonName + '-' + string(size(schema.spec.dungeonName) * 7) + '-RUNE'}"
+          loot: "${schema.spec.opened == 1 ? 'Key: ' + schema.spec.dungeonName + '-' + string(size(schema.spec.dungeonName) * 7) + '-RUNE' : ''}"


### PR DESCRIPTION
## Summary
- The treasure-graph Secret was pre-populating the `loot` field at dungeon creation time, exposing the key to anyone with Secret read access in the namespace before the chest was opened
- Now gates `stringData.loot` on `schema.spec.opened == 1`, matching the existing ConfigMap condition — empty string when unopened, key value when opened

Closes #116