### PR TITLE
feat: multi-phase boss mechanics with HP thresholds (#25)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -360,6 +360,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 		return err
 	}
 	spec := getMap(dungeon.Object, "spec")
+	dungeonStatus := getMap(dungeon.Object, "status")
 
 	heroHP := getInt(spec, "heroHP")
 	heroClass := getString(spec, "heroClass", "warrior")
@@ -368,6 +369,16 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 	tauntActive := getInt(spec, "tauntActive")
 	backstabCD := getInt(spec, "backstabCooldown")
 	attackSeq := getInt(spec, "attackSeq")
+
+	// Boss phase damage multiplier from kro-derived status (boss-graph CEL).
+	// Stored as integer *10: phase1=10 (1.0x), phase2=15 (1.5x), phase3=20 (2.0x).
+	// Default to 10 (1.0x) if status not yet populated.
+	bossDmgMultiplierStr := getString(dungeonStatus, "bossDamageMultiplier", "10")
+	bossDmgMultiplier, _ := strconv.ParseInt(bossDmgMultiplierStr, 10, 64)
+	if bossDmgMultiplier <= 0 {
+		bossDmgMultiplier = 10
+	}
+	bossPhaseStr := getString(dungeonStatus, "bossPhase", "phase1")
 
 	// Conflict guard: if the client sent a known sequence number that doesn't
 	// match the current spec, another request already advanced the dungeon
@@ -652,6 +663,15 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 		default:
 			counter = 5
 		}
+		// Apply boss phase multiplier (derived from boss-graph CEL via kro status).
+		// Phase 1: ×1.0, Phase 2: ×1.5, Phase 3: ×2.0 — stored as integer *10.
+		counter = counter * bossDmgMultiplier / 10
+		phaseNote := ""
+		if bossPhaseStr == "phase2" {
+			phaseNote = " [ENRAGED ×1.5]"
+		} else if bossPhaseStr == "phase3" {
+			phaseNote = " [BERSERK ×2.0]"
+		}
 		enemyAction := ""
 		effectNote := ""
 		if newBossHP > 0 {
@@ -688,7 +708,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 				counter = heroHP - 1
 			}
 			heroHP = max64(heroHP-counter, 0)
-			enemyAction = fmt.Sprintf("Boss strikes back for %d damage! (Hero HP: %d)", counter, heroHP)
+			enemyAction = fmt.Sprintf("Boss strikes back for %d damage!%s (Hero HP: %d)", counter, phaseNote, heroHP)
 
 			// Status effects from boss — boots provide status resist
 			effectRoll := seededRoll(attackUID+"-fx", 100)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -364,6 +364,13 @@ export default function App() {
         const nowAllDead = (updated.spec.monsterHP || []).every((hp: number) => hp <= 0)
         if (nowAllDead && !prevAllDead) { addEvent('🐉', 'Boss unlocked! All monsters slain!'); triggerInsight('boss-ready') }
         if (newBossHP <= 0 && prevBossHP > 0) { addEvent('🏆', 'VICTORY! Boss defeated!'); triggerInsight('boss-killed') }
+        // Boss phase transitions
+        const prevMaxBossHP = Number(detail?.status?.maxBossHP) || (prevBossHP > 0 ? prevBossHP : 1)
+        const newMaxBossHP = Number(updated.status?.maxBossHP) || prevMaxBossHP
+        const prevPct = newMaxBossHP > 0 ? (prevBossHP / newMaxBossHP) * 100 : 100
+        const newPct = newMaxBossHP > 0 ? (newBossHP / newMaxBossHP) * 100 : 100
+        if (prevPct > 50 && newPct <= 50 && newBossHP > 0) addEvent('🔥', '⚠️ The boss becomes ENRAGED! (Phase 2: ×1.5 damage)')
+        if (prevPct > 25 && newPct <= 25 && newBossHP > 0) addEvent('💀', '💀 BERSERK MODE! Boss attacks with fury! (Phase 3: ×2.0 damage)')
         if ((updated.spec.heroHP ?? 100) <= 0 && (detail?.spec.heroHP ?? 100) > 0) addEvent('💀', 'Hero has fallen...')
         // Detect monster kill
         const prevDeadCount = (detail?.spec.monsterHP || []).filter((hp: number) => hp <= 0).length
@@ -954,6 +961,18 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
   const isDefeated = status?.defeated || heroHP <= 0
   const allMonstersDead = (spec.monsterHP || []).every((hp: number) => hp <= 0)
   const bossState = spec.bossHP <= 0 ? 'defeated' : allMonstersDead ? 'ready' : 'pending'
+  // Boss phase — read from kro-derived status (boss-graph CEL), fallback to local derivation
+  const bossPhase: 'phase1' | 'phase2' | 'phase3' | 'defeated' = (() => {
+    if (spec.bossHP <= 0) return 'defeated'
+    const fromStatus = status?.bossPhase as string | undefined
+    if (fromStatus && fromStatus !== 'phase1') return fromStatus as 'phase2' | 'phase3'
+    if (maxBossHP > 0) {
+      const pct = (spec.bossHP / maxBossHP) * 100
+      if (pct <= 25) return 'phase3'
+      if (pct <= 50) return 'phase2'
+    }
+    return 'phase1'
+  })()
   // During room 2 transition, bossHP=0 is stale from room 1 — not a real victory
   const inRoomTransition = (spec.currentRoom || 1) === 2 && spec.bossHP <= 0 && allMonstersDead && (spec.room2BossHP || 0) > 0
   const gameOver = isDefeated || (!inRoomTransition && spec.bossHP <= 0 && allMonstersDead)
@@ -1229,14 +1248,20 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
               else if (inCombatB && bossState === 'ready') bAction = 'attack'
               if (!inCombatB && (status?.victory || spec.bossHP <= 0)) bAction = 'victory'
               const bossName = `${dungeonName}-boss`
+              const phaseClass = bossState === 'ready' ? (bossPhase === 'phase3' ? ' boss-phase3' : bossPhase === 'phase2' ? ' boss-phase2' : '') : ''
               return (
-                <div className={`arena-entity boss-entity`}
+                <div className={`arena-entity boss-entity${phaseClass}`}
                   style={{ top: '40%', left: '50%' }}
                   role={bossState === 'ready' && !gameOver && !attackPhase ? 'button' : undefined}
                   tabIndex={bossState === 'ready' && !gameOver && !attackPhase ? 0 : undefined}
                   aria-label={`Boss · HP: ${spec.bossHP}/${maxBossHP}${bossState === 'defeated' ? ' (defeated)' : ''}`}
                   onKeyDown={bossState === 'ready' && !gameOver && !attackPhase ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onAttack(bossName, 0) } } : undefined}>
                   {floatingDmg?.target?.includes('boss') && <div className="floating-dmg" style={{ color: '#e94560' }}>{floatingDmg.amount}</div>}
+                  {bossState === 'ready' && bossPhase !== 'phase1' && (
+                    <div className={`boss-phase-badge ${bossPhase}`}>
+                      {bossPhase === 'phase2' ? '🔥 ENRAGED' : '💀 BERSERK'}
+                    </div>
+                  )}
                   <Sprite spriteType={(spec.currentRoom || 1) === 2 ? 'bat-boss' : 'dragon'} action={bAction} size={144} />
                   <div className="arena-shadow" style={{ width: 120 }} />
                   <div className="arena-hover-ui">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -688,6 +688,43 @@ body {
   100% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
 }
 
+/* Boss phase visual effects */
+.boss-entity.boss-phase2 { filter: drop-shadow(0 0 10px #ff8800) drop-shadow(0 0 20px #ff4400); }
+.boss-entity.boss-phase3 { filter: drop-shadow(0 0 12px #ff0000) drop-shadow(0 0 24px #cc0000); animation: bossEntrance 0.8s ease-out, berserkPulse 1.2s ease-in-out infinite; }
+@keyframes berserkPulse {
+  0%, 100% { filter: drop-shadow(0 0 12px #ff0000) drop-shadow(0 0 24px #cc0000); }
+  50% { filter: drop-shadow(0 0 20px #ff3333) drop-shadow(0 0 40px #ff0000); }
+}
+
+/* Boss phase badge */
+.boss-phase-badge {
+  position: absolute;
+  top: -48px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: 'Press Start 2P', monospace;
+  font-size: 7px;
+  padding: 3px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+  z-index: 10;
+  animation: phaseBadgePulse 1.5s ease-in-out infinite;
+}
+.boss-phase-badge.phase2 {
+  background: rgba(255, 136, 0, 0.9);
+  color: #fff;
+  border: 1px solid #ff8800;
+}
+.boss-phase-badge.phase3 {
+  background: rgba(204, 0, 0, 0.9);
+  color: #fff;
+  border: 1px solid #ff0000;
+}
+@keyframes phaseBadgePulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
 /* Hero entity */
 .hero-entity { z-index: 3; }
 

--- a/manifests/rgds/boss-graph.yaml
+++ b/manifests/rgds/boss-graph.yaml
@@ -12,11 +12,15 @@ spec:
     spec:
       dungeonName: string | required=true
       hp: integer | required=true
+      maxHP: integer | default=400
       difficulty: string | default="normal"
       monstersAlive: integer | default=1
     status:
       entityState: "${bossState.data.entityState}"
       hp: "${bossState.data.hp}"
+      phase: "${bossState.data.phase}"
+      damageMultiplier: "${bossState.data.damageMultiplier}"
+      specialAttackChance: "${bossState.data.specialAttackChance}"
 
   resources:
     - id: bossState
@@ -30,9 +34,44 @@ spec:
             game.k8s.example/dungeon: ${schema.spec.dungeonName}
             game.k8s.example/entity: boss
             game.k8s.example/state: "${schema.spec.hp > 0 ? (schema.spec.monstersAlive == 0 ? 'ready' : 'pending') : 'defeated'}"
+            game.k8s.example/phase: >-
+              ${
+                schema.spec.hp <= 0 ? 'defeated' :
+                schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 50 ? 'phase1' :
+                schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 25 ? 'phase2' :
+                'phase3'
+              }
         data:
           entityState: "${schema.spec.hp > 0 ? (schema.spec.monstersAlive == 0 ? 'ready' : 'pending') : 'defeated'}"
           hp: "${string(schema.spec.hp)}"
+          # Phase derived from HP % of maxHP:
+          #   Phase 1: >50% HP  (100-51%)
+          #   Phase 2: >25% HP  (50-26%)
+          #   Phase 3: >0% HP   (25-1%)
+          #   Phase defeated:   HP == 0
+          phase: >-
+            ${
+              schema.spec.hp <= 0 ? 'defeated' :
+              schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 50 ? 'phase1' :
+              schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 25 ? 'phase2' :
+              'phase3'
+            }
+          # Damage multiplier per phase: 1.0x / 1.5x / 2.0x (stored as integer *10)
+          damageMultiplier: >-
+            ${
+              schema.spec.hp <= 0 ? '10' :
+              schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 50 ? '10' :
+              schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 25 ? '15' :
+              '20'
+            }
+          # Special attack chance per phase: 20% / 40% / 60%
+          specialAttackChance: >-
+            ${
+              schema.spec.hp <= 0 ? '0' :
+              schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 50 ? '20' :
+              schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 25 ? '40' :
+              '60'
+            }
 
     # Loot CR — boss always drops on kill (hp == 0), always rare or epic
     #

--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -45,6 +45,9 @@ spec:
     status:
       livingMonsters: "${size(monsterCRs.filter(m, m.status.?entityState.orValue('alive') == 'alive'))}"
       bossState: "${bossCR.status.?entityState.orValue('pending')}"
+      bossPhase: "${bossCR.status.?phase.orValue('phase1')}"
+      bossDamageMultiplier: "${bossCR.status.?damageMultiplier.orValue('10')}"
+      bossSpecialAttackChance: "${bossCR.status.?specialAttackChance.orValue('20')}"
       victory: "${bossCR.status.?entityState.orValue('pending') == 'defeated'}"
       defeat: "${heroCR.status.?entityState.orValue('alive') == 'defeated'}"
       loot: "${treasureCR.status.?loot.orValue('')}"
@@ -111,6 +114,7 @@ spec:
         spec:
           dungeonName: ${schema.metadata.name}
           hp: ${schema.spec.bossHP}
+          maxHP: "${schema.spec.difficulty == 'easy' ? 200 : schema.spec.difficulty == 'hard' ? 800 : 400}"
           difficulty: ${schema.spec.difficulty}
           monstersAlive: "${size(schema.spec.monsterHP.filter(hp, hp > 0))}"
 

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -339,6 +339,17 @@ grep -q "KRO_STATUS_TIPS" frontend/src/App.tsx && pass "Status bar kro tooltips 
 [ -f "frontend/src/KroTeach.tsx" ] && pass "KroTeach.tsx exists" || fail "KroTeach.tsx missing"
 [ -f "frontend/src/KroGraph.tsx" ] && pass "KroGraph.tsx exists" || fail "KroGraph.tsx missing"
 
+# --- Multi-phase boss guardrails ---
+echo "=== Multi-phase boss guardrails"
+grep -q "phase.*phase1\|phase.*phase2\|phase.*phase3" manifests/rgds/boss-graph.yaml && pass "boss-graph derives phase from HP thresholds" || fail "boss-graph missing phase derivation"
+grep -q "damageMultiplier" manifests/rgds/boss-graph.yaml && pass "boss-graph exposes damageMultiplier in status" || fail "boss-graph missing damageMultiplier"
+grep -q "bossPhase" manifests/rgds/dungeon-graph.yaml && pass "dungeon-graph exposes bossPhase in status" || fail "dungeon-graph missing bossPhase status field"
+grep -q "bossDamageMultiplier" manifests/rgds/dungeon-graph.yaml && pass "dungeon-graph exposes bossDamageMultiplier in status" || fail "dungeon-graph missing bossDamageMultiplier status field"
+grep -q "bossDamageMultiplier\|bossDmgMultiplier" backend/internal/handlers/handlers.go && pass "Backend reads bossDamageMultiplier and applies to counter-attack" || fail "Backend not reading bossDamageMultiplier"
+grep -q "boss-phase2\|boss-phase3" frontend/src/App.tsx && pass "Frontend applies boss phase CSS classes" || fail "Frontend missing boss phase CSS classes"
+grep -q "boss-phase-badge" frontend/src/App.tsx && pass "Frontend renders boss phase badge" || fail "Frontend missing boss phase badge"
+grep -q "ENRAGED\|BERSERK" frontend/src/App.tsx && pass "Frontend emits phase transition events to combat log" || fail "Frontend missing phase transition log events"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

- **boss-graph RGD**: adds `phase` (phase1/phase2/phase3/defeated), `damageMultiplier` (×1.0/×1.5/×2.0 stored as int×10), and `specialAttackChance` (20%/40%/60%) derived from HP % via CEL. `maxHP` is now passed from dungeon-graph so the threshold math is correct per difficulty.
- **dungeon-graph RGD**: exposes `bossPhase`, `bossDamageMultiplier`, `bossSpecialAttackChance` in status via CEL aggregation from Boss CR.
- **Backend**: reads `bossDamageMultiplier` from dungeon status and multiplies base counter-attack damage. Phase note appended to enemy action string (`[ENRAGED ×1.5]` / `[BERSERK ×2.0]`).
- **Frontend**: boss entity gets `boss-phase2` (orange glow) or `boss-phase3` (red pulsing glow) CSS class. Phase badge (`🔥 ENRAGED` / `💀 BERSERK`) renders above sprite when active. Phase transition events emitted to combat log at 50% and 25% HP thresholds.
- **Guardrails**: 8 new checks covering RGD fields, backend integration, and frontend rendering.

Closes #25