### PR TITLE
feat: kro Expert certificate on dungeon victory (#203)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import { PixelIcon } from './PixelIcon'
 import {
   InsightCard, KroConceptModal, KroGlossary,
   useKroGlossary, getInsightForEvent, kroAnnotate,
-  KRO_STATUS_TIPS, CelTrace, type CelTraceData,
+  KRO_STATUS_TIPS, CelTrace, KroExpertCertificate, type CelTraceData,
   type InsightTrigger, type KroConceptId,
 } from './KroTeach'
 import { KroGraphPanel } from './KroGraph'
@@ -976,6 +976,16 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
   // During room 2 transition, bossHP=0 is stale from room 1 — not a real victory
   const inRoomTransition = (spec.currentRoom || 1) === 2 && spec.bossHP <= 0 && allMonstersDead && (spec.room2BossHP || 0) > 0
   const gameOver = isDefeated || (!inRoomTransition && spec.bossHP <= 0 && allMonstersDead)
+  const isVictory = gameOver && !isDefeated && (spec.currentRoom || 1) === 2
+  const [showCertificate, setShowCertificate] = useState(false)
+  // Auto-show certificate once on room-2 victory
+  const certShownRef = useRef(false)
+  useEffect(() => {
+    if (isVictory && !certShownRef.current) {
+      certShownRef.current = true
+      setTimeout(() => setShowCertificate(true), 800)
+    }
+  }, [isVictory])
   const [showDoorModal, setShowDoorModal] = useState(false)
   const [doorPassword, setDoorPassword] = useState('')
   const autoTriggeredRef = useRef('')
@@ -1122,10 +1132,23 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
       )}
 
       {gameOver && !isDefeated && (spec.currentRoom || 1) === 2 && (
-        <div className="victory-banner">
+        <div className="victory-banner" style={{ cursor: 'pointer' }} onClick={() => setShowCertificate(true)}>
           <h2><PixelIcon name="crown" size={18} /> VICTORY! <PixelIcon name="crown" size={18} /></h2>
           <p className="loot">The dungeon has been conquered!</p>
+          <p style={{ fontSize: 7, color: 'var(--text-dim)', marginTop: 4 }}>Click for your kro certificate →</p>
         </div>
+      )}
+
+      {showCertificate && (
+        <KroExpertCertificate
+          dungeonName={dungeonName}
+          heroClass={spec.heroClass || 'warrior'}
+          difficulty={spec.difficulty || 'normal'}
+          turns={spec.attackSeq || 0}
+          unlocked={kroUnlocked}
+          k8sLog={k8sLog}
+          onClose={() => setShowCertificate(false)}
+        />
       )}
 
       {lootDrop && !combatModal && (

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -722,13 +722,90 @@ export function CelTrace({ data, onLearnMore }: { data: CelTraceData; onLearnMor
                   <td className="cel-trace-note">{l.note || ''}</td>
                 </tr>
               ))}
-            </tbody>
+             </tbody>
           </table>
           <button className="k8s-annotation-learn" onClick={onLearnMore} style={{ marginTop: 4 }}>
             Learn: cel-basics →
           </button>
         </div>
       )}
+    </div>
+  )
+}
+
+// ─── kro Expert Certificate ──────────────────────────────────────────────────
+
+export interface KroExpertCertificateProps {
+  dungeonName: string
+  heroClass: string
+  difficulty: string
+  turns: number
+  unlocked: Set<KroConceptId>
+  k8sLog: { ts: string; cmd: string; res: string }[]
+  onClose: () => void
+}
+
+export function KroExpertCertificate({ dungeonName, heroClass, difficulty, turns, unlocked, k8sLog, onClose }: KroExpertCertificateProps) {
+  const total = CONCEPT_ORDER.length
+  const count = unlocked.size
+  const isMaster = count === total
+  const title = isMaster ? 'kro Master' : count >= 9 ? 'kro Expert' : count >= 4 ? 'kro Practitioner' : 'kro Apprentice'
+
+  const handleCopyKubectl = () => {
+    const cmds = k8sLog
+      .filter(e => e.cmd.startsWith('kubectl'))
+      .map(e => `# ${e.res}\n${e.cmd}`)
+      .join('\n\n')
+    navigator.clipboard.writeText(cmds).catch(() => {/* ignore */})
+  }
+
+  return (
+    <div className="kro-cert-overlay" onClick={onClose}>
+      <div className="kro-cert-modal" onClick={e => e.stopPropagation()}>
+        <div className="kro-cert-header">
+          <div className="kro-cert-badge">{isMaster ? '👑' : '🎓'}</div>
+          <div className="kro-cert-title">{title}</div>
+          <div className="kro-cert-subtitle">Certificate of Completion</div>
+        </div>
+
+        <div className="kro-cert-body">
+          <div className="kro-cert-field"><span className="kro-cert-label">Dungeon</span><span className="kro-cert-value">{dungeonName}</span></div>
+          <div className="kro-cert-field"><span className="kro-cert-label">Hero</span><span className="kro-cert-value">{heroClass} · {difficulty}</span></div>
+          <div className="kro-cert-field"><span className="kro-cert-label">Turns</span><span className="kro-cert-value">{turns}</span></div>
+          <div className="kro-cert-field"><span className="kro-cert-label">kro Concepts</span><span className="kro-cert-value" style={{ color: isMaster ? '#f5c518' : '#4ade80' }}>{count}/{total}</span></div>
+        </div>
+
+        <div className="kro-cert-concepts">
+          <div className="kro-cert-section-title">Concepts Mastered</div>
+          <div className="kro-cert-concept-grid">
+            {CONCEPT_ORDER.map(id => {
+              const c = KRO_CONCEPTS[id]
+              const done = unlocked.has(id)
+              return (
+                <div key={id} className={`kro-cert-concept ${done ? 'done' : 'locked'}`}>
+                  <span className="kro-cert-concept-check">{done ? '✓' : '○'}</span>
+                  <span className="kro-cert-concept-name">{c.title.split('(')[0].trim()}</span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        {!isMaster && (
+          <div className="kro-cert-hint">
+            Play again to unlock all {total} concepts and earn <strong>kro Master</strong>!
+          </div>
+        )}
+
+        <div className="kro-cert-actions">
+          <button className="btn btn-primary" onClick={handleCopyKubectl} style={{ fontSize: 8 }}>
+            📋 Copy kubectl commands
+          </button>
+          <button className="btn" onClick={onClose} style={{ fontSize: 8 }}>
+            Close
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1326,3 +1326,37 @@ body {
 .cel-trace-expr { color: #9b59b6; font-family: 'Press Start 2P', monospace; }
 .cel-trace-val  { color: #00ff41; white-space: nowrap; }
 .cel-trace-note { color: #555; }
+
+/* ─── kro Expert Certificate ──────────────────────────────────────────────── */
+.kro-cert-overlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.85); z-index: 2000;
+  display: flex; align-items: center; justify-content: center;
+}
+.kro-cert-modal {
+  background: #0a0e1a; border: 2px solid #f5c518; border-radius: 6px;
+  padding: 24px; max-width: 480px; width: 90%; font-family: 'Press Start 2P', monospace;
+  box-shadow: 0 0 40px rgba(245,197,24,0.3);
+  animation: certEntrance 0.4s ease-out;
+}
+@keyframes certEntrance {
+  0% { opacity: 0; transform: scale(0.85); }
+  100% { opacity: 1; transform: scale(1); }
+}
+.kro-cert-header { text-align: center; margin-bottom: 20px; }
+.kro-cert-badge { font-size: 32px; margin-bottom: 8px; }
+.kro-cert-title { font-size: 14px; color: #f5c518; margin-bottom: 4px; }
+.kro-cert-subtitle { font-size: 7px; color: #888; }
+.kro-cert-body { border: 1px solid #1a2a3a; border-radius: 4px; padding: 12px; margin-bottom: 16px; }
+.kro-cert-field { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+.kro-cert-field:last-child { margin-bottom: 0; }
+.kro-cert-label { font-size: 7px; color: #888; }
+.kro-cert-value { font-size: 8px; color: #eee; }
+.kro-cert-section-title { font-size: 7px; color: #888; margin-bottom: 10px; }
+.kro-cert-concept-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-bottom: 16px; }
+.kro-cert-concept { display: flex; align-items: center; gap: 6px; font-size: 6px; }
+.kro-cert-concept.done { color: #4ade80; }
+.kro-cert-concept.locked { color: #444; }
+.kro-cert-concept-check { font-size: 8px; }
+.kro-cert-hint { font-size: 7px; color: #888; text-align: center; margin-bottom: 16px; line-height: 1.8; }
+.kro-cert-hint strong { color: #f5c518; }
+.kro-cert-actions { display: flex; gap: 8px; justify-content: center; }


### PR DESCRIPTION
## Summary

On Room 2 victory, the banner now auto-opens a **kro Expert Certificate** modal after 0.8s. The banner itself is also clickable to re-open it.

### Certificate features
- Title tier: **kro Apprentice** (0-3) → **kro Practitioner** (4-8) → **kro Expert** (9-12) → **kro Master** (13/13)
- Shows dungeon name, hero class, difficulty, turn count, concepts unlocked (N/13)
- Concept grid: all 13 concepts shown as ✓ (green) or ○ (locked grey)
- If not 13/13: hint to replay to earn kro Master
- **"Copy kubectl commands"** button copies filtered k8sLog kubectl entries to clipboard
- Pixel-art gold-border modal with entrance animation

### Why
Transforms "you won" into "you learned something you can use on Monday." Direct payoff for the primary vision — players leave with a tangible summary of what kro concepts they exercised.

Closes #203