### PR TITLE
fix: taunt duration consistency (#165)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -461,7 +461,8 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 		tauntNote = " [Taunt active: -60% counter dmg]"
 		tauntActive = 2
 	} else if tauntActive > 1 {
-		tauntActive--
+		// Taunt protected exactly 1 turn — expire it now
+		tauntActive = 0
 	}
 
 	// Determine real target (strip -backstab suffix)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1086,8 +1086,8 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
                 </button>
               )}
               {spec.heroClass === 'warrior' && (
-                <button className={`btn btn-ability${(spec.tauntActive ?? 0) === 1 ? ' active' : ''}`}
-                  disabled={(spec.tauntActive ?? 0) >= 1}
+                <button className={`btn btn-ability${(spec.tauntActive ?? 0) > 0 ? ' active' : ''}`}
+                  disabled={(spec.tauntActive ?? 0) > 0}
                   onClick={() => onAttack('activate-taunt', 0)}>
                   <PixelIcon name="shield" size={12} /> Taunt
                 </button>
@@ -1110,6 +1110,7 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
             const poison = spec.poisonTurns || 0
             const burn = spec.burnTurns || 0
             const stun = spec.stunTurns || 0
+            const taunt = spec.tauntActive || 0
             const RARITY_COLOR: Record<string, string> = { common: '#aaa', rare: '#5dade2', epic: '#9b59b6' }
             return (
               <div className="equip-panel">
@@ -1138,6 +1139,7 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
 
                 <div className="status-row">
                   {modifier !== 'none' && <Tooltip text={`${modifier.startsWith('curse') ? 'Curse' : 'Blessing'}: ${status?.modifier || modifier}`}><div className={`status-badge ${modifier.startsWith('curse') ? 'curse' : 'blessing'}`}><ItemSprite id={modifier} size={18} /></div></Tooltip>}
+                  {taunt > 0 && <Tooltip text={taunt === 1 ? 'Taunt ready: next attack has 60% counter-attack reduction' : 'TAUNTING: 60% counter-attack reduction active this turn'}><div className="status-badge effect taunt"><PixelIcon name="shield" size={12} /><span>{taunt === 2 ? 'ACT' : 'RDY'}</span></div></Tooltip>}
                   {poison > 0 && <Tooltip text={`Poison: -5 HP per turn, ${poison} turns remaining`}><div className="status-badge effect" data-effect="poison"><PixelIcon name="poison" size={12} /><span>{poison}</span></div></Tooltip>}
                   {burn > 0 && <Tooltip text={`Burn: -8 HP per turn, ${burn} turns remaining`}><div className="status-badge effect" data-effect="burn"><PixelIcon name="fire" size={12} /><span>{burn}</span></div></Tooltip>}
                   {stun > 0 && <Tooltip text={`Stun: skip next attack, ${stun} turns remaining`}><div className="status-badge effect" data-effect="stun"><PixelIcon name="lightning" size={12} /><span>{stun}</span></div></Tooltip>}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -552,6 +552,8 @@ body {
 .status-badge.blessing { background: #0a1a0a; border: 1px solid #ffd700; }
 .status-badge.effect { background: #0a0a1a; border: 1px solid #555; flex-direction: column; }
 .status-badge.effect span { font-size: 6px; color: #aaa; }
+.status-badge.effect.taunt { border-color: #4a90d9; color: #4a90d9; background: #0a0f1a; }
+.status-badge.effect.taunt span { color: #4a90d9; }
 
 .backpack { align-self: center; }
 .backpack-label { font-size: 7px; color: #555; margin-bottom: 2px; text-align: center; }


### PR DESCRIPTION
Closes #165

## Root cause

The taunt state machine in `handlers.go` had an infinite-cycle bug:

| State | Transition | Effect |
|---|---|---|
| Activate | `0 → 1` | Queued (1 turn cost) |
| Next attack | `1 → 2` | Protection applied ✓ |
| Following attack | `2 → 2-1 = 1` | No protection — but cycles back! |
| Next attack again | `1 → 2` | Protection applies **again** ← bug |

`tauntActive--` at the expiry branch turned `2 → 1`, restarting the protection cycle every 2 turns indefinitely.

## Fix

**Backend (`handlers.go`):** Changed `tauntActive--` to `tauntActive = 0` so taunt expires cleanly after exactly 1 protected turn, matching the Help modal ("1 round").

**Frontend (`App.tsx`):**
- Fixed Taunt button `active` class/disabled check: was `=== 1` (only pending state), now `> 0` (both pending and protecting states)
- Added a taunt status badge in the hero status-row alongside POISON/BURN/STUN, showing `RDY` (tauntActive=1, queued) or `ACT` (tauntActive=2, protecting this turn) with a blue shield icon

**CSS (`index.css`):** Added `.status-badge.effect.taunt` rule with blue (#4a90d9) styling consistent with the defensive/tank theme.