### PR TITLE
fix: validate dungeon name as K8s DNS label (#120)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -92,6 +93,10 @@ var defaultHP = map[string]struct{ monster, boss int64 }{
 	"hard":   {80, 800},
 }
 
+// validDNSLabel matches valid Kubernetes namespace names (RFC 1123 DNS label).
+// Must be lowercase alphanumeric or hyphens, start/end with alphanumeric, max 63 chars.
+var validDNSLabel = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
 type CreateDungeonReq struct {
 	Name       string `json:"name"`
 	Monsters   int64  `json:"monsters"`
@@ -108,6 +113,10 @@ func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Name == "" || req.Monsters < 1 || req.Monsters > 10 {
 		writeError(w, "invalid name or monsters (1-10)", http.StatusBadRequest)
+		return
+	}
+	if !validDNSLabel.MatchString(req.Name) {
+		writeError(w, "dungeon name must be a valid DNS label (lowercase alphanumeric and hyphens only, max 63 chars, must start and end with alphanumeric)", http.StatusBadRequest)
 		return
 	}
 	if req.Difficulty != "easy" && req.Difficulty != "normal" && req.Difficulty != "hard" {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -380,9 +380,22 @@ function CreateForm({ onCreate }: { onCreate: (n: string, m: number, d: string, 
   const [monsters, setMonsters] = useState(3)
   const [difficulty, setDifficulty] = useState('normal')
   const [heroClass, setHeroClass] = useState('warrior')
+  const dnsLabelRegex = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/
+  const nameValid = name === '' || dnsLabelRegex.test(name)
+  const canCreate = name.length > 0 && dnsLabelRegex.test(name)
   return (
     <div className="create-form">
-      <div><label>Dungeon Name</label><input value={name} onChange={e => setName(e.target.value)} placeholder="my-dungeon" /></div>
+      <div>
+        <label>Dungeon Name</label>
+        <input
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="my-dungeon"
+          maxLength={63}
+          pattern="[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?"
+        />
+        {!nameValid && <div className="input-error">Lowercase letters, numbers, hyphens only. Max 63 chars. Must start and end with alphanumeric.</div>}
+      </div>
       <div><label>Monsters</label><input type="number" min={1} max={10} value={monsters} onChange={e => setMonsters(+e.target.value)} /></div>
       <div><label>Difficulty</label>
         <select value={difficulty} onChange={e => setDifficulty(e.target.value)}>
@@ -394,7 +407,7 @@ function CreateForm({ onCreate }: { onCreate: (n: string, m: number, d: string, 
           <option value="warrior">⚔️ Warrior</option><option value="mage">🔮 Mage</option><option value="rogue">🗡️ Rogue</option>
         </select>
       </div>
-      <button className="btn btn-gold" onClick={() => { if (name) { onCreate(name, monsters, difficulty, heroClass); setName('') } }}>
+      <button className="btn btn-gold" disabled={!canCreate} onClick={() => { if (canCreate) { onCreate(name, monsters, difficulty, heroClass); setName('') } }}>
         Create Dungeon
       </button>
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -111,6 +111,7 @@ body {
   border: 2px solid var(--border);
   width: 140px;
 }
+.input-error { font-size: 6px; color: var(--accent); margin-top: 4px; max-width: 200px; line-height: 1.6; }
 
 /* Dungeon View */
 .dungeon-header {


### PR DESCRIPTION
## Summary
- Backend: adds `regexp.MustCompile` DNS label validation (`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`) in `CreateDungeon` before the CR is submitted to Kubernetes — invalid names now get a clear 400 with an explanation
- Frontend: adds `pattern`, `maxLength=63`, inline error message, and disables the Create button until the name is valid

Without this, names like `My_Dungeon` or `test dungeon` would silently fail at the kro/namespace level with no feedback to the player.

Closes #120