### PR TITLE
feat: kro teaching layer — in-game interactive kro education

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,12 @@ import { useWebSocket, WSEvent } from './useWebSocket'
 
 import { Sprite, getMonsterSprite, SpriteAction, ItemSprite } from './Sprite'
 import { PixelIcon } from './PixelIcon'
+import {
+  InsightCard, KroConceptModal, KroGlossary,
+  useKroGlossary, getInsightForEvent, kroAnnotate,
+  KRO_STATUS_TIPS,
+  type InsightTrigger, type KroConceptId,
+} from './KroTeach'
 
 // 8-bit styled text icons (consistent cross-platform, matches pixel font)
 const ICO = {
@@ -55,6 +61,22 @@ export default function App() {
   const [lootDrop, setLootDrop] = useState<string | null>(null)
   const [attackTarget, setAttackTarget] = useState<string | null>(null)
   const [animPhase, setAnimPhase] = useState<'idle' | 'hero-attack' | 'enemy-attack' | 'item-use' | 'done'>('idle')
+
+  // kro teaching layer
+  const { unlocked, unlock } = useKroGlossary()
+  const [insightQueue, setInsightQueue] = useState<InsightTrigger[]>([])
+  const [kroConceptModal, setKroConceptModal] = useState<KroConceptId | null>(null)
+  const shownInsightsRef = useRef<Set<KroConceptId>>(new Set())
+
+  const triggerInsight = useCallback((event: string) => {
+    const trigger = getInsightForEvent(event)
+    if (!trigger) return
+    unlock(trigger.conceptId)
+    // Only show each concept card once per session
+    if (shownInsightsRef.current.has(trigger.conceptId)) return
+    shownInsightsRef.current.add(trigger.conceptId)
+    setInsightQueue(q => [...q, trigger])
+  }, [unlock])
 
   const { connected, lastEvent } = useWebSocket(selected?.ns, selected?.name)
   const selectedRef = useRef(selected)
@@ -108,7 +130,12 @@ export default function App() {
           if (cancelled) return
           try {
             const d = await getDungeon(selected.ns, selected.name)
-            if (!cancelled) { setDetail(d); setLoading(false) }
+            if (!cancelled) {
+              setDetail(d)
+              setLoading(false)
+              // Teach modifier concept if this dungeon has one
+              if (d.spec.modifier && d.spec.modifier !== 'none') triggerInsight('modifier-present')
+            }
             return
           } catch {
             await new Promise(r => setTimeout(r, 2000))
@@ -157,6 +184,9 @@ export default function App() {
       await createDungeon(name, monsters, difficulty, heroClass, 'default')
       addK8s(`kubectl apply -f dungeon.yaml`, 'dungeon.game.k8s.example created',
         `apiVersion: game.k8s.example/v1alpha1\nkind: Dungeon\nmetadata:\n  name: ${name}\nspec:\n  monsters: ${monsters}\n  difficulty: ${difficulty}\n  heroClass: ${heroClass}`)
+      triggerInsight('dungeon-created')
+      // forEach is always in play when creating a dungeon with multiple monsters
+      if (monsters > 1) triggerInsight('forEach')
       localStorage.setItem('lastDungeon', JSON.stringify({ ns: 'default', name }))
       navigate(`/dungeon/default/${name}`)
     } catch (e: any) { setError(e.message) }
@@ -198,6 +228,8 @@ export default function App() {
       const crField = isItem ? `action: ${target}` : `target: ${target}\n  damage: ${damage}`
       addK8s(`kubectl apply -f ${crKind.toLowerCase()}.yaml`, `${crKind.toLowerCase()}.game.k8s.example created`,
         `apiVersion: game.k8s.example/v1alpha1\nkind: ${crKind}\nmetadata:\n  name: ${selected.name}-${target}-${Date.now() % 100000}\nspec:\n  dungeonName: ${selected.name}\n  dungeonNamespace: ${selected.ns}\n  ${crField}`)
+      // Teach: Attack CR = empty RGD pattern; first combat attack = CEL basics
+      if (!isItem && !isAbility) triggerInsight('attack-cr')
 
       let updated = detail!
 
@@ -231,6 +263,9 @@ export default function App() {
         setAnimPhase('idle')
         setAttackTarget(null)
         attackingRef.current = false
+        // Teach specific item/room events
+        if (target === 'enter-room-2') triggerInsight('enter-room-2')
+        if (target === 'open-treasure') triggerInsight('treasure-opened')
         return // Items done — don't fall through to combat/loot logic
       } else {
         // Combat: backend is synchronous — attackSeq increments before API returns.
@@ -275,7 +310,10 @@ export default function App() {
       }
 
       // Loot drop — only check on combat actions (not items/equip)
-      if (!isItem && pollSucceeded && updated.spec.lastLootDrop) setLootDrop(updated.spec.lastLootDrop)
+      if (!isItem && pollSucceeded && updated.spec.lastLootDrop) {
+        setLootDrop(updated.spec.lastLootDrop)
+        triggerInsight('loot-drop')
+      }
       await new Promise(r => setTimeout(r, 100))
 
       // Read combat log from Dungeon CR — skip "already dead" non-events
@@ -316,9 +354,15 @@ export default function App() {
         const newBossHP = updated.spec.bossHP ?? 1
         const prevAllDead = (detail?.spec.monsterHP || []).every((hp: number) => hp <= 0)
         const nowAllDead = (updated.spec.monsterHP || []).every((hp: number) => hp <= 0)
-        if (nowAllDead && !prevAllDead) addEvent('🐉', 'Boss unlocked! All monsters slain!')
-        if (newBossHP <= 0 && prevBossHP > 0) addEvent('🏆', 'VICTORY! Boss defeated!')
+        if (nowAllDead && !prevAllDead) { addEvent('🐉', 'Boss unlocked! All monsters slain!'); triggerInsight('boss-ready') }
+        if (newBossHP <= 0 && prevBossHP > 0) { addEvent('🏆', 'VICTORY! Boss defeated!'); triggerInsight('boss-killed') }
         if ((updated.spec.heroHP ?? 100) <= 0 && (detail?.spec.heroHP ?? 100) > 0) addEvent('💀', 'Hero has fallen...')
+        // Detect monster kill
+        const prevDeadCount = (detail?.spec.monsterHP || []).filter((hp: number) => hp <= 0).length
+        const newDeadCount = (updated.spec.monsterHP || []).filter((hp: number) => hp <= 0).length
+        if (newDeadCount > prevDeadCount) triggerInsight('monster-killed')
+        // First attack
+        if ((detail?.spec.attackSeq ?? 0) === 0 && (updated.spec.attackSeq ?? 0) > 0) triggerInsight('first-attack')
       }
 
       // Don't clear attackPhase/attackTarget — user must dismiss combat modal
@@ -449,8 +493,24 @@ export default function App() {
           onToggleCheat={() => setShowCheat(c => !c)}
           wsConnected={connected}
           apiError={apiError}
+          kroUnlocked={unlocked}
+          onViewKroConcept={setKroConceptModal}
         />
       ) : null}
+
+      {/* kro Insight Cards — slide in from bottom-right */}
+      {insightQueue.length > 0 && (
+        <InsightCard
+          trigger={insightQueue[0]}
+          onDismiss={() => setInsightQueue(q => q.slice(1))}
+          onViewConcept={setKroConceptModal}
+        />
+      )}
+
+      {/* kro Concept Modal */}
+      {kroConceptModal && (
+        <KroConceptModal conceptId={kroConceptModal} onClose={() => setKroConceptModal(null)} />
+      )}
     </div>
   )
 }
@@ -590,23 +650,55 @@ function FlyingBat({ startX, startY, endX, endY, dur, onDone }: { startX: number
       style={{ left: `${pos.x}%`, top: `${pos.y}%`, transform: `translate(-50%,-50%) scaleX(${endX > startX ? 1 : -1})` }} />
   )
 }
-function EventLogTabs({ events, k8sLog }: { events: WSEvent[]; k8sLog: { ts: string; cmd: string; res: string; yaml?: string }[] }) {
-  const [tab, setTab] = useState<'game' | 'k8s'>('game')
-  const [yamlModal, setYamlModal] = useState<string | null>(null)
+function EventLogTabs({ events, k8sLog, kroUnlocked, onViewKroConcept }: {
+  events: WSEvent[]
+  k8sLog: { ts: string; cmd: string; res: string; yaml?: string }[]
+  kroUnlocked: Set<KroConceptId>
+  onViewKroConcept: (id: KroConceptId) => void
+}) {
+  const [tab, setTab] = useState<'game' | 'k8s' | 'kro'>('game')
+  const [yamlModal, setYamlModal] = useState<{ yaml: string; cmd: string } | null>(null)
+  const [kroConceptModal, setKroConceptModal] = useState<KroConceptId | null>(null)
   return (
     <div style={{ marginTop: 16 }}>
       <div className="log-tabs">
         <button className={`log-tab${tab === 'game' ? ' active' : ''}`} onClick={() => setTab('game')}>Game Log</button>
         <button className={`log-tab${tab === 'k8s' ? ' active' : ''}`} onClick={() => setTab('k8s')}>K8s Log</button>
+        <button className={`log-tab kro-tab${tab === 'kro' ? ' active' : ''}`} onClick={() => setTab('kro')}>
+          kro ({kroUnlocked.size}/13)
+        </button>
       </div>
+
+      {/* YAML + kro annotation modal */}
       {yamlModal && (
         <div className="modal-overlay" onClick={() => setYamlModal(null)}>
-          <div className="modal" role="dialog" aria-modal="true" aria-label="YAML viewer" onClick={e => e.stopPropagation()} style={{ maxWidth: 500, textAlign: 'left' }}>
-            <pre className="yaml-view">{yamlModal}</pre>
+          <div className="modal" role="dialog" aria-modal="true" aria-label="YAML viewer" onClick={e => e.stopPropagation()} style={{ maxWidth: 520, textAlign: 'left' }}>
+            <pre className="yaml-view">{yamlModal.yaml}</pre>
+            {(() => {
+              const ann = kroAnnotate(yamlModal.cmd, yamlModal.yaml)
+              if (!ann) return null
+              return (
+                <div className="k8s-annotation">
+                  <div className="k8s-annotation-label">kro — what happened</div>
+                  <div className="k8s-annotation-what">{ann.what}</div>
+                  <div className="k8s-annotation-rgd">RGD: {ann.rgd}</div>
+                  {ann.cel && <pre className="k8s-annotation-cel">{ann.cel}</pre>}
+                  <button className="k8s-annotation-learn" onClick={() => { setYamlModal(null); onViewKroConcept(ann.concept) }}>
+                    Learn: {ann.concept} →
+                  </button>
+                </div>
+              )
+            })()}
             <button className="btn btn-gold" style={{ marginTop: 8 }} onClick={() => setYamlModal(null)}>Close</button>
           </div>
         </div>
       )}
+
+      {/* kro concept modal opened from glossary */}
+      {kroConceptModal && (
+        <KroConceptModal conceptId={kroConceptModal} onClose={() => setKroConceptModal(null)} />
+      )}
+
       {tab === 'game' ? (
         <div className="event-log" aria-live="polite" aria-atomic="false" aria-label="Game event log">
           {events.length === 0 && <div className="event-entry">Waiting for events...</div>}
@@ -617,17 +709,19 @@ function EventLogTabs({ events, k8sLog }: { events: WSEvent[]; k8sLog: { ts: str
             </div>
           ))}
         </div>
-      ) : (
+      ) : tab === 'k8s' ? (
         <div className="event-log k8s-log">
           {k8sLog.length === 0 && <div className="event-entry">No K8s operations yet...</div>}
           {k8sLog.map((e, i) => (
-            <div key={i} className={`k8s-entry${e.yaml ? ' clickable' : ''}`} onClick={() => e.yaml && setYamlModal(e.yaml)}>
+            <div key={i} className={`k8s-entry${e.yaml ? ' clickable' : ''}`} onClick={() => e.yaml && setYamlModal({ yaml: e.yaml, cmd: e.cmd })}>
               <span className="k8s-ts">{e.ts}</span>
               <span className="k8s-cmd">$ {e.cmd}</span>
               <span className="k8s-res">{e.res}</span>
             </div>
           ))}
         </div>
+      ) : (
+        <KroGlossary unlocked={kroUnlocked} onViewConcept={id => setKroConceptModal(id)} />
       )}
     </div>
   )
@@ -822,7 +916,7 @@ function HelpModal({ onClose, onCheat }: { onClose: () => void; onCheat: () => v
     </div>
   )
 }
-function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, showCheat, onToggleCheat, floatingDmg, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError }: {
+function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, showCheat, onToggleCheat, floatingDmg, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError, kroUnlocked, onViewKroConcept }: {
   cr: DungeonCR; onBack: () => void; onAttack: (t: string, d: number) => void; events: WSEvent[]; k8sLog: { ts: string; cmd: string; res: string; yaml?: string }[]
   showLoot: boolean; onOpenLoot: () => void; onCloseLoot: () => void
   attackPhase: string | null; roomLoading: boolean
@@ -835,6 +929,8 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
   lootDrop: string | null; onDismissLoot: () => void
   wsConnected: boolean
   apiError: string | null
+  kroUnlocked: Set<KroConceptId>
+  onViewKroConcept: (id: KroConceptId) => void
 }) {
   if (!cr?.metadata?.name) return <div className="loading">Loading dungeon</div>
   const spec = cr.spec || { monsters: 0, difficulty: 'normal', monsterHP: [], bossHP: 0, heroHP: 100 }
@@ -1012,11 +1108,21 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
       )}
 
       <div className="status-bar">
-        <div><span className="label">Monsters alive:</span><span className="value">{status?.livingMonsters ?? '?'}</span></div>
-        <div><span className="label">Boss:</span><span className="value">{bossState}</span></div>
-        <div><span className="label">Difficulty:</span><span className="value">{spec.difficulty}</span></div>
-        <div><span className="label">Room:</span><span className="value">{spec.currentRoom || 1}</span></div>
-        <div><span className="label">Turn:</span><span className="value">{(spec.attackSeq ?? 0) + 1}</span></div>
+        <Tooltip text={KRO_STATUS_TIPS.livingMonsters}>
+          <div><span className="label">Monsters alive:</span><span className="value">{status?.livingMonsters ?? '?'}</span></div>
+        </Tooltip>
+        <Tooltip text={KRO_STATUS_TIPS.bossState}>
+          <div><span className="label">Boss:</span><span className="value">{bossState}</span></div>
+        </Tooltip>
+        <Tooltip text={KRO_STATUS_TIPS.difficulty}>
+          <div><span className="label">Difficulty:</span><span className="value">{spec.difficulty}</span></div>
+        </Tooltip>
+        <Tooltip text={KRO_STATUS_TIPS.room}>
+          <div><span className="label">Room:</span><span className="value">{spec.currentRoom || 1}</span></div>
+        </Tooltip>
+        <Tooltip text={KRO_STATUS_TIPS.turn}>
+          <div><span className="label">Turn:</span><span className="value">{(spec.attackSeq ?? 0) + 1}</span></div>
+        </Tooltip>
       </div>
 
       <div className="game-layout">
@@ -1327,7 +1433,7 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
         </div>
       </div>
 
-      <EventLogTabs events={events} k8sLog={k8sLog} />
+      <EventLogTabs events={events} k8sLog={k8sLog} kroUnlocked={kroUnlocked} onViewKroConcept={onViewKroConcept} />
     </div>
   )
 }

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -1,0 +1,613 @@
+/**
+ * KroTeach — in-game kro teaching layer
+ *
+ * Components:
+ *  - InsightCard      : slide-in contextual card triggered by game events
+ *  - KroGlossary      : progressive concept glossary (fills in as player triggers concepts)
+ *  - kroAnnotate()    : returns kro commentary + CEL snippets for a K8s log entry
+ *  - KRO_STATUS_TIPS  : per-field tooltip copy for the status bar
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type KroConceptId =
+  | 'rgd'
+  | 'spec-schema'
+  | 'resource-chaining'
+  | 'cel-basics'
+  | 'cel-ternary'
+  | 'forEach'
+  | 'includeWhen'
+  | 'readyWhen'
+  | 'status-aggregation'
+  | 'seeded-random'
+  | 'secret-output'
+  | 'empty-rgd'
+  | 'spec-mutation'
+
+export interface KroConcept {
+  id: KroConceptId
+  title: string
+  tagline: string
+  body: string
+  snippet: string   // YAML/CEL snippet to show
+  learnMore: string // short description of where to look in the repo
+}
+
+export interface InsightTrigger {
+  conceptId: KroConceptId
+  headline: string   // one-line "what just happened" in game terms
+}
+
+// ─── Concept Definitions ─────────────────────────────────────────────────────
+
+export const KRO_CONCEPTS: Record<KroConceptId, KroConcept> = {
+  'rgd': {
+    id: 'rgd',
+    title: 'ResourceGraphDefinition (RGD)',
+    tagline: 'One CR. Seven resources. Zero imperative code.',
+    body: `A ResourceGraphDefinition is a kro custom resource that describes a graph of Kubernetes resources.
+When you applied the Dungeon CR, kro read the dungeon-graph RGD and automatically created a Namespace, Hero CR, Monster CRs, Boss CR, Treasure CR, Modifier CR, and two ConfigMaps — all from a single \`kubectl apply\`.`,
+    snippet: `# manifests/rgds/dungeon-graph.yaml
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: dungeon-graph
+spec:
+  schema:
+    apiVersion: game.k8s.example/v1alpha1
+    kind: Dungeon
+    spec:
+      monsters: integer | default=3 minimum=1 maximum=10
+      difficulty: string | default="normal" enum=easy,normal,hard
+      heroClass: string | default="warrior"
+      # ... 30+ more typed fields
+  resources:
+    - id: namespace
+      template: # Namespace resource ...
+    - id: heroCR
+      template: # Hero CR resource ...
+    - id: monsterCRs  # forEach fan-out!
+      forEach: lists.range(size(schema.spec.monsterHP))
+      template: # ...`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml',
+  },
+
+  'spec-schema': {
+    id: 'spec-schema',
+    title: 'Typed spec.schema with defaults & enums',
+    tagline: 'kro validates and defaults your CR fields at admission time.',
+    body: `kro's RGD \`spec.schema\` block is an OpenAPI-compatible schema. Fields can have types, defaults, enums, and validation constraints.
+When you chose "hard" difficulty, kro validated that value against the enum \`[easy, normal, hard]\` before the CR was stored. Defaults mean you never need to specify every field.`,
+    snippet: `# Inside dungeon-graph RGD — spec.schema block
+spec:
+  schema:
+    spec:
+      difficulty:
+        type: string
+        default: "normal"
+        enum: [easy, normal, hard]
+      monsters:
+        type: integer
+        default: 3
+        minimum: 1
+        maximum: 10
+      heroClass:
+        type: string
+        default: "warrior"
+        enum: [warrior, mage, rogue]`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — spec.schema section',
+  },
+
+  'resource-chaining': {
+    id: 'resource-chaining',
+    title: 'Resource Chaining',
+    tagline: 'Child CR status flows back to parent status automatically.',
+    body: `dungeon-graph creates a Hero CR. The Hero CR is handled by hero-graph, which creates a heroState ConfigMap. dungeon-graph's status block reads from that ConfigMap (via \`${'{'}heroCR.status.maxHP{'}'}\`) and exposes it as the dungeon's own status.
+This is resource chaining: each RGD handles one layer, and kro wires the outputs together.`,
+    snippet: `# dungeon-graph status — reading from child CRs
+status:
+  maxHeroHP: \${heroCR.status.maxHP}
+  livingMonsters: >-
+    \${size(monsterCRs.filter(m,
+      m.status.?entityState.orValue('alive') == 'alive'))}
+  bossState: \${bossCR.status.entityState}
+  treasureState: \${treasureCR.status.treasureState}`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — status block',
+  },
+
+  'cel-basics': {
+    id: 'cel-basics',
+    title: 'CEL — Common Expression Language',
+    tagline: 'All game logic is pure CEL inside YAML. No controllers.',
+    body: `CEL (Common Expression Language) is the expression engine kro uses inside \${...} blocks. Every dice roll, HP transition, and state change in this game is a CEL expression evaluated at reconcile time — no custom controllers, no Go code for game logic.
+The damage you just dealt was computed by a CEL expression in the combatResult ConfigMap.`,
+    snippet: `# dungeon-graph — combatResult ConfigMap (damage computation)
+# CEL evaluates on every reconcile triggered by an Attack CR
+data:
+  diceRoll: >-
+    \${string(int(random.seededString(schema.spec.lastCombatLog,
+      'abcdefghijklmnopqrstuvwxyz0123456789', 8), 36) % 20 + 1)}
+  heroBaseDmg: >-
+    \${schema.spec.difficulty == 'easy'
+      ? string(int(diceRoll) + 2)
+      : schema.spec.difficulty == 'hard'
+        ? string(int(diceRoll) * 3 + 5)
+        : string(int(diceRoll) * 2 + 4)}`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — combatResult ConfigMap',
+  },
+
+  'cel-ternary': {
+    id: 'cel-ternary',
+    title: 'CEL Ternary Chains — State Machines in YAML',
+    tagline: 'Multi-state machines expressed as nested ternaries.',
+    body: `CEL does not have if/else blocks, but nested ternary expressions (\`condition ? a : b\`) create powerful state machines.
+The boss transitions between three states — pending, ready, and defeated — using a single two-level ternary. No controller code, no webhook: pure CEL evaluated by kro on every reconcile.`,
+    snippet: `# boss-graph — entityState CEL ternary
+# Reads monstersAlive (computed by dungeon-graph, forwarded as spec field)
+data:
+  entityState: >-
+    \${schema.spec.hp > 0
+      ? (schema.spec.monstersAlive == 0 ? 'ready' : 'pending')
+      : 'defeated'}
+
+# hero-graph — entityState (simpler, 2-state)
+data:
+  entityState: "\${schema.spec.hp > 0 ? 'alive' : 'defeated'}"`,
+    learnMore: 'manifests/rgds/boss-graph.yaml and hero-graph.yaml',
+  },
+
+  'forEach': {
+    id: 'forEach',
+    title: 'forEach — Dynamic Resource Fan-out',
+    tagline: 'One spec field → N child resources, computed at reconcile time.',
+    body: `The \`forEach\` directive in an RGD resource block creates one resource per item in a list.
+When you created this dungeon with 3 monsters, kro evaluated \`lists.range(size(schema.spec.monsterHP))\` to get [0, 1, 2] and created three Monster CRs automatically. Change \`monsters: 5\` and kro would create five.`,
+    snippet: `# dungeon-graph — forEach creates one Monster CR per monsterHP entry
+resources:
+  - id: monsterCRs
+    forEach: lists.range(size(schema.spec.monsterHP))
+    template:
+      apiVersion: game.k8s.example/v1alpha1
+      kind: Monster
+      metadata:
+        name: \${schema.metadata.name + '-monster-' + string(item)}
+        namespace: \${schema.metadata.namespace}
+      spec:
+        hp: \${schema.spec.monsterHP[item]}
+        dungeonName: \${schema.metadata.name}`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — monsterCRs resource block',
+  },
+
+  'includeWhen': {
+    id: 'includeWhen',
+    title: 'includeWhen — Conditional Resources',
+    tagline: 'Resources that only exist when a condition is true.',
+    body: `\`includeWhen\` is a CEL expression on a resource block. When it evaluates to \`false\`, kro does not create (or deletes) that resource. When it flips to \`true\`, kro creates it.
+This is how loot works: the Loot CR only appears when a monster's HP reaches 0. The moment you killed that monster, kro evaluated \`schema.spec.hp == 0\` and created the Loot CR, which trigger loot-graph to generate the item.`,
+    snippet: `# monster-graph — lootCR only created on kill
+resources:
+  - id: lootCR
+    includeWhen:
+      - "\${schema.spec.hp == 0}"
+    template:
+      apiVersion: game.k8s.example/v1alpha1
+      kind: Loot
+      metadata:
+        name: \${schema.metadata.name + '-loot'}
+      spec:
+        # ... item type/rarity via random.seededString()
+
+# treasure-graph — Secret only exists when treasure is opened
+  - id: treasureSecret
+    includeWhen:
+      - "\${schema.spec.opened == 1}"
+    template:
+      kind: Secret`,
+    learnMore: 'manifests/rgds/monster-graph.yaml and treasure-graph.yaml',
+  },
+
+  'readyWhen': {
+    id: 'readyWhen',
+    title: 'readyWhen — Resource Readiness Gates',
+    tagline: 'kro waits for dependencies before proceeding.',
+    body: `\`readyWhen\` is a condition on a resource or on a reference to a child CR. kro will not consider the parent resource ready until all \`readyWhen\` conditions on its children resolve to true.
+The dungeon modifier works this way: dungeon-graph has a \`readyWhen\` on the modifierCR that waits until modifier-graph has finished computing the modifier type. This prevents the dungeon from reporting a wrong state before the modifier is ready.`,
+    snippet: `# dungeon-graph — readyWhen gates on modifierCR
+resources:
+  - id: modifierCR
+    includeWhen:
+      - "\${schema.spec.modifier != 'none'}"
+    readyWhen:
+      - "\${self.status.?modifierType.orValue('') != ''}"
+    template:
+      # ... Modifier CR
+
+# modifier-graph — resource declares itself ready
+resources:
+  - id: modifierState
+    readyWhen:
+      - "self.data.modifierType != ''"
+    template:
+      kind: ConfigMap`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml and modifier-graph.yaml',
+  },
+
+  'status-aggregation': {
+    id: 'status-aggregation',
+    title: 'Status Aggregation Across a Resource Graph',
+    tagline: 'Parent status = .filter() across all child CR statuses.',
+    body: `dungeon-graph's \`livingMonsters\` status field uses CEL's \`.filter()\` on the entire \`monsterCRs\` array (which was created by forEach). It counts how many Monster CRs have \`entityState == 'alive'\`.
+This is pure declarative aggregation: no controller loop, no explicit watch — kro re-evaluates this CEL on every reconcile.`,
+    snippet: `# dungeon-graph status — aggregate across all Monster CRs
+status:
+  livingMonsters: >-
+    \${size(monsterCRs.filter(m,
+      m.status.?entityState.orValue('alive') == 'alive'))}
+  # Safe navigation (?.) guards against not-yet-ready child CRs
+  # orValue('alive') defaults to 'alive' while Monster CR initializes`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — status.livingMonsters',
+  },
+
+  'seeded-random': {
+    id: 'seeded-random',
+    title: 'random.seededString() — Deterministic Randomness',
+    tagline: 'kro extends CEL with seeded random for reproducible results.',
+    body: `kro ships a CEL extension function \`random.seededString(seed, alphabet, length)\` that generates a deterministic pseudo-random string from a seed.
+Dice rolls in this game use the lastCombatLog field as a seed — so the same attack submitted twice with the same combat log produces the same "random" number. This makes the game reproducible and auditable from the CR spec alone.`,
+    snippet: `# dungeon-graph — dice roll via random.seededString
+data:
+  diceRoll: >-
+    \${string(
+      int(random.seededString(
+        schema.spec.lastCombatLog,   # seed (changes every attack)
+        'abcdefghijklmnopqrstuvwxyz0123456789',
+        8                            # length of random string
+      ), 36) % 20 + 1               # base-36 → mod → dice value
+    )}`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — combatResult ConfigMap',
+  },
+
+  'secret-output': {
+    id: 'secret-output',
+    title: 'Kubernetes Secret as a Computed RGD Output',
+    tagline: 'RGDs can produce any resource type — including Secrets.',
+    body: `kro RGDs are not limited to ConfigMaps. The loot-graph RGD creates a Kubernetes Secret to store item data — the item type, rarity, and description are all computed by CEL and stored in Secret.stringData.
+Similarly, treasure-graph creates a Secret (conditionally, via includeWhen) that holds the dungeon key. This demonstrates that kro can manage any Kubernetes resource, not just CRDs.`,
+    snippet: `# loot-graph — Kubernetes Secret as output
+resources:
+  - id: lootSecret
+    template:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: \${schema.metadata.name}
+        labels:
+          game.k8s.example/item-type: \${schema.spec.itemType}
+          game.k8s.example/rarity: \${schema.spec.rarity}
+      stringData:
+        description: >-
+          \${schema.spec.itemType == 'weapon'
+            ? 'A ' + schema.spec.rarity + ' weapon (+' + string(schema.spec.statValue) + ' damage)'
+            : schema.spec.itemType == 'armor'
+              ? 'A ' + schema.spec.rarity + ' armor (+' + string(schema.spec.statValue) + '% defense)'
+              : '...'}`,
+    learnMore: 'manifests/rgds/loot-graph.yaml and treasure-graph.yaml',
+  },
+
+  'empty-rgd': {
+    id: 'empty-rgd',
+    title: 'Empty RGD — CRD Factory Pattern',
+    tagline: 'An RGD with resources:[] creates a CRD with no managed children.',
+    body: `attack-graph and action-graph have \`resources: []\` — they manage no child resources at all. Their sole purpose is to define the Attack and Action custom resource types (CRDs).
+This is the "CRD factory" pattern: use kro to get a typed, validated CRD for free, without writing a controller. The actual logic lives in dungeon-graph's ConfigMaps (CEL expressions) and in the Go backend.`,
+    snippet: `# attack-graph — empty RGD, defines Attack CRD only
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: attack-graph
+spec:
+  schema:
+    apiVersion: game.k8s.example/v1alpha1
+    kind: Attack
+    spec:
+      dungeonName: string | required=true
+      target: string | required=true
+      damage: integer | default=0
+  resources: []   # <-- no managed children
+  status:
+    state: "ready"  # static literal, not a CEL expression`,
+    learnMore: 'manifests/rgds/attack-graph.yaml and action-graph.yaml',
+  },
+
+  'spec-mutation': {
+    id: 'spec-mutation',
+    title: 'Spec Mutation Triggers Full Reconcile',
+    tagline: 'One patch to spec → kro reconciles the entire resource graph.',
+    body: `When you enter Room 2, the backend patches a single field — \`currentRoom: 2\` — on the Dungeon CR spec. kro watches the Dungeon CR and immediately re-evaluates all CEL expressions in dungeon-graph.
+This causes new Monster CRs (room2MonsterHP), a new Boss CR (room2BossHP), and updated ConfigMaps to be created or updated — all from a single spec field change. Kubernetes becomes the state machine.`,
+    snippet: `# Backend Go code — one PATCH drives the whole transition
+patch := map[string]interface{}{
+  "spec": map[string]interface{}{
+    "currentRoom":    2,
+    "monsterHP":      room2MonsterHP,
+    "bossHP":         room2BossHP,
+    "attackSeq":      newSeq,
+    // kro re-evaluates ALL dungeon-graph CEL with these new values
+  },
+}
+// manifests/rgds/dungeon-graph.yaml reacts automatically`,
+    learnMore: 'backend/internal/handlers/handlers.go and dungeon-graph.yaml',
+  },
+}
+
+// ─── Insight trigger mapping ──────────────────────────────────────────────────
+
+/** Map game events to insight triggers */
+export function getInsightForEvent(event: string): InsightTrigger | null {
+  if (event === 'dungeon-created') return { conceptId: 'rgd', headline: 'kro created 7 resources from your one Dungeon CR' }
+  if (event === 'first-attack') return { conceptId: 'cel-basics', headline: 'Your damage was computed by a CEL expression in a ConfigMap' }
+  if (event === 'monster-killed') return { conceptId: 'includeWhen', headline: 'A Loot CR appeared because monster HP hit 0 (includeWhen)' }
+  if (event === 'boss-ready') return { conceptId: 'cel-ternary', headline: 'Boss transitioned pending → ready via a CEL ternary in boss-graph' }
+  if (event === 'boss-killed') return { conceptId: 'status-aggregation', headline: 'Victory state aggregated from Hero + Boss + Monster CR statuses' }
+  if (event === 'treasure-opened') return { conceptId: 'secret-output', headline: 'Opening treasure created a Kubernetes Secret via treasure-graph' }
+  if (event === 'enter-room-2') return { conceptId: 'spec-mutation', headline: 'One spec patch triggered a full kro reconcile of the resource graph' }
+  if (event === 'modifier-present') return { conceptId: 'readyWhen', headline: 'dungeon-graph waited for modifier-graph via readyWhen before proceeding' }
+  if (event === 'forEach') return { conceptId: 'forEach', headline: 'kro created one Monster CR per entry in monsterHP[] via forEach' }
+  if (event === 'loot-drop') return { conceptId: 'seeded-random', headline: 'Loot type and rarity rolled via random.seededString() in monster-graph' }
+  if (event === 'attack-cr') return { conceptId: 'empty-rgd', headline: 'Attack CR is defined by an RGD with resources:[] — a CRD factory' }
+  return null
+}
+
+// ─── InsightCard Component ────────────────────────────────────────────────────
+
+interface InsightCardProps {
+  trigger: InsightTrigger
+  onDismiss: () => void
+  onViewConcept: (id: KroConceptId) => void
+}
+
+export function InsightCard({ trigger, onDismiss, onViewConcept }: InsightCardProps) {
+  const concept = KRO_CONCEPTS[trigger.conceptId]
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    // slide in
+    const t1 = setTimeout(() => setVisible(true), 50)
+    // auto-dismiss after 12s
+    const t2 = setTimeout(() => { setVisible(false); setTimeout(onDismiss, 350) }, 12000)
+    return () => { clearTimeout(t1); clearTimeout(t2) }
+  }, [trigger.conceptId])
+
+  const handleDismiss = () => {
+    setVisible(false)
+    setTimeout(onDismiss, 350)
+  }
+
+  return (
+    <div className={`kro-insight-card${visible ? ' visible' : ''}`} role="complementary" aria-label="kro insight">
+      <div className="kro-insight-header">
+        <span className="kro-insight-badge">kro</span>
+        <span className="kro-insight-headline">{trigger.headline}</span>
+        <button className="kro-insight-dismiss" onClick={handleDismiss} aria-label="Dismiss insight">✕</button>
+      </div>
+      <div className="kro-insight-title">{concept.title}</div>
+      <div className="kro-insight-tagline">{concept.tagline}</div>
+      <button className="kro-insight-learn" onClick={() => { onViewConcept(trigger.conceptId); handleDismiss() }}>
+        Learn more →
+      </button>
+    </div>
+  )
+}
+
+// ─── KroConceptModal ─────────────────────────────────────────────────────────
+
+interface KroConceptModalProps {
+  conceptId: KroConceptId
+  onClose: () => void
+}
+
+export function KroConceptModal({ conceptId, onClose }: KroConceptModalProps) {
+  const concept = KRO_CONCEPTS[conceptId]
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal kro-concept-modal" role="dialog" aria-modal="true" aria-label={`kro concept: ${concept.title}`}
+        onClick={e => e.stopPropagation()} style={{ maxWidth: 560, textAlign: 'left' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8 }}>
+          <div>
+            <span className="kro-insight-badge" style={{ fontSize: 8, marginBottom: 4, display: 'inline-block' }}>kro concept</span>
+            <h2 style={{ color: 'var(--gold)', fontSize: 12, margin: 0 }}>{concept.title}</h2>
+          </div>
+          <button className="modal-close" onClick={onClose} aria-label="Close concept">✕</button>
+        </div>
+        <p style={{ fontSize: 8, color: '#ccc', marginBottom: 12, lineHeight: 1.6 }}>{concept.body}</p>
+        <div className="kro-snippet-block">
+          <div className="kro-snippet-label">YAML / CEL</div>
+          <pre className="yaml-view kro-snippet-pre">{concept.snippet}</pre>
+        </div>
+        <div style={{ fontSize: 7, color: '#666', marginTop: 8 }}>
+          See: <span style={{ color: '#5dade2' }}>{concept.learnMore}</span>
+        </div>
+        <button className="btn btn-gold" style={{ marginTop: 12 }} onClick={onClose}>Got it</button>
+      </div>
+    </div>
+  )
+}
+
+// ─── KroGlossary Component ────────────────────────────────────────────────────
+
+const STORAGE_KEY = 'kroUnlockedConcepts'
+
+export function useKroGlossary() {
+  const [unlocked, setUnlocked] = useState<Set<KroConceptId>>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) return new Set(JSON.parse(stored) as KroConceptId[])
+    } catch { /* ignore */ }
+    return new Set()
+  })
+
+  const unlock = useCallback((id: KroConceptId) => {
+    setUnlocked(prev => {
+      if (prev.has(id)) return prev
+      const next = new Set(prev)
+      next.add(id)
+      try { localStorage.setItem(STORAGE_KEY, JSON.stringify([...next])) } catch { /* ignore */ }
+      return next
+    })
+  }, [])
+
+  return { unlocked, unlock }
+}
+
+const CONCEPT_ORDER: KroConceptId[] = [
+  'rgd', 'spec-schema', 'resource-chaining', 'cel-basics', 'cel-ternary',
+  'forEach', 'includeWhen', 'readyWhen', 'status-aggregation',
+  'seeded-random', 'secret-output', 'empty-rgd', 'spec-mutation',
+]
+
+interface KroGlossaryProps {
+  unlocked: Set<KroConceptId>
+  onViewConcept: (id: KroConceptId) => void
+}
+
+export function KroGlossary({ unlocked, onViewConcept }: KroGlossaryProps) {
+  const total = CONCEPT_ORDER.length
+  const count = unlocked.size
+
+  return (
+    <div className="kro-glossary">
+      <div className="kro-glossary-header">
+        <span className="kro-insight-badge">kro</span>
+        <span style={{ fontSize: 8, color: '#ccc', marginLeft: 6 }}>Concepts discovered:</span>
+        <span style={{ fontSize: 8, color: 'var(--gold)', marginLeft: 4 }}>{count} / {total}</span>
+        {count === total && <span style={{ fontSize: 7, color: '#2ecc71', marginLeft: 6 }}>kro expert!</span>}
+      </div>
+      <div className="kro-glossary-grid">
+        {CONCEPT_ORDER.map(id => {
+          const c = KRO_CONCEPTS[id]
+          const isUnlocked = unlocked.has(id)
+          return (
+            <button
+              key={id}
+              className={`kro-glossary-item${isUnlocked ? ' unlocked' : ' locked'}`}
+              onClick={() => isUnlocked && onViewConcept(id)}
+              disabled={!isUnlocked}
+              title={isUnlocked ? c.title : 'Keep playing to unlock'}
+              aria-label={isUnlocked ? `kro concept: ${c.title}` : 'Locked concept'}
+            >
+              <div className="kro-glossary-item-title">{isUnlocked ? c.title : '???'}</div>
+              {isUnlocked && <div className="kro-glossary-item-tagline">{c.tagline}</div>}
+              {!isUnlocked && <div className="kro-glossary-item-tagline" style={{ color: '#444' }}>Keep playing to unlock</div>}
+            </button>
+          )
+        })}
+      </div>
+      {count === 0 && (
+        <div style={{ fontSize: 7, color: '#555', textAlign: 'center', padding: '16px 0' }}>
+          Start playing to discover kro concepts in action.
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── K8s Log Annotations ─────────────────────────────────────────────────────
+
+export interface KroAnnotation {
+  what: string     // what happened in kro terms
+  rgd: string      // which RGD handles this
+  cel?: string     // relevant CEL expression snippet
+  concept: KroConceptId
+}
+
+/** Given a K8s log command + yaml string, return a kro annotation */
+export function kroAnnotate(cmd: string, yaml: string): KroAnnotation | null {
+  if (cmd.includes('kubectl apply') && yaml.includes('kind: Dungeon')) {
+    return {
+      what: 'kro reads dungeon-graph RGD and creates: Namespace, Hero CR, Monster CRs (forEach), Boss CR, Treasure CR, Modifier CR, combatResult ConfigMap, actionResult ConfigMap.',
+      rgd: 'dungeon-graph',
+      cel: `forEach: lists.range(size(schema.spec.monsterHP))
+# Creates one Monster CR per monsterHP entry`,
+      concept: 'rgd',
+    }
+  }
+  if (cmd.includes('kubectl apply') && yaml.includes('kind: Attack')) {
+    return {
+      what: 'kro sees the Attack CR (via attack-graph empty RGD). dungeon-graph reconciles, re-evaluating the combatResult ConfigMap CEL to compute new HP values.',
+      rgd: 'attack-graph (empty RGD) + dungeon-graph (combatResult)',
+      cel: `# dungeon-graph combatResult ConfigMap
+diceRoll: "\${string(int(random.seededString(
+  schema.spec.lastCombatLog, 'abc...', 8), 36) % 20 + 1)}"
+heroBaseDmg: "\${difficulty == 'hard' ? roll*3+5 : roll*2+4}"`,
+      concept: 'cel-basics',
+    }
+  }
+  if (cmd.includes('kubectl apply') && yaml.includes('kind: Action') && yaml.includes('equip')) {
+    return {
+      what: 'kro sees the Action CR (action-graph empty RGD). dungeon-graph reconciles, re-evaluating the actionResult ConfigMap to compute new weaponBonus/armorBonus/etc.',
+      rgd: 'action-graph (empty RGD) + dungeon-graph (actionResult)',
+      cel: `# dungeon-graph actionResult ConfigMap
+weaponBonus: "\${action == 'equip-weapon-rare' ? '10'
+  : action == 'equip-weapon-epic' ? '20' : '5'}"`,
+      concept: 'empty-rgd',
+    }
+  }
+  if (cmd.includes('kubectl apply') && yaml.includes('kind: Action') && yaml.includes('use-')) {
+    return {
+      what: 'Item use is also an Action CR. The actionResult ConfigMap CEL computes the new heroHP after applying the potion.',
+      rgd: 'action-graph (empty RGD) + dungeon-graph (actionResult)',
+      cel: `# actionResult — HP potion CEL
+newHeroHP: "\${action == 'use-hppotion-epic'
+  ? string(maxHeroHP)
+  : string(min(heroHP + healAmt, maxHeroHP))}"`,
+      concept: 'empty-rgd',
+    }
+  }
+  if (cmd.includes('kubectl get dungeon')) {
+    return {
+      what: 'After reconcile, dungeon-graph has re-aggregated all child CR statuses into this Dungeon CR status. livingMonsters is a .filter() over all Monster CR statuses.',
+      rgd: 'dungeon-graph (status aggregation)',
+      cel: `status:
+  livingMonsters: "\${size(monsterCRs.filter(m,
+    m.status.?entityState.orValue('alive') == 'alive'))}"
+  bossState: "\${bossCR.status.entityState}"`,
+      concept: 'status-aggregation',
+    }
+  }
+  return null
+}
+
+// ─── Status Bar kro Tooltips ─────────────────────────────────────────────────
+
+export const KRO_STATUS_TIPS = {
+  livingMonsters: `kro field: status.livingMonsters
+Computed by dungeon-graph via:
+  size(monsterCRs.filter(m,
+    m.status.?entityState.orValue('alive') == 'alive'))
+Each monster-graph RGD updates its entityState ConfigMap when HP changes.`,
+
+  bossState: `kro field: status.bossState → bossCR.status.entityState
+boss-graph CEL ternary:
+  hp > 0
+    ? (monstersAlive == 0 ? 'ready' : 'pending')
+    : 'defeated'
+Three states, zero controller code.`,
+
+  difficulty: `kro field: spec.difficulty
+Validated by dungeon-graph spec.schema:
+  difficulty: string | default="normal" enum=easy,normal,hard
+kro rejects invalid values at admission time.`,
+
+  room: `kro field: spec.currentRoom
+Patched by the backend when you enter Room 2.
+One spec patch triggers full dungeon-graph reconciliation:
+  new Monster CRs, new Boss CR, updated ConfigMaps.`,
+
+  turn: `kro field: spec.attackSeq
+Monotonically incrementing counter.
+The backend uses this for optimistic concurrency control:
+  reject attack if attackSeq in request != current attackSeq.`,
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -890,3 +890,247 @@ body {
   .k8s-cmd { font-size: 6px; }
   .k8s-res { font-size: 6px; }
 }
+
+/* ─── kro Teaching Layer ──────────────────────────────────────────────────── */
+
+/* Badge */
+.kro-insight-badge {
+  display: inline-block;
+  background: #0f3460;
+  color: #00d4ff;
+  border: 1px solid #00d4ff;
+  border-radius: 2px;
+  font-size: 7px;
+  padding: 1px 5px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+/* Insight Card — slides in from the bottom-right */
+.kro-insight-card {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 280px;
+  background: #0d1b2e;
+  border: 2px solid #00d4ff;
+  border-radius: 4px;
+  padding: 12px;
+  z-index: 500;
+  box-shadow: 0 4px 24px rgba(0,212,255,0.15);
+  transform: translateY(120%);
+  opacity: 0;
+  transition: transform 0.35s cubic-bezier(0.22,1,0.36,1), opacity 0.3s;
+}
+.kro-insight-card.visible {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.kro-insight-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.kro-insight-headline {
+  font-size: 7px;
+  color: #ccc;
+  flex: 1;
+  line-height: 1.5;
+}
+.kro-insight-dismiss {
+  background: none;
+  border: none;
+  color: #555;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 9px;
+  padding: 0;
+  flex-shrink: 0;
+  line-height: 1;
+}
+.kro-insight-dismiss:hover { color: #aaa; }
+
+.kro-insight-title {
+  font-size: 8px;
+  color: #00d4ff;
+  margin-bottom: 4px;
+  line-height: 1.4;
+}
+.kro-insight-tagline {
+  font-size: 7px;
+  color: #888;
+  margin-bottom: 10px;
+  line-height: 1.5;
+  font-style: italic;
+}
+.kro-insight-learn {
+  background: none;
+  border: 1px solid #00d4ff;
+  color: #00d4ff;
+  font-family: inherit;
+  font-size: 7px;
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: 2px;
+  transition: background 0.1s;
+}
+.kro-insight-learn:hover { background: rgba(0,212,255,0.1); }
+
+/* Concept Modal */
+.kro-concept-modal {
+  max-height: 90vh;
+  overflow-y: auto;
+}
+.kro-snippet-block {
+  background: #0a0e1a;
+  border: 1px solid #1e3a5f;
+  border-radius: 3px;
+  padding: 10px;
+  margin-top: 8px;
+}
+.kro-snippet-label {
+  font-size: 6px;
+  color: #5dade2;
+  letter-spacing: 2px;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+.kro-snippet-pre {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 6px;
+  color: #9b59b6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.8;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+/* K8s log entry — kro annotation section */
+.k8s-annotation {
+  margin-top: 8px;
+  padding: 8px;
+  background: #0a0e1a;
+  border-left: 2px solid #00d4ff;
+  border-radius: 0 3px 3px 0;
+}
+.k8s-annotation-label {
+  font-size: 6px;
+  color: #00d4ff;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+.k8s-annotation-what {
+  font-size: 6px;
+  color: #aaa;
+  margin-bottom: 6px;
+  line-height: 1.7;
+}
+.k8s-annotation-rgd {
+  font-size: 6px;
+  color: #5dade2;
+  margin-bottom: 6px;
+}
+.k8s-annotation-cel {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 6px;
+  color: #9b59b6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.7;
+  background: #060a12;
+  padding: 6px;
+  border-radius: 2px;
+}
+.k8s-annotation-learn {
+  background: none;
+  border: none;
+  color: #00d4ff;
+  font-family: inherit;
+  font-size: 6px;
+  padding: 4px 0 0 0;
+  cursor: pointer;
+  text-decoration: underline;
+  display: block;
+  margin-top: 4px;
+}
+.k8s-annotation-learn:hover { color: #5dade2; }
+
+/* Glossary Tab */
+.kro-glossary {
+  padding: 8px 0;
+}
+.kro-glossary-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #1e3a5f;
+}
+.kro-glossary-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+.kro-glossary-item {
+  background: #0d1b2e;
+  border: 1px solid #1e3a5f;
+  border-radius: 3px;
+  padding: 8px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  transition: border-color 0.15s, background 0.15s;
+}
+.kro-glossary-item.unlocked {
+  border-color: #0f3460;
+}
+.kro-glossary-item.unlocked:hover {
+  border-color: #00d4ff;
+  background: rgba(0,212,255,0.05);
+}
+.kro-glossary-item.locked {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.kro-glossary-item-title {
+  font-size: 7px;
+  color: #00d4ff;
+  margin-bottom: 4px;
+  line-height: 1.4;
+}
+.kro-glossary-item.locked .kro-glossary-item-title {
+  color: #444;
+}
+.kro-glossary-item-tagline {
+  font-size: 6px;
+  color: #666;
+  line-height: 1.5;
+}
+.kro-glossary-item.unlocked .kro-glossary-item-tagline {
+  color: #777;
+}
+
+/* Status bar kro tooltip — richer content */
+.kro-status-tip {
+  white-space: pre-line;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 6px;
+  line-height: 1.8;
+  color: #ccc;
+  max-width: 260px;
+}
+
+/* Log tabs — kro tab styling */
+.log-tab.kro-tab {
+  color: #00d4ff;
+  border-color: #00d4ff;
+}
+.log-tab.kro-tab.active {
+  background: #0f3460;
+  color: #00d4ff;
+}


### PR DESCRIPTION
## Summary

Implements a full in-game kro teaching layer that teaches players kro concepts as they play, without interrupting gameplay.

### What's new

**InsightCard** — small slide-in cards (bottom-right, 12s auto-dismiss) triggered by game events:
- Create dungeon → RGD concept
- First attack → CEL basics
- Monster kill → includeWhen
- Boss goes pending→ready → CEL ternary state machines
- Boss kill → status aggregation
- Loot drop → seeded-random
- Treasure open → Secret as output
- Enter room 2 → spec mutation triggers reconcile
- Modifier dungeon → readyWhen
- Multiple monsters → forEach fan-out

**Annotated K8s Log** — clicking any K8s log entry now shows the YAML + a kro annotation panel explaining:
- What kro did with this CR
- Which RGD handles it
- The actual CEL expression snippet
- A "Learn:" link that opens the full concept modal

**kro Glossary tab** — third tab in the event log area (`kro 0/13`):
- Progressive unlock: concepts appear as you trigger them in-game
- Locked concepts show as `???` with "keep playing" hint
- Unlocked concepts are clickable → opens full concept modal with body text + YAML/CEL snippet
- Persisted to localStorage across sessions
- Progress counter in tab label

**Status bar kro tooltips** — hovering each status chip now shows the kro field + CEL expression behind it (livingMonsters filter, boss-graph ternary, spec.schema enum validation, etc.)

**13 kro concepts covered:**
rgd, spec-schema, resource-chaining, cel-basics, cel-ternary, forEach, includeWhen, readyWhen, status-aggregation, seeded-random, secret-output, empty-rgd, spec-mutation

### Files changed
- `frontend/src/KroTeach.tsx` — new file, all teaching layer logic
- `frontend/src/App.tsx` — wired in teaching layer, upgraded EventLogTabs, status bar tooltips
- `frontend/src/index.css` — styles for InsightCard, KroGlossary, annotations

Build is clean (`vite build` ✓). Guardrails pass (only live-cluster check fails as expected locally).