### PR TITLE
fix: CelTrace stun/dodge, manaAfterEpic CEL inversion, KroGraph lootSecret nodes

### DIFF
--- a/frontend/src/KroGraph.tsx
+++ b/frontend/src/KroGraph.tsx
@@ -159,6 +159,19 @@ export function buildGraph(cr: DungeonCR, reconciling: boolean): { nodes: GraphN
       detail: lootExists ? 'dropped on kill' : 'includeWhen: hp==0',
     })
     edges.push({ from: mcmId, to: lootId, label: 'includeWhen', dashed: true })
+
+    // lootSecret Secret (created by loot-graph when Loot CR exists)
+    const lootSecretId = `loot-secret-m${i}`
+    nodes.push({
+      id: lootSecretId,
+      label: 'LootSecret',
+      kind: 'Secret',
+      state: lootExists ? 'ok' : 'locked',
+      exists: lootExists,
+      concept: 'secrets',
+      detail: lootExists ? 'item data in Secret' : 'created by loot-graph',
+    })
+    edges.push({ from: lootId, to: lootSecretId, label: 'loot-graph', dashed: !lootExists })
   }
   if (monsterHP.length > 4) {
     nodes.push({
@@ -214,6 +227,18 @@ export function buildGraph(cr: DungeonCR, reconciling: boolean): { nodes: GraphN
     detail: bossLootExists ? 'guaranteed drop' : 'includeWhen: hp==0',
   })
   edges.push({ from: 'boss-cm', to: 'boss-loot', label: 'includeWhen', dashed: true })
+
+  // Boss lootSecret Secret (created by loot-graph)
+  nodes.push({
+    id: 'boss-loot-secret',
+    label: 'BossLootSecret',
+    kind: 'Secret',
+    state: bossLootExists ? 'ok' : 'locked',
+    exists: bossLootExists,
+    concept: 'secrets',
+    detail: bossLootExists ? 'boss item in Secret' : 'created by loot-graph',
+  })
+  edges.push({ from: 'boss-loot', to: 'boss-loot-secret', label: 'loot-graph', dashed: !bossLootExists })
 
   // Treasure CR
   const treasureState: NodeState = treasureOpened ? 'ok' : 'pending'

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -695,6 +695,33 @@ export function CelTrace({ data, onLearnMore }: { data: CelTraceData; onLearnMor
     })
   }
 
+  // Stun: hero skipped attack this turn
+  if (data.heroAction.includes('STUNNED')) {
+    celLines.push({
+      expr: `schema.spec.stunTurns > 0`,
+      result: 'true',
+      note: 'hero stunned — attack skipped, stunTurns decremented',
+    })
+  }
+
+  // Rogue dodge
+  if (data.heroAction.includes('dodged') || data.heroAction.includes('Rogue dodged')) {
+    celLines.push({
+      expr: `schema.spec.heroClass == 'rogue' && seededRoll < 25`,
+      result: 'true',
+      note: '25% dodge chance — counter-attack negated',
+    })
+  }
+
+  // Backstab
+  if (data.heroAction.includes('Backstab') || data.heroAction.includes('backstab')) {
+    celLines.push({
+      expr: `schema.spec.backstabCooldown == 0 ? damage * 3 : damage`,
+      result: dmgMatch ? String(Number(dmgMatch[1])) : '3x',
+      note: 'Backstab: 3× damage, sets cooldown=3',
+    })
+  }
+
   return (
     <div className="cel-trace">
       <button className="cel-trace-toggle" onClick={() => setOpen(o => !o)}>

--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -255,7 +255,7 @@ spec:
           # === MANA POTION ===
           manaAfterCommon: "${string(schema.spec.heroMana + 2 < 8 ? schema.spec.heroMana + 2 : 8)}"
           manaAfterRare:   "${string(schema.spec.heroMana + 3 < 8 ? schema.spec.heroMana + 3 : 8)}"
-          manaAfterEpic:   "${string(schema.spec.heroMana + 8 < 8 ? schema.spec.heroMana + 8 : 8)}"
+          manaAfterEpic:   "${string(schema.spec.heroMana + 8 > 8 ? 8 : schema.spec.heroMana + 8)}"
 
           # === EQUIP WEAPON ===
           weaponBonusCommon: "5"


### PR DESCRIPTION
## Bug fixes (3 issues)

### #200 — CelTrace missing stun/dodge branches
Added `celLines` entries in `KroTeach.tsx` for:
- STUNNED path: shows `schema.spec.stunTurns > 0 → true` with note about attack skip
- Rogue dodge: shows `seededRoll < 25 → true` 25% dodge expression
- Backstab: shows `backstabCooldown == 0 ? damage * 3` expression

### #201 — manaAfterEpic CEL condition inverted
`heroMana + 8 < 8` was always false → epic mana potion identical to common. Fixed to `heroMana + 8 > 8 ? 8 : heroMana + 8` (correct cap at max mana 8).

**Note:** requires `kubectl delete rgd dungeon-graph` after deploy for kro to pick up the RGD schema change.

### #202 — KroGraph missing lootSecret leaf nodes
Each monster Loot CR and the boss Loot CR now have a child `Secret` node (loot-graph output) that appears when `hp==0`. Completes the `monster-graph → Loot CR → lootSecret` chain and makes the `secrets` concept concrete in the graph.

Closes #200, Closes #201, Closes #202