### PR TITLE
feat: live kro resource graph panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import {
   KRO_STATUS_TIPS,
   type InsightTrigger, type KroConceptId,
 } from './KroTeach'
+import { KroGraphPanel } from './KroGraph'
 
 // 8-bit styled text icons (consistent cross-platform, matches pixel font)
 const ICO = {
@@ -67,6 +68,7 @@ export default function App() {
   const [insightQueue, setInsightQueue] = useState<InsightTrigger[]>([])
   const [kroConceptModal, setKroConceptModal] = useState<KroConceptId | null>(null)
   const shownInsightsRef = useRef<Set<KroConceptId>>(new Set())
+  const [reconciling, setReconciling] = useState(false)
 
   const triggerInsight = useCallback((event: string) => {
     const trigger = getInsightForEvent(event)
@@ -224,6 +226,7 @@ export default function App() {
 
       await submitAttack(selected.ns, selected.name, target, damage,
         isItem ? (detail?.spec.actionSeq ?? -1) : (detail?.spec.attackSeq ?? -1))
+      setReconciling(true)
       const crKind = isItem ? 'Action' : 'Attack'
       const crField = isItem ? `action: ${target}` : `target: ${target}\n  damage: ${damage}`
       addK8s(`kubectl apply -f ${crKind.toLowerCase()}.yaml`, `${crKind.toLowerCase()}.game.k8s.example created`,
@@ -259,6 +262,7 @@ export default function App() {
         }
         setDetail(updated)
         setRoomLoading(false)
+        setReconciling(false)
         setAttackPhase(null)
         setAnimPhase('idle')
         setAttackTarget(null)
@@ -291,6 +295,7 @@ export default function App() {
           await new Promise(r => setTimeout(r, 3000))
         }
         setDetail(updated)
+        setReconciling(false)
       }
 
       const heroAction = updated.spec.lastHeroAction || ''
@@ -381,6 +386,7 @@ export default function App() {
       }
       setCombatModal(null)
       setAttackPhase(null)
+      setReconciling(false)
       setAnimPhase('idle')
       setAttackTarget(null)
       setFloatingDmg(null)
@@ -495,6 +501,7 @@ export default function App() {
           apiError={apiError}
           kroUnlocked={unlocked}
           onViewKroConcept={setKroConceptModal}
+          reconciling={reconciling}
         />
       ) : null}
 
@@ -916,7 +923,7 @@ function HelpModal({ onClose, onCheat }: { onClose: () => void; onCheat: () => v
     </div>
   )
 }
-function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, showCheat, onToggleCheat, floatingDmg, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError, kroUnlocked, onViewKroConcept }: {
+function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, showCheat, onToggleCheat, floatingDmg, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError, kroUnlocked, onViewKroConcept, reconciling }: {
   cr: DungeonCR; onBack: () => void; onAttack: (t: string, d: number) => void; events: WSEvent[]; k8sLog: { ts: string; cmd: string; res: string; yaml?: string }[]
   showLoot: boolean; onOpenLoot: () => void; onCloseLoot: () => void
   attackPhase: string | null; roomLoading: boolean
@@ -931,6 +938,7 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
   apiError: string | null
   kroUnlocked: Set<KroConceptId>
   onViewKroConcept: (id: KroConceptId) => void
+  reconciling: boolean
 }) {
   if (!cr?.metadata?.name) return <div className="loading">Loading dungeon</div>
   const spec = cr.spec || { monsters: 0, difficulty: 'normal', monsterHP: [], bossHP: 0, heroHP: 100 }
@@ -1432,6 +1440,8 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
           })()}
         </div>
       </div>
+
+      <KroGraphPanel cr={cr} reconciling={reconciling} onViewConcept={onViewKroConcept} />
 
       <EventLogTabs events={events} k8sLog={k8sLog} kroUnlocked={kroUnlocked} onViewKroConcept={onViewKroConcept} />
     </div>

--- a/frontend/src/KroGraph.tsx
+++ b/frontend/src/KroGraph.tsx
@@ -1,0 +1,680 @@
+/**
+ * KroGraph — Live kro Resource Graph Panel
+ *
+ * Renders the dungeon's live ResourceGraphDefinition tree as an SVG DAG.
+ * Every node reflects real-time state from the DungeonCR spec/status.
+ * Clicking a node opens the relevant kro concept modal.
+ *
+ * Layout (fixed, pixel-art aesthetic):
+ *
+ *   [Dungeon CR]  ← root
+ *       ├── [Namespace]
+ *       ├── [Hero CR] → [heroState CM]
+ *       ├── [Monster CR ×N] → [monsterState CM] → [Loot CR?] → [lootSecret?]
+ *       ├── [Boss CR] → [bossState CM] → [Loot CR?]
+ *       ├── [Treasure CR] → [treasureState CM] → [treasureSecret?]
+ *       ├── [Modifier CR?] → [modifierState CM]
+ *       ├── [combatResult CM]
+ *       ├── [actionResult CM]
+ *       └── [gameConfig CM]
+ */
+
+import { useState, useEffect, useRef } from 'react'
+import type { DungeonCR } from './api'
+import type { KroConceptId } from './KroTeach'
+
+// ─── Node types ──────────────────────────────────────────────────────────────
+
+type NodeState = 'alive' | 'dead' | 'ready' | 'pending' | 'defeated' | 'locked' | 'reconciling' | 'ok'
+
+interface GraphNode {
+  id: string
+  label: string        // short display label
+  kind: string         // K8s kind
+  state: NodeState
+  exists: boolean      // false = includeWhen blocked, shown as outline
+  concept: KroConceptId | null
+  detail?: string      // short status line shown below label
+  pulse?: boolean      // true during reconcile window
+}
+
+interface GraphEdge {
+  from: string
+  to: string
+  label?: string       // relationship annotation
+  dashed?: boolean     // dashed = conditional (includeWhen)
+}
+
+// ─── Build graph from DungeonCR ──────────────────────────────────────────────
+
+export function buildGraph(cr: DungeonCR, reconciling: boolean): { nodes: GraphNode[]; edges: GraphEdge[] } {
+  const spec = cr.spec
+  const status = cr.status
+  const name = cr.metadata.name
+  const monsterHP: number[] = spec.monsterHP || []
+  const allMonstersDead = monsterHP.length > 0 && monsterHP.every(hp => hp <= 0)
+  const bossHP = spec.bossHP ?? 0
+  const bossDefeated = bossHP <= 0 && allMonstersDead
+  const hasModifier = !!spec.modifier && spec.modifier !== 'none'
+  const treasureOpened = (spec.treasureOpened ?? 0) === 1
+
+  const nodes: GraphNode[] = []
+  const edges: GraphEdge[] = []
+
+  // Root: Dungeon CR
+  const dungeonState: NodeState = reconciling ? 'reconciling'
+    : status?.victory ? 'alive'
+    : spec.heroHP <= 0 ? 'dead'
+    : 'alive'
+  nodes.push({
+    id: 'dungeon',
+    label: name.length > 12 ? name.slice(0, 10) + '..' : name,
+    kind: 'Dungeon',
+    state: dungeonState,
+    exists: true,
+    concept: 'rgd',
+    detail: `spec.difficulty=${spec.difficulty}`,
+    pulse: reconciling,
+  })
+
+  // Namespace
+  nodes.push({
+    id: 'namespace',
+    label: 'default',
+    kind: 'Namespace',
+    state: 'ok',
+    exists: true,
+    concept: 'rgd',
+    detail: 'created by dungeon-graph',
+  })
+  edges.push({ from: 'dungeon', to: 'namespace' })
+
+  // Hero CR
+  const heroState: NodeState = (spec.heroHP ?? 100) <= 0 ? 'defeated' : reconciling ? 'reconciling' : 'alive'
+  nodes.push({
+    id: 'hero',
+    label: `Hero`,
+    kind: 'Hero CR',
+    state: heroState,
+    exists: true,
+    concept: 'resource-chaining',
+    detail: `HP: ${spec.heroHP}/${status?.maxHeroHP ?? '?'} · ${spec.heroClass || 'warrior'}`,
+    pulse: reconciling,
+  })
+  edges.push({ from: 'dungeon', to: 'hero' })
+
+  // heroState ConfigMap
+  nodes.push({
+    id: 'hero-cm',
+    label: 'heroState',
+    kind: 'ConfigMap',
+    state: 'ok',
+    exists: true,
+    concept: 'cel-basics',
+    detail: `entityState=${heroState === 'defeated' ? 'defeated' : 'alive'}`,
+  })
+  edges.push({ from: 'hero', to: 'hero-cm', label: 'hero-graph' })
+
+  // Monster CRs (show up to 4 collapsed if more)
+  const showMonsters = Math.min(monsterHP.length, 4)
+  for (let i = 0; i < showMonsters; i++) {
+    const hp = monsterHP[i]
+    const mState: NodeState = reconciling && hp > 0 ? 'reconciling' : hp > 0 ? 'alive' : 'dead'
+    const mId = `monster-${i}`
+    nodes.push({
+      id: mId,
+      label: `M${i}`,
+      kind: 'Monster CR',
+      state: mState,
+      exists: true,
+      concept: 'forEach',
+      detail: `HP: ${hp}/${status?.maxMonsterHP ?? '?'}`,
+      pulse: reconciling && hp > 0,
+    })
+    edges.push({ from: 'dungeon', to: mId, label: i === 0 ? 'forEach' : undefined })
+
+    // monsterState ConfigMap
+    const mcmId = `monster-cm-${i}`
+    nodes.push({
+      id: mcmId,
+      label: `m${i}State`,
+      kind: 'ConfigMap',
+      state: hp > 0 ? 'alive' : 'dead',
+      exists: true,
+      concept: 'cel-basics',
+      detail: hp > 0 ? 'entityState=alive' : 'entityState=dead',
+    })
+    edges.push({ from: mId, to: mcmId, label: 'monster-graph' })
+
+    // Loot CR (includeWhen: hp==0)
+    const lootId = `loot-m${i}`
+    const lootExists = hp <= 0
+    nodes.push({
+      id: lootId,
+      label: `Loot`,
+      kind: 'Loot CR',
+      state: lootExists ? 'ok' : 'locked',
+      exists: lootExists,
+      concept: 'includeWhen',
+      detail: lootExists ? 'dropped on kill' : 'includeWhen: hp==0',
+    })
+    edges.push({ from: mcmId, to: lootId, label: 'includeWhen', dashed: true })
+  }
+  if (monsterHP.length > 4) {
+    nodes.push({
+      id: 'monster-more',
+      label: `+${monsterHP.length - 4} more`,
+      kind: 'Monster CR',
+      state: 'ok',
+      exists: true,
+      concept: 'forEach',
+      detail: `${monsterHP.length - 4} additional monsters`,
+    })
+    edges.push({ from: 'dungeon', to: 'monster-more' })
+  }
+
+  // Boss CR
+  const bossState: NodeState = reconciling ? 'reconciling'
+    : bossDefeated ? 'defeated'
+    : allMonstersDead ? 'ready'
+    : 'pending'
+  nodes.push({
+    id: 'boss',
+    label: 'Boss',
+    kind: 'Boss CR',
+    state: bossState,
+    exists: true,
+    concept: 'cel-ternary',
+    detail: `HP: ${bossHP}/${status?.maxBossHP ?? '?'} · ${bossState}`,
+    pulse: reconciling,
+  })
+  edges.push({ from: 'dungeon', to: 'boss' })
+
+  // bossState ConfigMap
+  nodes.push({
+    id: 'boss-cm',
+    label: 'bossState',
+    kind: 'ConfigMap',
+    state: bossState === 'defeated' ? 'defeated' : bossState === 'ready' ? 'ready' : 'pending',
+    exists: true,
+    concept: 'cel-ternary',
+    detail: `entityState=${bossState}`,
+  })
+  edges.push({ from: 'boss', to: 'boss-cm', label: 'boss-graph' })
+
+  // Boss Loot CR (includeWhen: hp==0)
+  const bossLootExists = bossDefeated
+  nodes.push({
+    id: 'boss-loot',
+    label: 'BossLoot',
+    kind: 'Loot CR',
+    state: bossLootExists ? 'ok' : 'locked',
+    exists: bossLootExists,
+    concept: 'includeWhen',
+    detail: bossLootExists ? 'guaranteed drop' : 'includeWhen: hp==0',
+  })
+  edges.push({ from: 'boss-cm', to: 'boss-loot', label: 'includeWhen', dashed: true })
+
+  // Treasure CR
+  const treasureState: NodeState = treasureOpened ? 'ok' : 'pending'
+  nodes.push({
+    id: 'treasure',
+    label: 'Treasure',
+    kind: 'Treasure CR',
+    state: treasureState,
+    exists: true,
+    concept: 'secret-output',
+    detail: `opened=${treasureOpened ? 1 : 0}`,
+  })
+  edges.push({ from: 'dungeon', to: 'treasure' })
+
+  // treasureState ConfigMap
+  nodes.push({
+    id: 'treasure-cm',
+    label: 'treasureState',
+    kind: 'ConfigMap',
+    state: treasureOpened ? 'ok' : 'pending',
+    exists: true,
+    concept: 'secret-output',
+    detail: treasureOpened ? 'opened' : 'unopened',
+  })
+  edges.push({ from: 'treasure', to: 'treasure-cm', label: 'treasure-graph' })
+
+  // treasureSecret Secret (includeWhen: opened==1)
+  nodes.push({
+    id: 'treasure-secret',
+    label: 'Key Secret',
+    kind: 'Secret',
+    state: treasureOpened ? 'ok' : 'locked',
+    exists: treasureOpened,
+    concept: 'secret-output',
+    detail: treasureOpened ? 'holds dungeon key' : 'includeWhen: opened==1',
+  })
+  edges.push({ from: 'treasure-cm', to: 'treasure-secret', label: 'includeWhen', dashed: true })
+
+  // Modifier CR (includeWhen: modifier != "none")
+  nodes.push({
+    id: 'modifier',
+    label: hasModifier ? (spec.modifier || 'modifier').slice(0, 8) : 'Modifier',
+    kind: 'Modifier CR',
+    state: hasModifier ? 'ok' : 'locked',
+    exists: hasModifier,
+    concept: 'readyWhen',
+    detail: hasModifier ? `type=${status?.modifierType || '?'}` : 'includeWhen: modifier!="none"',
+  })
+  edges.push({ from: 'dungeon', to: 'modifier', label: 'includeWhen', dashed: !hasModifier })
+
+  if (hasModifier) {
+    nodes.push({
+      id: 'modifier-cm',
+      label: 'modifierState',
+      kind: 'ConfigMap',
+      state: status?.modifierType ? 'ok' : 'pending',
+      exists: true,
+      concept: 'readyWhen',
+      detail: `readyWhen: modifierType!=''`,
+    })
+    edges.push({ from: 'modifier', to: 'modifier-cm', label: 'modifier-graph\nreadyWhen' })
+  }
+
+  // combatResult ConfigMap
+  nodes.push({
+    id: 'combat-cm',
+    label: 'combatResult',
+    kind: 'ConfigMap',
+    state: reconciling ? 'reconciling' : 'ok',
+    exists: true,
+    concept: 'cel-basics',
+    detail: `dice: ${status?.diceFormula || '?'}`,
+    pulse: reconciling,
+  })
+  edges.push({ from: 'dungeon', to: 'combat-cm', label: 'CEL' })
+
+  // actionResult ConfigMap
+  nodes.push({
+    id: 'action-cm',
+    label: 'actionResult',
+    kind: 'ConfigMap',
+    state: reconciling ? 'reconciling' : 'ok',
+    exists: true,
+    concept: 'empty-rgd',
+    detail: 'equip/use/door/room logic',
+    pulse: reconciling,
+  })
+  edges.push({ from: 'dungeon', to: 'action-cm', label: 'CEL' })
+
+  // gameConfig ConfigMap
+  nodes.push({
+    id: 'gameconfig-cm',
+    label: 'gameConfig',
+    kind: 'ConfigMap',
+    state: 'ok',
+    exists: true,
+    concept: 'spec-schema',
+    detail: `counters, maxHP values`,
+  })
+  edges.push({ from: 'dungeon', to: 'gameconfig-cm' })
+
+  return { nodes, edges }
+}
+
+// ─── Layout engine ───────────────────────────────────────────────────────────
+//
+// Top-down row layout:
+//   Row 0 (y=0):   Dungeon CR  (centered)
+//   Row 1 (y=56):  Hero, Monster×N, Boss, Treasure, Modifier, Namespace
+//   Row 2 (y=112): CMs for each row-1 CR  (aligned under parent)
+//   Row 3 (y=168): Conditional outputs (Loot CRs, Secrets)
+//   Row 4 (y=224): combatResult, actionResult, gameConfig (system CMs from Dungeon)
+
+interface NodePos { x: number; y: number; w: number; h: number }
+
+const NODE_W = 82
+const NODE_H = 36
+const H_GAP = 94    // horizontal gap between node centers
+const V_GAP = 56    // vertical gap between rows
+
+function layoutGraph(nodes: GraphNode[], _edges: GraphEdge[]): Map<string, NodePos> {
+  const positions = new Map<string, NodePos>()
+
+  // Row assignments
+  const row = (id: string): number => {
+    if (id === 'dungeon') return 0
+    if (id === 'namespace' || id === 'hero' || id.match(/^monster-\d+$/) || id === 'monster-more'
+        || id === 'boss' || id === 'treasure' || id === 'modifier') return 1
+    if (id === 'hero-cm' || id.match(/^monster-cm-\d+$/) || id === 'boss-cm'
+        || id === 'treasure-cm' || id === 'modifier-cm') return 2
+    if (id.match(/^loot-m\d+$/) || id === 'boss-loot' || id === 'treasure-secret') return 3
+    if (id === 'combat-cm' || id === 'action-cm' || id === 'gameconfig-cm') return 4
+    return 1
+  }
+
+  // Group by row, preserve insertion order (which matches left-to-right intent)
+  const rows: Map<number, string[]> = new Map()
+  for (const n of nodes) {
+    const r = row(n.id)
+    if (!rows.has(r)) rows.set(r, [])
+    rows.get(r)!.push(n.id)
+  }
+
+  // For each row, distribute nodes evenly and center the whole row
+  const totalWidth = (ids: string[]) => ids.length * H_GAP
+  // Find max row width to determine overall canvas width
+  let maxRowW = 0
+  for (const ids of rows.values()) maxRowW = Math.max(maxRowW, totalWidth(ids))
+
+  for (const [r, ids] of rows) {
+    const rowW = totalWidth(ids)
+    const startX = (maxRowW - rowW) / 2 + H_GAP / 2 - NODE_W / 2
+    ids.forEach((id, i) => {
+      positions.set(id, {
+        x: startX + i * H_GAP,
+        y: r * V_GAP + 8,
+        w: NODE_W,
+        h: NODE_H,
+      })
+    })
+  }
+
+  return positions
+}
+
+// ─── Color mapping ───────────────────────────────────────────────────────────
+
+function stateColor(state: NodeState, exists: boolean): { border: string; bg: string; text: string } {
+  if (!exists) return { border: '#2a2a4a', bg: '#0d0d1a', text: '#333' }
+  switch (state) {
+    case 'alive':       return { border: '#00ff41', bg: '#0a1f0a', text: '#00ff41' }
+    case 'ready':       return { border: '#f5c518', bg: '#1a1500', text: '#f5c518' }
+    case 'pending':     return { border: '#555', bg: '#111', text: '#888' }
+    case 'dead':        return { border: '#e94560', bg: '#1a0a0a', text: '#e94560' }
+    case 'defeated':    return { border: '#9b59b6', bg: '#130a1a', text: '#9b59b6' }
+    case 'reconciling': return { border: '#00d4ff', bg: '#0a1520', text: '#00d4ff' }
+    case 'locked':      return { border: '#222', bg: '#0a0a12', text: '#333' }
+    case 'ok':          return { border: '#2a4a6a', bg: '#0a1420', text: '#5dade2' }
+    default:            return { border: '#333', bg: '#111', text: '#888' }
+  }
+}
+
+// ─── SVG Graph Component ─────────────────────────────────────────────────────
+
+interface KroGraphProps {
+  cr: DungeonCR
+  reconciling: boolean
+  onNodeClick: (conceptId: KroConceptId) => void
+}
+
+export function KroGraph({ cr, reconciling, onNodeClick }: KroGraphProps) {
+  const { nodes, edges } = buildGraph(cr, reconciling)
+  const positions = layoutGraph(nodes, edges)
+  const nodeMap = new Map(nodes.map(n => [n.id, n]))
+
+  // Compute SVG dimensions
+  let maxX = 0, maxY = 0
+  for (const pos of positions.values()) {
+    maxX = Math.max(maxX, pos.x + pos.w)
+    maxY = Math.max(maxY, pos.y + pos.h)
+  }
+  const svgW = maxX + 16
+  const svgH = maxY + 16
+
+  const [hovered, setHovered] = useState<string | null>(null)
+  const [pulseFrame, setPulseFrame] = useState(0)
+
+  // Pulse animation for reconciling nodes
+  useEffect(() => {
+    if (!reconciling) return
+    const id = setInterval(() => setPulseFrame(f => (f + 1) % 6), 200)
+    return () => clearInterval(id)
+  }, [reconciling])
+
+  return (
+    <div className="kro-graph-wrap">
+      <svg
+        width={svgW}
+        height={svgH}
+        viewBox={`0 0 ${svgW} ${svgH}`}
+        style={{ display: 'block', overflow: 'visible' }}
+        aria-label="kro resource graph"
+      >
+        <defs>
+          <marker id="arrowhead" markerWidth="6" markerHeight="6" refX="3" refY="6" orient="auto">
+            <path d="M0,0 L6,0 L3,6 z" fill="#2a4a6a" />
+          </marker>
+          <marker id="arrowhead-active" markerWidth="6" markerHeight="6" refX="3" refY="6" orient="auto">
+            <path d="M0,0 L6,0 L3,6 z" fill="#00d4ff" />
+          </marker>
+          <marker id="arrowhead-dashed" markerWidth="6" markerHeight="6" refX="3" refY="6" orient="auto">
+            <path d="M0,0 L6,0 L3,6 z" fill="#333" />
+          </marker>
+        </defs>
+
+        {/* Edges — drawn first (behind nodes) */}
+        {edges.map((edge, i) => {
+          const fromPos = positions.get(edge.from)
+          const toPos = positions.get(edge.to)
+          if (!fromPos || !toPos) return null
+
+          const fromNode = nodeMap.get(edge.from)
+          const toNode = nodeMap.get(edge.to)
+          const isActive = reconciling && (fromNode?.pulse || toNode?.pulse)
+          const isExistEdge = toNode?.exists !== false
+
+          // Top-down edges: from bottom-center of parent to top-center of child
+          const x1 = fromPos.x + fromPos.w / 2
+          const y1 = fromPos.y + fromPos.h
+          const x2 = toPos.x + toPos.w / 2
+          const y2 = toPos.y
+
+          // Cubic bezier curves for clean top-down flow
+          const my = (y1 + y2) / 2
+          const path = `M${x1},${y1} C${x1},${my} ${x2},${my} ${x2},${y2}`
+
+          const stroke = isActive ? '#00d4ff' : edge.dashed ? '#2a2a4a' : '#1e3a5f'
+          const marker = isActive ? 'url(#arrowhead-active)' : edge.dashed ? 'url(#arrowhead-dashed)' : 'url(#arrowhead)'
+
+          return (
+            <g key={i}>
+              <path
+                d={path}
+                fill="none"
+                stroke={stroke}
+                strokeWidth={isActive ? 1.5 : 1}
+                strokeDasharray={edge.dashed ? '4,3' : undefined}
+                markerEnd={marker}
+                opacity={isExistEdge ? 1 : 0.3}
+              />
+              {edge.label && (
+                <text
+                  x={(x1 + x2) / 2 + 4}
+                  y={my - 2}
+                  textAnchor="middle"
+                  fontSize={5}
+                  fill={isActive ? '#00d4ff' : '#2a4a6a'}
+                  style={{ fontFamily: "'Press Start 2P', monospace" }}
+                >
+                  {edge.label.split('\n').map((line, li) => (
+                    <tspan key={li} x={(x1 + x2) / 2 + 4} dy={li === 0 ? 0 : 7}>{line}</tspan>
+                  ))}
+                </text>
+              )}
+            </g>
+          )
+        })}
+
+        {/* Nodes */}
+        {nodes.map(node => {
+          const pos = positions.get(node.id)
+          if (!pos) return null
+
+          const colors = stateColor(node.state, node.exists)
+          const isHovered = hovered === node.id
+          const isPulsing = node.pulse && reconciling
+          const pulseOpacity = isPulsing ? 0.3 + (Math.sin(pulseFrame * Math.PI / 3) + 1) * 0.35 : 0
+          const canClick = !!node.concept
+
+          return (
+            <g
+              key={node.id}
+              transform={`translate(${pos.x},${pos.y})`}
+              style={{ cursor: canClick ? 'pointer' : 'default' }}
+              onClick={() => canClick && node.concept && onNodeClick(node.concept)}
+              onMouseEnter={() => setHovered(node.id)}
+              onMouseLeave={() => setHovered(null)}
+              role={canClick ? 'button' : undefined}
+              aria-label={`${node.kind}: ${node.label} — ${node.state}`}
+            >
+              {/* Pulse glow */}
+              {isPulsing && (
+                <rect
+                  x={-3} y={-3}
+                  width={pos.w + 6} height={pos.h + 6}
+                  rx={3}
+                  fill={colors.border}
+                  opacity={pulseOpacity}
+                />
+              )}
+
+              {/* Node background */}
+              <rect
+                x={0} y={0}
+                width={pos.w} height={pos.h}
+                rx={2}
+                fill={isHovered ? colors.bg : colors.bg}
+                stroke={isHovered ? '#00d4ff' : colors.border}
+                strokeWidth={isHovered ? 1.5 : 1}
+                opacity={node.exists ? 1 : 0.35}
+                strokeDasharray={!node.exists ? '3,2' : undefined}
+              />
+
+              {/* Kind label (top, tiny) */}
+              <text
+                x={pos.w / 2} y={10}
+                textAnchor="middle"
+                fontSize={5}
+                fill={node.exists ? '#555' : '#2a2a4a'}
+                style={{ fontFamily: "'Press Start 2P', monospace" }}
+              >
+                {node.kind}
+              </text>
+
+              {/* Main label */}
+              <text
+                x={pos.w / 2} y={21}
+                textAnchor="middle"
+                fontSize={6}
+                fill={node.exists ? colors.text : '#333'}
+                style={{ fontFamily: "'Press Start 2P', monospace", fontWeight: 'bold' }}
+              >
+                {node.label}
+              </text>
+
+              {/* State dot */}
+              {node.exists && (
+                <circle
+                  cx={pos.w - 6} cy={6}
+                  r={3}
+                  fill={colors.border}
+                  opacity={0.9}
+                />
+              )}
+              {!node.exists && (
+                <text
+                  x={pos.w / 2} y={30}
+                  textAnchor="middle"
+                  fontSize={5}
+                  fill="#2a2a4a"
+                  style={{ fontFamily: "'Press Start 2P', monospace" }}
+                >
+                  locked
+                </text>
+              )}
+
+              {/* Hover tooltip */}
+              {isHovered && node.detail && (
+                <g>
+                  <rect
+                    x={pos.w / 2 - 60} y={pos.h + 4}
+                    width={120} height={22}
+                    rx={2}
+                    fill="#0a0e1a"
+                    stroke="#00d4ff"
+                    strokeWidth={1}
+                  />
+                  <text
+                    x={pos.w / 2} y={pos.h + 14}
+                    textAnchor="middle"
+                    fontSize={5}
+                    fill="#ccc"
+                    style={{ fontFamily: "'Press Start 2P', monospace" }}
+                  >
+                    {node.detail.slice(0, 24)}
+                  </text>
+                  {node.concept && (
+                    <text
+                      x={pos.w / 2} y={pos.h + 22}
+                      textAnchor="middle"
+                      fontSize={5}
+                      fill="#00d4ff"
+                      style={{ fontFamily: "'Press Start 2P', monospace" }}
+                    >
+                      click → learn {node.concept}
+                    </text>
+                  )}
+                </g>
+              )}
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+// ─── KroGraphPanel — collapsible wrapper ─────────────────────────────────────
+
+interface KroGraphPanelProps {
+  cr: DungeonCR
+  reconciling: boolean
+  onViewConcept: (id: KroConceptId) => void
+}
+
+export function KroGraphPanel({ cr, reconciling, onViewConcept }: KroGraphPanelProps) {
+  const [collapsed, setCollapsed] = useState(false)
+
+  return (
+    <div className="kro-graph-panel">
+      <div className="kro-graph-header" onClick={() => setCollapsed(c => !c)}>
+        <span className="kro-insight-badge">kro</span>
+        <span className="kro-graph-title">Resource Graph</span>
+        {reconciling && <span className="kro-graph-reconciling">● reconciling</span>}
+        <span className="kro-graph-toggle">{collapsed ? '▼' : '▲'}</span>
+      </div>
+      {!collapsed && (
+        <div className="kro-graph-body">
+          <div className="kro-graph-legend">
+            {[
+              { color: '#00ff41', label: 'alive' },
+              { color: '#f5c518', label: 'ready' },
+              { color: '#e94560', label: 'dead' },
+              { color: '#9b59b6', label: 'defeated' },
+              { color: '#00d4ff', label: 'reconciling' },
+              { color: '#333', label: 'locked (includeWhen)' },
+            ].map(({ color, label }) => (
+              <span key={label} className="kro-legend-item">
+                <span className="kro-legend-dot" style={{ background: color }} />
+                <span className="kro-legend-label">{label}</span>
+              </span>
+            ))}
+          </div>
+          <div className="kro-graph-scroll">
+            <KroGraph cr={cr} reconciling={reconciling} onNodeClick={onViewConcept} />
+          </div>
+          <div className="kro-graph-hint">
+            Hover nodes for details · Click to learn the kro concept
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1134,3 +1134,99 @@ body {
   background: #0f3460;
   color: #00d4ff;
 }
+
+/* ─── kro Resource Graph Panel ───────────────────────────────────────────── */
+
+.kro-graph-panel {
+  margin-top: 16px;
+  border: 1px solid #0f3460;
+  border-radius: 4px;
+  background: #0a0e1a;
+  overflow: hidden;
+}
+
+.kro-graph-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid #0f3460;
+  user-select: none;
+  background: #0d1420;
+}
+.kro-graph-header:hover {
+  background: #111a2e;
+}
+
+.kro-graph-title {
+  font-size: 8px;
+  color: #ccc;
+  flex: 1;
+}
+
+.kro-graph-reconciling {
+  font-size: 7px;
+  color: #00d4ff;
+  animation: kro-blink 0.8s step-end infinite;
+}
+@keyframes kro-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.kro-graph-toggle {
+  font-size: 8px;
+  color: #555;
+}
+
+.kro-graph-body {
+  padding: 10px 12px 8px;
+}
+
+.kro-graph-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  margin-bottom: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #0f3460;
+}
+
+.kro-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.kro-legend-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.kro-legend-label {
+  font-size: 6px;
+  color: #666;
+}
+
+.kro-graph-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 4px;
+  max-height: 320px;
+}
+
+.kro-graph-wrap {
+  display: inline-block;
+  min-width: 100%;
+}
+
+.kro-graph-hint {
+  font-size: 6px;
+  color: #333;
+  margin-top: 6px;
+  text-align: center;
+  letter-spacing: 0.5px;
+}

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -327,6 +327,18 @@ CLEAR_COUNT=$(grep -c "setAttackTarget(null)" frontend/src/App.tsx)
 [ "$CLEAR_COUNT" -le 4 ] && pass "attackTarget cleared only in dismiss/catch/item ($CLEAR_COUNT)" || fail "attackTarget cleared too many places: $CLEAR_COUNT"
 grep -q "opacity.*dead.*0.35" frontend/src/Sprite.tsx && pass "Dead sprites have reduced opacity" || fail "Dead sprites missing opacity"
 
+# --- kro teaching layer guardrails ---
+echo "=== kro teaching layer guardrails"
+grep -q "InsightCard" frontend/src/App.tsx && pass "InsightCard wired into App" || fail "InsightCard missing from App"
+grep -q "KroGraphPanel" frontend/src/App.tsx && pass "KroGraphPanel wired into App" || fail "KroGraphPanel missing from App"
+grep -q "KroGlossary" frontend/src/App.tsx && pass "KroGlossary wired into EventLogTabs" || fail "KroGlossary missing from App"
+grep -q "kroAnnotate" frontend/src/App.tsx && pass "K8s log annotations wired in" || fail "K8s log annotations missing"
+grep -q "triggerInsight.*dungeon-created" frontend/src/App.tsx && pass "Dungeon creation triggers insight" || fail "Dungeon creation insight missing"
+grep -q "triggerInsight.*monster-killed" frontend/src/App.tsx && pass "Monster kill triggers insight" || fail "Monster kill insight missing"
+grep -q "KRO_STATUS_TIPS" frontend/src/App.tsx && pass "Status bar kro tooltips wired in" || fail "Status bar kro tooltips missing"
+[ -f "frontend/src/KroTeach.tsx" ] && pass "KroTeach.tsx exists" || fail "KroTeach.tsx missing"
+[ -f "frontend/src/KroGraph.tsx" ] && pass "KroGraph.tsx exists" || fail "KroGraph.tsx missing"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

Adds a live, interactive resource graph panel below the dungeon arena that shows the real kro ResourceGraphDefinition tree for the current dungeon, updated in real time from the DungeonCR spec/status.

### What the panel shows

A top-down SVG DAG with 5 rows:
- **Row 0**: Dungeon CR (root)
- **Row 1**: Hero CR, Monster CRs (forEach), Boss CR, Treasure CR, Modifier CR, Namespace
- **Row 2**: Output ConfigMaps from each child RGD (heroState, monsterState×N, bossState, treasureState, modifierState)
- **Row 3**: Conditional resources — Loot CRs and Secrets (shown as dashed outlines when locked by `includeWhen`, fade in when condition fires)
- **Row 4**: System ConfigMaps directly from dungeon-graph (combatResult, actionResult, gameConfig)

### Interactive features
- **Live state**: every node reflects actual spec/status fields — monster HP, boss state (pending/ready/defeated), treasure opened, modifier present
- **Reconcile pulse**: nodes pulse cyan when kro is actively reconciling (between action submit and state settle)
- **includeWhen visualisation**: locked resources shown as dashed outlines with `locked` label; they appear when the condition fires (monster kill, treasure open, etc.)
- **Click to learn**: every node is clickable and opens the corresponding kro concept modal (forEach, includeWhen, cel-ternary, readyWhen, etc.)
- **Hover tooltips**: shows live field values (HP, entityState, dice formula)
- **Collapsible**: panel collapses to a header bar to save screen space
- **Reconciling indicator**: header shows `● reconciling` blinking badge during active reconcile

### New guardrail checks (9)
Prevents teaching layer regressions: checks for InsightCard, KroGraphPanel, KroGlossary, kroAnnotate, insight triggers, status tooltips, and file existence.

Build clean ✓. All local guardrails pass (live-cluster check excluded as expected).