### PR TITLE
observability: surface kro errors in UI (#129)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -758,6 +758,20 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
   const [showDoorModal, setShowDoorModal] = useState(false)
   const [doorPassword, setDoorPassword] = useState('')
   const autoTriggeredRef = useRef('')
+  const [dismissedEngineWarning, setDismissedEngineWarning] = useState('')
+
+  // Derive kro reconciliation error from status.conditions
+  const engineWarning = (() => {
+    const conditions = (status as any)?.conditions as Array<{ type: string; status: string; message?: string; reason?: string }> | undefined
+    if (!conditions?.length) return null
+    // Prefer explicit Error-type condition
+    const errCond = conditions.find(c => c.type === 'Error' && c.message)
+    if (errCond) return errCond.message!
+    // Fall back to any condition with status=False and a message
+    const falseCond = conditions.find(c => c.status === 'False' && c.message)
+    if (falseCond) return falseCond.message!
+    return null
+  })()
 
   // Auto-open treasure and unlock door after boss kill (room 1 only)
   useEffect(() => {
@@ -800,6 +814,17 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
       {!wsConnected && (
         <div className="ws-reconnecting-banner">
           ○ Reconnecting to server...
+        </div>
+      )}
+
+      {engineWarning && engineWarning !== dismissedEngineWarning && (
+        <div className="engine-warning-banner" role="alert">
+          <span>Engine warning: {engineWarning}</span>
+          <button
+            onClick={() => setDismissedEngineWarning(engineWarning)}
+            aria-label="Dismiss engine warning"
+            style={{ background: 'none', border: 'none', color: 'inherit', cursor: 'pointer', fontFamily: 'inherit', fontSize: '10px', marginLeft: 8 }}
+          >✕</button>
         </div>
       )}
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -6,6 +6,14 @@ export interface DungeonSummary {
 }
 
 // GetDungeon now returns the raw Dungeon CR — all state is in spec + status
+export interface KroCondition {
+  type: string       // e.g. "Ready", "Error"
+  status: string     // "True" or "False"
+  reason?: string
+  message?: string
+  lastTransitionTime?: string
+}
+
 export interface DungeonCR {
   metadata: { name: string; namespace: string }
   spec: {
@@ -26,6 +34,7 @@ export interface DungeonCR {
     loot: string; maxMonsterHP: number; maxBossHP: number
     maxHeroHP: number; diceFormula: string; monsterCounter: number; bossCounter: number
     modifier?: string; modifierType?: string; treasureState?: string
+    conditions?: KroCondition[]
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -402,6 +402,19 @@ body {
 }
 @keyframes reconnectPulse { 0%,100% { opacity: 1; } 50% { opacity: 0.5; } }
 
+.engine-warning-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 5px 10px;
+  margin-bottom: 8px;
+  background: rgba(245, 197, 24, 0.1);
+  border: 1px solid #b8860b;
+  color: #f5c518;
+  font-size: 7px;
+  border-radius: 2px;
+}
+
 /* Defeat */
 .defeat-banner {
   text-align: center;


### PR DESCRIPTION
Closes #129

Surfaces kro reconciliation error conditions from Dungeon CR status into the game UI as a dismissable warning banner.

## What changed

- **`frontend/src/api.ts`**: Added `KroCondition` interface (`type`, `status`, `reason`, `message`, `lastTransitionTime`) and added `conditions?: KroCondition[]` to `DungeonCR.status`. The backend's `GetDungeon` already returns the full raw CR object (including `status.conditions`), so no backend change is needed.

- **`frontend/src/App.tsx`**: In `DungeonView`, derives `engineWarning` from `status.conditions` — picks any condition with `type: "Error"` (with a message), or falls back to the first condition with `status: "False"` and a non-empty message. Renders a dismissable amber banner: _"Engine warning: \<message\>"_. The dismissed message is tracked in local state so re-renders don't resurface the same message.

- **`frontend/src/index.css`**: Added `.engine-warning-banner` styles — small amber/yellow banner with `rgba(245,197,24,0.1)` background and `#b8860b` border, 7px font, matching the existing pixel-art aesthetic.

## Banner behaviour

- Only shown when `status.conditions` contains an error condition
- Dismissable via ✕ button (dismissed message stored in local state — same message won't re-appear until it changes)
- If the condition clears (kro reconciles successfully), the banner disappears automatically on the next poll
- Non-intrusive: small banner between the WS reconnecting indicator and the combat modal area