### PR TITLE
ci: fix kubectl set image container names

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -95,10 +95,10 @@ jobs:
       - run: aws eks update-kubeconfig --region us-west-2 --name krombat
       - run: |
           kubectl set image deployment/rpg-backend \
-            rpg-backend=$REGISTRY/krombat/backend:${{ github.sha }} \
+            backend=$REGISTRY/krombat/backend:${{ github.sha }} \
             -n rpg-system
           kubectl set image deployment/rpg-frontend \
-            rpg-frontend=$REGISTRY/krombat/frontend:${{ github.sha }} \
+            frontend=$REGISTRY/krombat/frontend:${{ github.sha }} \
             -n rpg-system
           kubectl rollout status deployment/rpg-backend -n rpg-system --timeout=120s
           kubectl rollout status deployment/rpg-frontend -n rpg-system --timeout=120s


### PR DESCRIPTION
## Summary
- `kubectl set image` was referencing container names `rpg-backend`/`rpg-frontend`
- Actual container names in the deployment specs are `backend`/`frontend` (see `manifests/system/backend.yaml` and `frontend.yaml`)
- This caused the `rollout` job to fail on every push to `main` for the last 5+ runs, meaning the cluster has been running stale images

Fixes the `Build & Push Images` workflow so rollouts succeed after merge.