### PR TITLE
fix: actionSeq conflict guard for concurrent attack protection (#130)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -293,6 +293,11 @@ func (h *Handler) DeleteDungeon(w http.ResponseWriter, r *http.Request) {
 type CreateAttackReq struct {
 	Target string `json:"target"`
 	Damage int64  `json:"damage"`
+	// Seq is the actionSeq/attackSeq the client last observed. The backend
+	// compares this against the current dungeon spec to detect concurrent
+	// writes. A value of -1 (omitted / zero-valued client) disables the guard
+	// so existing clients without the field are not broken.
+	Seq int64 `json:"seq"`
 }
 
 // CreateAttack handles all player actions. Routes to Action CR (non-combat) or
@@ -324,12 +329,12 @@ func (h *Handler) CreateAttack(w http.ResponseWriter, r *http.Request) {
 	ctx := context.Background()
 
 	if isAction {
-		if err := h.processAction(ctx, ns, name, req.Target, w); err != nil {
+		if err := h.processAction(ctx, ns, name, req.Target, req.Seq, w); err != nil {
 			// error already written
 			return
 		}
 	} else {
-		if err := h.processCombat(ctx, ns, name, req.Target, req.Damage, w); err != nil {
+		if err := h.processCombat(ctx, ns, name, req.Target, req.Damage, req.Seq, w); err != nil {
 			// error already written
 			return
 		}
@@ -338,10 +343,11 @@ func (h *Handler) CreateAttack(w http.ResponseWriter, r *http.Request) {
 
 // processCombat handles a combat action:
 // 1. Read current dungeon spec to get current attackSeq and room
-// 2. Upsert fixed-name Attack CR (SSA) with new seq = attackSeq+1 and targetRoom
-// 3. kro re-reconciles dungeon-graph, writes combatResult ConfigMap
-// 4. Backend reads combatResult ConfigMap, runs full combat math, patches Dungeon spec
-func (h *Handler) processCombat(ctx context.Context, ns, name, target string, clientDamage int64, w http.ResponseWriter) error {
+// 2. If clientSeq >= 0 and clientSeq != attackSeq, return 409 Conflict (stale request)
+// 3. Upsert fixed-name Attack CR (SSA) with new seq = attackSeq+1 and targetRoom
+// 4. kro re-reconciles dungeon-graph, writes combatResult ConfigMap
+// 5. Backend reads combatResult ConfigMap, runs full combat math, patches Dungeon spec
+func (h *Handler) processCombat(ctx context.Context, ns, name, target string, clientDamage int64, clientSeq int64, w http.ResponseWriter) error {
 	start := time.Now()
 	defer func() {
 		slog.Info("attack_processed", "component", "api", "dungeon", name, "target", target, "duration_ms", time.Since(start).Milliseconds())
@@ -362,6 +368,15 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 	tauntActive := getInt(spec, "tauntActive")
 	backstabCD := getInt(spec, "backstabCooldown")
 	attackSeq := getInt(spec, "attackSeq")
+
+	// Conflict guard: if the client sent a known sequence number that doesn't
+	// match the current spec, another request already advanced the dungeon
+	// state. Reject with 409 so the client re-fetches before retrying.
+	if clientSeq >= 0 && clientSeq != attackSeq {
+		slog.Warn("stale attack rejected", "component", "api", "dungeon", name, "clientSeq", clientSeq, "serverSeq", attackSeq)
+		writeError(w, "stale request — dungeon state has changed, please retry", http.StatusConflict)
+		return fmt.Errorf("stale attack: clientSeq=%d serverSeq=%d", clientSeq, attackSeq)
+	}
 	modifier := getString(spec, "modifier", "none")
 	inventory := getString(spec, "inventory", "")
 	weaponBonus := getInt(spec, "weaponBonus")
@@ -878,7 +893,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 }
 
 // processAction handles a non-combat action (use item, equip, treasure, door, room transition).
-func (h *Handler) processAction(ctx context.Context, ns, name, action string, w http.ResponseWriter) error {
+func (h *Handler) processAction(ctx context.Context, ns, name, action string, clientSeq int64, w http.ResponseWriter) error {
 	start := time.Now()
 	defer func() {
 		slog.Info("action_processed", "component", "api", "dungeon", name, "action", action, "duration_ms", time.Since(start).Milliseconds())
@@ -899,6 +914,15 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, w 
 	difficulty := getString(spec, "difficulty", "normal")
 	bossHP := getInt(spec, "bossHP")
 	actionSeq := getInt(spec, "actionSeq")
+
+	// Conflict guard: reject stale requests where the client's observed
+	// actionSeq no longer matches the server. clientSeq < 0 means the client
+	// did not send a sequence (old clients) — those are passed through.
+	if clientSeq >= 0 && clientSeq != actionSeq {
+		slog.Warn("stale action rejected", "component", "api", "dungeon", name, "clientSeq", clientSeq, "serverSeq", actionSeq)
+		writeError(w, "stale request — dungeon state has changed, please retry", http.StatusConflict)
+		return fmt.Errorf("stale action: clientSeq=%d serverSeq=%d", clientSeq, actionSeq)
+	}
 	monsterHPRaw, _ := spec["monsterHP"].([]interface{})
 
 	if backstabCD > 0 {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { DungeonSummary, DungeonCR, listDungeons, getDungeon, createDungeon, submitAttack, deleteDungeon } from './api'
+import { DungeonSummary, DungeonCR, listDungeons, getDungeon, createDungeon, submitAttack, deleteDungeon, ApiError } from './api'
 import { useWebSocket, WSEvent } from './useWebSocket'
 
 import { Sprite, getMonsterSprite, SpriteAction, ItemSprite } from './Sprite'
@@ -163,7 +163,8 @@ export default function App() {
         setCombatModal({ phase: 'rolling', formula: detail?.status?.diceFormula || '2d12+6', heroAction: '', enemyAction: '', spec: detail?.spec, oldHP: detail?.spec.heroHP ?? 100 })
       }
 
-      await submitAttack(selected.ns, selected.name, target, damage)
+      await submitAttack(selected.ns, selected.name, target, damage,
+        isItem ? (detail?.spec.actionSeq ?? -1) : (detail?.spec.attackSeq ?? -1))
       const crKind = isItem ? 'Action' : 'Attack'
       const crField = isItem ? `action: ${target}` : `target: ${target}\n  damage: ${damage}`
       addK8s(`kubectl apply -f ${crKind.toLowerCase()}.yaml`, `${crKind.toLowerCase()}.game.k8s.example created`,
@@ -290,7 +291,18 @@ export default function App() {
 
       // Don't clear attackPhase/attackTarget — user must dismiss combat modal
     } catch (e: any) {
-      setError(e.message)
+      // 409 Conflict: another concurrent request already advanced the dungeon
+      // state. Re-fetch the latest state so the player sees current HP/seq,
+      // then show a non-blocking notice so they can retry.
+      if (e instanceof ApiError && e.status === 409) {
+        try {
+          const refreshed = await getDungeon(selected!.ns, selected!.name)
+          setDetail(refreshed)
+        } catch { /* best-effort */ }
+        setError('State changed — dungeon refreshed. Please retry your action.')
+      } else {
+        setError(e.message)
+      }
       setCombatModal(null)
       setAttackPhase(null)
       setAnimPhase('idle')

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -28,6 +28,8 @@ export interface DungeonCR {
     treasureOpened?: number
     currentRoom?: number; doorUnlocked?: number
     lastHeroAction?: string; lastEnemyAction?: string
+    attackSeq?: number
+    actionSeq?: number
   }
   status?: {
     livingMonsters: number; bossState: string; victory: boolean; defeated: boolean
@@ -64,11 +66,20 @@ export async function deleteDungeon(ns: string, name: string) {
 }
 
 
-export async function submitAttack(ns: string, dungeon: string, target: string, damage: number) {
+export class ApiError extends Error {
+  constructor(public readonly status: number, message: string) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+export async function submitAttack(ns: string, dungeon: string, target: string, damage: number, seq?: number) {
   const r = await fetch(`${BASE}/dungeons/${ns}/${dungeon}/attacks`, {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ target, damage }),
+    // seq: send the last-known sequence so the backend can detect concurrent
+    // writes. Omit (send -1) when seq is unknown to stay backward-compatible.
+    body: JSON.stringify({ target, damage, seq: seq ?? -1 }),
   })
-  if (!r.ok) throw new Error(await r.text())
+  if (!r.ok) throw new ApiError(r.status, await r.text())
   return r.json()
 }


### PR DESCRIPTION
Closes #130

## Summary

- Adds a `seq` field to the attack/action request payload — the client sends the `attackSeq` (for combat) or `actionSeq` (for actions) it last observed from the dungeon spec
- The backend reads the current sequence from the Dungeon CR spec before applying the SSA upsert; if they don't match (`clientSeq >= 0 && clientSeq != serverSeq`), it returns **HTTP 409 Conflict** with `"stale request — dungeon state has changed, please retry"`
- Clients that omit `seq` (or send `-1`) bypass the guard, preserving backward compatibility
- The frontend passes the correct sequence on every attack/action call and on 409 re-fetches the latest dungeon state and shows a user-friendly retry notice instead of silently overwriting

## How the guard works

```
Tab A sends attack with seq=5  →  backend reads dungeonSpec.attackSeq=5  →  match, proceed, patches attackSeq=6
Tab B sends attack with seq=5  →  backend reads dungeonSpec.attackSeq=6  →  mismatch (5≠6), 409 returned
Tab B receives 409             →  re-fetches dungeon (sees seq=6)         →  shows "State changed — retry"
Tab B resends with seq=6       →  backend reads dungeonSpec.attackSeq=6  →  match, proceeds normally
```

## What the frontend does on 409

1. Catches the `ApiError` with `status === 409`
2. Re-fetches the latest `DungeonCR` via `getDungeon()` to sync state
3. Sets `detail` to the fresh CR so HP bars, inventory, and sequences are up to date
4. Displays `"State changed — dungeon refreshed. Please retry your action."` in the error banner
5. Clears all animation/modal state so the player can immediately retry