### PR TITLE
test: ability rejection coverage (#123)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -473,6 +473,10 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			writeError(w, "only warrior can taunt", http.StatusBadRequest)
 			return fmt.Errorf("only warrior can taunt")
 		}
+		if tauntActive > 0 {
+			writeError(w, "taunt already active", http.StatusBadRequest)
+			return fmt.Errorf("taunt already active")
+		}
 		patch := map[string]interface{}{
 			"spec": map[string]interface{}{
 				"tauntActive":     1,

--- a/tests/backend-api.sh
+++ b/tests/backend-api.sh
@@ -200,6 +200,57 @@ print('lastLootDrop:', repr(spec['lastLootDrop']))
   || fail "lastLootDrop field missing from dungeon spec after kill"
 kubectl delete dungeon "$LOOT_TEST" --ignore-not-found --wait=false 2>/dev/null || true
 
+# --- Test 16: Ability rejection — backstab on cooldown (direct patch) ---
+log "Test 16: Backstab-on-cooldown rejection (direct spec patch)"
+ROGUE_CD_DUNGEON="api-test-rogue-cd-$(date +%s)"
+curl -s -X POST "$BASE/api/v1/dungeons" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$ROGUE_CD_DUNGEON\",\"monsters\":2,\"difficulty\":\"easy\",\"heroClass\":\"rogue\"}" -o /dev/null
+sleep 15
+# Patch backstabCooldown to 1 directly on the spec
+kubectl patch dungeon "$ROGUE_CD_DUNGEON" -n default --type=merge -p '{"spec":{"backstabCooldown":1}}' &>/dev/null || true
+sleep 3
+# Attempt backstab — should be rejected with 400 (cooldown active)
+CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$ROGUE_CD_DUNGEON/attacks" \
+  -H "Content-Type: application/json" \
+  -d "{\"target\":\"${ROGUE_CD_DUNGEON}-monster-0-backstab\",\"damage\":20}")
+[ "$CODE" = "400" ] && pass "Backstab-on-cooldown (patched) rejected -> 400" || fail "Backstab-on-cooldown (patched) -> $CODE (expected 400)"
+kubectl delete dungeon "$ROGUE_CD_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
+
+# --- Test 17: Ability rejection — mage heal with 0 mana (direct patch, correct target) ---
+log "Test 17: Mage heal no-mana rejection (direct spec patch, target=hero)"
+MAGE_NOMANA_DUNGEON="api-test-mage-nm-$(date +%s)"
+curl -s -X POST "$BASE/api/v1/dungeons" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$MAGE_NOMANA_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"mage\"}" -o /dev/null
+sleep 15
+# Drain heroMana to 0 by patching the dungeon CR directly
+kubectl patch dungeon "$MAGE_NOMANA_DUNGEON" -n default --type=merge -p '{"spec":{"heroMana":0}}' &>/dev/null || true
+sleep 3
+# Attempt heal with 0 mana (target="hero" is the heal trigger) — should be 400
+CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$MAGE_NOMANA_DUNGEON/attacks" \
+  -H "Content-Type: application/json" \
+  -d '{"target":"hero","damage":0}')
+[ "$CODE" = "400" ] && pass "Mage heal with 0 mana (patched) rejected -> 400" || fail "Mage heal no-mana (patched) -> $CODE (expected 400)"
+kubectl delete dungeon "$MAGE_NOMANA_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
+
+# --- Test 18: Ability rejection — taunt already active (direct patch) ---
+log "Test 18: Taunt-already-active rejection (direct spec patch)"
+WARRIOR_TAUNT_DUNGEON="api-test-warrior-taunt-$(date +%s)"
+curl -s -X POST "$BASE/api/v1/dungeons" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$WARRIOR_TAUNT_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
+sleep 15
+# Patch tauntActive to true (non-zero) directly on the spec
+kubectl patch dungeon "$WARRIOR_TAUNT_DUNGEON" -n default --type=merge -p '{"spec":{"tauntActive":1}}' &>/dev/null || true
+sleep 3
+# Attempt taunt while already active — should be rejected with 400
+CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$WARRIOR_TAUNT_DUNGEON/attacks" \
+  -H "Content-Type: application/json" \
+  -d '{"target":"activate-taunt","damage":0}')
+[ "$CODE" = "400" ] && pass "Taunt-already-active rejected -> 400" || fail "Taunt-already-active -> $CODE (expected 400)"
+kubectl delete dungeon "$WARRIOR_TAUNT_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
+
 # --- Summary ---
 echo ""
 echo "========================================"


### PR DESCRIPTION
Closes #123

Adds backend API tests for the three ability-rejection paths that were previously untested, and adds the missing backend guard for taunt-already-active.

## Changes

### `tests/backend-api.sh` — 3 new tests
- **Test 16** — Backstab-on-cooldown: creates a Rogue dungeon, patches `backstabCooldown: 1` directly on the spec, asserts `POST .../attacks` with `-backstab` target returns 400
- **Test 17** — Mage heal no-mana: creates a Mage dungeon, patches `heroMana: 0`, asserts `POST .../attacks` with `target: "hero"` returns 400 (corrects existing Test 13 which used wrong target `"mage-heal"`)
- **Test 18** — Taunt already active: creates a Warrior dungeon, patches `tauntActive: 1`, asserts `POST .../attacks` with `target: "activate-taunt"` returns 400

### `backend/internal/handlers/handlers.go` — backend guard
- Added `tauntActive > 0` guard in the `activate-taunt` branch (`processCombat`) — without this, the endpoint silently overwrites an active taunt instead of rejecting. This is the backend rejection Test 18 validates.