### PR TITLE
security: gate treasure Secret on treasureOpened (#116)

### DIFF
--- a/manifests/rgds/treasure-graph.yaml
+++ b/manifests/rgds/treasure-graph.yaml
@@ -32,6 +32,8 @@ spec:
           loot: "${schema.spec.opened == 1 ? 'Key: ' + schema.spec.dungeonName + '-' + string(size(schema.spec.dungeonName) * 7) + '-RUNE' : ''}"
 
     - id: treasureSecret
+      includeWhen:
+        - "${schema.spec.opened == 1}"
       template:
         apiVersion: v1
         kind: Secret
@@ -42,4 +44,4 @@ spec:
             game.k8s.example/dungeon: ${schema.spec.dungeonName}
             game.k8s.example/entity: treasure
         stringData:
-          loot: "${schema.spec.opened == 1 ? 'Key: ' + schema.spec.dungeonName + '-' + string(size(schema.spec.dungeonName) * 7) + '-RUNE' : ''}"
+          loot: "${'Key: ' + schema.spec.dungeonName + '-' + string(size(schema.spec.dungeonName) * 7) + '-RUNE'}"


### PR DESCRIPTION
Closes #116

## Problem

The `treasureSecret` resource in `treasure-graph.yaml` was always created, even when the chest was unopened (`opened == 0`). The CEL expression used a ternary to set the `loot` value to an empty string when unopened, but:

1. The Secret key `loot` always existed in `stringData` — a client with Secret read access could observe it at any time.
2. Any future logic change that pre-computes loot contents (e.g. for UI previews) would immediately leak through this Secret.

## Fix

Added `includeWhen: ["${schema.spec.opened == 1}"]` to the `treasureSecret` resource. The Secret is now **not created at all** until the chest is opened. When it is created, the `loot` field contains the unconditional value (no ternary needed since the condition is already enforced by `includeWhen`).

## What was NOT changed

- `treasureState` ConfigMap — intentionally left unchanged. ConfigMaps are less sensitive than Secrets, and the loot value in the ConfigMap is already gated by the same ternary (`opened == 1 ? ... : ''`). The ConfigMap is the source of truth for `treasureCR.status.loot` → `dungeonCR.status.loot`, and that flow is correct.
- dungeon-graph.yaml — no treasure-Secret references; loot flows through the Treasure CR status, not the Secret directly.

## Technique used

`includeWhen` on the Secret resource (kro RGD feature), **not** a CEL conditional on the data field. This is strictly stronger — the resource doesn't exist rather than existing with an empty value.