### PR TITLE
fix: Rogue dodge seed predictability (#154)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -653,7 +653,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			if heroClass == "warrior" {
 				counter = counter * 3 / 4
 			} else if heroClass == "rogue" {
-				if seededRoll(attackUID+"-dodge", 100) < 25 {
+				if seededRoll(attackUID+"-dodge-boss", 100) < 25 {
 					counter = 0
 					classNote += " Rogue dodged!"
 				}
@@ -819,7 +819,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			if heroClass == "warrior" {
 				totalCounter = totalCounter * 4 / 5
 			} else if heroClass == "rogue" {
-				if seededRoll(attackUID+"-dodge", 100) < 25 {
+				if seededRoll(attackUID+"-dodge-monster", 100) < 25 {
 					totalCounter = 0
 					classNote += " Rogue dodged!"
 				}


### PR DESCRIPTION
Closes #154

Uses distinct seed suffixes for monster vs boss dodge rolls to prevent identical outcomes from the same attack UID.

## Problem

Both monster counter-attack and boss counter-attack Rogue dodge rolls used the same seed suffix . Since  is a deterministic FNV-1a hash, the same attack UID always produced the same hash value for both paths — meaning a Rogue would always either dodge both or neither, with no independent variance between the two situations.

## Fix

| Location | Old seed suffix | New seed suffix |
|---|---|---|
| Boss counter-attack (line 656) | `attackUID+"-dodge"` | `attackUID+"-dodge-boss"` |
| Monster counter-attack (line 822) | `attackUID+"-dodge"` | `attackUID+"-dodge-monster"` |

This ensures the two code paths hash to different values from the same UID, giving each roll an independent, unpredictable outcome.