### PR TITLE
observability: attack/action latency metrics (#121)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -342,6 +342,10 @@ func (h *Handler) CreateAttack(w http.ResponseWriter, r *http.Request) {
 // 3. kro re-reconciles dungeon-graph, writes combatResult ConfigMap
 // 4. Backend reads combatResult ConfigMap, runs full combat math, patches Dungeon spec
 func (h *Handler) processCombat(ctx context.Context, ns, name, target string, clientDamage int64, w http.ResponseWriter) error {
+	start := time.Now()
+	defer func() {
+		slog.Info("attack_processed", "component", "api", "dungeon", name, "target", target, "duration_ms", time.Since(start).Milliseconds())
+	}()
 	// Step 1: read current dungeon spec
 	dungeon, err := h.client.Dynamic.Resource(k8s.DungeonGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
@@ -866,6 +870,10 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 
 // processAction handles a non-combat action (use item, equip, treasure, door, room transition).
 func (h *Handler) processAction(ctx context.Context, ns, name, action string, w http.ResponseWriter) error {
+	start := time.Now()
+	defer func() {
+		slog.Info("action_processed", "component", "api", "dungeon", name, "action", action, "duration_ms", time.Since(start).Milliseconds())
+	}()
 	dungeon, err := h.client.Dynamic.Resource(k8s.DungeonGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		slog.Error("failed to get dungeon for action", "component", "api", "dungeon", name, "namespace", ns, "error", err)

--- a/infra/observability.tf
+++ b/infra/observability.tf
@@ -308,6 +308,66 @@ resource "aws_cloudwatch_log_metric_filter" "reaper_success" {
   }
 }
 
+# Extracts attack handler duration_ms for P95 latency tracking.
+# Log line emitted by processCombat: attack_processed dungeon=<n> target=<t> duration_ms=<v>
+resource "aws_cloudwatch_log_metric_filter" "attack_latency" {
+  name           = "${var.cluster_name}-attack-latency"
+  log_group_name = aws_cloudwatch_log_group.rpg_system.name
+  pattern        = "[timestamp, level, msg=\"attack_processed\", dungeon, target, duration]"
+
+  metric_transformation {
+    name      = "AttackDurationMs"
+    namespace = "Krombat/Game"
+    value     = "$duration"
+    unit      = "Milliseconds"
+  }
+}
+
+# Extracts action handler duration_ms for P95 latency tracking.
+# Log line emitted by processAction: action_processed dungeon=<n> action=<a> duration_ms=<v>
+resource "aws_cloudwatch_log_metric_filter" "action_latency" {
+  name           = "${var.cluster_name}-action-latency"
+  log_group_name = aws_cloudwatch_log_group.rpg_system.name
+  pattern        = "[timestamp, level, msg=\"action_processed\", dungeon, action, duration]"
+
+  metric_transformation {
+    name      = "ActionDurationMs"
+    namespace = "Krombat/Game"
+    value     = "$duration"
+    unit      = "Milliseconds"
+  }
+}
+
+# Counts each processed attack event for game-event throughput tracking.
+resource "aws_cloudwatch_log_metric_filter" "attack_count" {
+  name           = "${var.cluster_name}-attack-count"
+  log_group_name = aws_cloudwatch_log_group.rpg_system.name
+  pattern        = "attack_processed"
+
+  metric_transformation {
+    name          = "AttackCount"
+    namespace     = "Krombat/Game"
+    value         = "1"
+    default_value = "0"
+    unit          = "Count"
+  }
+}
+
+# Counts each processed action event for game-event throughput tracking.
+resource "aws_cloudwatch_log_metric_filter" "action_count" {
+  name           = "${var.cluster_name}-action-count"
+  log_group_name = aws_cloudwatch_log_group.rpg_system.name
+  pattern        = "action_processed"
+
+  metric_transformation {
+    name          = "ActionCount"
+    namespace     = "Krombat/Game"
+    value         = "1"
+    default_value = "0"
+    unit          = "Count"
+  }
+}
+
 # --- Additional CloudWatch Alarms ---
 
 # Alert if active dungeon count (running game-namespace pods) exceeds 50


### PR DESCRIPTION
Closes #121

Adds per-dungeon latency logging and CloudWatch metric filters for P95 histogram and game-event throughput tracking.

## Changes

### Backend (`handlers.go`)
- `processCombat`: records `start := time.Now()` at entry; a deferred closure logs `attack_processed` with `dungeon`, `target`, and `duration_ms` fields on every code path (including early returns for heal, taunt, already-dead guards)
- `processAction`: same pattern — deferred `action_processed` log with `dungeon`, `action`, and `duration_ms`

Both use `slog.Info` with structured key-value fields so the log format is consistent with existing backend logging.

### Infrastructure (`observability.tf`)
Four new `aws_cloudwatch_log_metric_filter` resources targeting the `/eks/krombat/rpg-system` log group:

| Resource | CloudWatch Metric | Purpose |
|---|---|---|
| `attack_latency` | `Krombat/Game::AttackDurationMs` | P95 histogram for combat handler latency |
| `action_latency` | `Krombat/Game::ActionDurationMs` | P95 histogram for action handler latency |
| `attack_count` | `Krombat/Game::AttackCount` | Game-event throughput (attacks/min) |
| `action_count` | `Krombat/Game::ActionCount` | Game-event throughput (actions/min) |

The latency filters use space-delimited pattern matching to extract `$duration` (the `duration_ms=<value>` token) as a `Milliseconds`-unit metric, enabling CloudWatch's built-in `p95` statistic directly on the metric.