### PR TITLE
fix: resource limits and PDB for backend/frontend (#166)

### DIFF
--- a/manifests/system/backend-pdb.yaml
+++ b/manifests/system/backend-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: rpg-backend-pdb
+  namespace: rpg-system
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app: rpg-backend

--- a/manifests/system/backend.yaml
+++ b/manifests/system/backend.yaml
@@ -33,8 +33,11 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: "50m"
-              memory: "64Mi"
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/system/frontend.yaml
+++ b/manifests/system/frontend.yaml
@@ -26,8 +26,11 @@ spec:
             periodSeconds: 5
           resources:
             requests:
-              cpu: "10m"
-              memory: "32Mi"
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Closes #166

Adds memory/CPU requests+limits to backend and frontend containers. Adds PodDisruptionBudget for backend.

## Changes

- **backend.yaml**: Upgraded resource requests (128Mi/100m) and added limits (256Mi/500m)
- **frontend.yaml**: Upgraded resource requests (128Mi/100m) and added limits (256Mi/500m)
- **backend-pdb.yaml**: New PodDisruptionBudget with `minAvailable: 0` for single-replica documentation of intent