### PR TITLE
feat: first-run onboarding, 2 new kro concepts, 4 bug fixes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import { PixelIcon } from './PixelIcon'
 import {
   InsightCard, KroConceptModal, KroGlossary,
   useKroGlossary, getInsightForEvent, kroAnnotate,
-  KRO_STATUS_TIPS, CelTrace, KroExpertCertificate, type CelTraceData,
+  KRO_STATUS_TIPS, CelTrace, KroExpertCertificate, KroOnboardingOverlay, KRO_CONCEPTS, type CelTraceData,
   type InsightTrigger, type KroConceptId,
 } from './KroTeach'
 import { KroGraphPanel } from './KroGraph'
@@ -55,6 +55,7 @@ export default function App() {
   const attackingRef = useRef(false)
   const [roomLoading, setRoomLoading] = useState(false)
   const [showHelp, setShowHelp] = useState(false)
+  const [showOnboarding, setShowOnboarding] = useState(() => !localStorage.getItem('kroOnboardingDone'))
   const [showCheat, setShowCheat] = useState(false)
   const [deleting, setDeleting] = useState<Set<string>>(new Set())
   const [resumePrompt, setResumePrompt] = useState<{ ns: string; name: string } | null>(null)
@@ -139,6 +140,11 @@ export default function App() {
               if (d.spec.modifier && d.spec.modifier !== 'none') triggerInsight('modifier-present')
               // Teach resource chaining once status is populated (Hero CR → dungeon status)
               if (d.status?.maxHeroHP) triggerInsight('resource-chaining')
+              // Teach status.conditions when kro reports an error/not-ready condition
+              const conditions = (d.status?.conditions as any[]) || []
+              if (conditions.some((c: any) => c.type === 'Error' || (c.type === 'Ready' && c.status === 'False'))) {
+                triggerInsight('status-conditions')
+              }
             }
             return
           } catch {
@@ -234,8 +240,11 @@ export default function App() {
       const crField = isItem ? `action: ${target}` : `target: ${target}\n  damage: ${damage}`
       addK8s(`kubectl apply -f ${crKind.toLowerCase()}.yaml`, `${crKind.toLowerCase()}.game.k8s.example created`,
         `apiVersion: game.k8s.example/v1alpha1\nkind: ${crKind}\nmetadata:\n  name: ${selected.name}-${target}-${Date.now() % 100000}\nspec:\n  dungeonName: ${selected.name}\n  dungeonNamespace: ${selected.ns}\n  ${crField}`)
-      // Teach: Attack CR = empty RGD pattern; first combat attack = CEL basics
-      if (!isItem && !isAbility) triggerInsight('attack-cr')
+      // Teach: Attack CR = empty RGD pattern; first combat attack = CEL basics; externalRef watch loop
+      if (!isItem && !isAbility) {
+        triggerInsight('attack-cr')
+        triggerInsight('externalRef')
+      }
 
       let updated = detail!
 
@@ -470,6 +479,7 @@ export default function App() {
 
       {!selected ? (
         <>
+          {showOnboarding && <KroOnboardingOverlay onDismiss={() => setShowOnboarding(false)} />}
           <CreateForm onCreate={handleCreate} />
           {resumePrompt && (
             <div className="card" style={{ borderColor: '#f5c518', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, padding: '8px 12px' }}>
@@ -682,7 +692,7 @@ function EventLogTabs({ events, k8sLog, kroUnlocked, onViewKroConcept }: {
         <button className={`log-tab${tab === 'game' ? ' active' : ''}`} onClick={() => setTab('game')}>Game Log</button>
         <button className={`log-tab${tab === 'k8s' ? ' active' : ''}`} onClick={() => setTab('k8s')}>K8s Log</button>
         <button className={`log-tab kro-tab${tab === 'kro' ? ' active' : ''}`} onClick={() => setTab('kro')}>
-          kro ({kroUnlocked.size}/13)
+          kro ({kroUnlocked.size}/{Object.keys(KRO_CONCEPTS).length})
         </button>
       </div>
 
@@ -974,7 +984,7 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
     return 'phase1'
   })()
   // During room 2 transition, bossHP=0 is stale from room 1 — not a real victory
-  const inRoomTransition = (spec.currentRoom || 1) === 2 && spec.bossHP <= 0 && allMonstersDead && (spec.room2BossHP || 0) > 0
+  const inRoomTransition = (spec.currentRoom || 1) === 2 && spec.bossHP <= 0 && allMonstersDead && (spec.room2BossHP || 0) > 0 && (spec.room2MonsterHP?.length ?? 0) > 0
   const gameOver = isDefeated || (!inRoomTransition && spec.bossHP <= 0 && allMonstersDead)
   const isVictory = gameOver && !isDefeated && (spec.currentRoom || 1) === 2
   const [showCertificate, setShowCertificate] = useState(false)

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -26,6 +26,8 @@ export type KroConceptId =
   | 'secret-output'
   | 'empty-rgd'
   | 'spec-mutation'
+  | 'externalRef'
+  | 'status-conditions'
 
 export interface KroConcept {
   id: KroConceptId
@@ -322,6 +324,58 @@ spec:
     learnMore: 'manifests/rgds/attack-graph.yaml and action-graph.yaml',
   },
 
+  'externalRef': {
+    id: 'externalRef',
+    title: 'externalRef — Watch External CRs to Trigger Reconcile',
+    tagline: 'kro can watch CRs it does not own and re-reconcile when they change.',
+    body: `Every time you attack, the backend creates an Attack CR. The dungeon-graph RGD watches this Attack CR via \`externalRef\` and immediately re-reconciles the full Dungeon resource graph — recomputing CEL expressions, updating ConfigMaps, deriving new boss phase, and writing the combat result.
+
+This is how the entire combat engine works: not a Job, not a webhook, but a kro watch loop. When the Attack CR changes, kro re-runs all CEL in dungeon-graph and the result ConfigMap is updated within seconds.`,
+    snippet: `# dungeon-graph watches the Attack CR via externalRef
+# Any change to <dungeonName>-latest-attack triggers full reconcile
+resources:
+  - id: combatResult
+    template:
+      apiVersion: v1
+      kind: ConfigMap
+      data:
+        # These CEL expressions re-evaluate on every Attack CR upsert:
+        diceRoll: >-
+          \${
+            schema.spec.difficulty == 'hard' ? string(
+              int('abcdef...'.indexOf(random.seededString(1, schema.spec.lastCombatLog + 'd1')) % 20)
+              + ... + 8
+            ) : ...
+          }`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — combatResult ConfigMap',
+  },
+
+  'status-conditions': {
+    id: 'status-conditions',
+    title: 'status.conditions — kro Health Signalling',
+    tagline: 'kro uses status.conditions to report whether your resource graph is Ready or has Errors.',
+    body: `Every kro-managed CR gets a \`status.conditions\` array automatically. kro writes two condition types:
+- \`type: Ready\` — the resource graph is fully reconciled and all readyWhen checks passed
+- \`type: Error\` — kro hit a problem (CEL evaluation error, missing dependency, webhook timeout)
+
+You just saw a kro condition in the engine warning banner. This is the same mechanism Kubernetes uses for Pods (\`PodReady\`, \`ContainersReady\`) and Deployments (\`Available\`, \`Progressing\`). kro follows the same contract.`,
+    snippet: `# kubectl get dungeon <name> -o yaml
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: ReconcileSucceeded
+      message: All resources reconciled
+    - type: Error
+      status: "False"
+      reason: CELEvaluationFailed
+      message: "cel: no such attribute: schema.spec.missingField"
+  # All other status fields are your CEL expressions:
+  bossState: ready
+  livingMonsters: "2"`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — status block',
+  },
+
   'spec-mutation': {
     id: 'spec-mutation',
     title: 'Spec Mutation Triggers Full Reconcile',
@@ -360,6 +414,8 @@ export function getInsightForEvent(event: string): InsightTrigger | null {
   if (event === 'forEach') return { conceptId: 'forEach', headline: 'kro created one Monster CR per entry in monsterHP[] via forEach' }
   if (event === 'loot-drop') return { conceptId: 'seeded-random', headline: 'Loot type and rarity rolled via random.seededString() in monster-graph' }
   if (event === 'attack-cr') return { conceptId: 'empty-rgd', headline: 'Attack CR is defined by an RGD with resources:[] — a CRD factory' }
+  if (event === 'externalRef') return { conceptId: 'externalRef', headline: 'Your attack created an Attack CR — kro watched it and re-reconciled the dungeon graph' }
+  if (event === 'status-conditions') return { conceptId: 'status-conditions', headline: 'kro is reporting its reconcile status via status.conditions — the Kubernetes health contract' }
   return null
 }
 
@@ -468,6 +524,7 @@ const CONCEPT_ORDER: KroConceptId[] = [
   'rgd', 'spec-schema', 'resource-chaining', 'cel-basics', 'cel-ternary',
   'forEach', 'includeWhen', 'readyWhen', 'status-aggregation',
   'seeded-random', 'secret-output', 'empty-rgd', 'spec-mutation',
+  'externalRef', 'status-conditions',
 ]
 
 interface KroGlossaryProps {
@@ -649,13 +706,12 @@ export function CelTrace({ data, onLearnMore }: { data: CelTraceData; onLearnMor
     result: `"${data.formula}"`,
     note: 'from gameConfig ConfigMap',
   })
-  if (log.seq) {
-    celLines.push({
-      expr: `random.seededString(lastCombatLog, alphabet, 8)`,
-      result: `"${data.combatLog.slice(0, 8)}..."`,
-      note: 'seeded → deterministic',
-    })
-  }
+  // Always show seeded-random row — even on first attack when combatLog is empty
+  celLines.push({
+    expr: `random.seededString(lastCombatLog, alphabet, 8)`,
+    result: `"${(data.combatLog || '(new-seed)').slice(0, 8)}..."`,
+    note: 'seeded → deterministic roll',
+  })
   if (log.weaponBonus > 0) {
     celLines.push({
       expr: `schema.spec.weaponBonus`,
@@ -832,6 +888,95 @@ export function KroExpertCertificate({ dungeonName, heroClass, difficulty, turns
             Close
           </button>
         </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── First-Run Onboarding Overlay ────────────────────────────────────────────
+
+const ONBOARDING_SLIDES = [
+  {
+    title: 'Your Dungeon is a Kubernetes CR',
+    body: 'When you create a dungeon, the frontend runs:\nkubectl apply -f dungeon.yaml\nYou are about to apply a real Custom Resource to a live EKS cluster.',
+    snippet: `apiVersion: game.k8s.example/v1alpha1
+kind: Dungeon
+metadata:
+  name: my-dungeon
+spec:
+  monsters: 3
+  difficulty: normal
+  heroClass: warrior`,
+  },
+  {
+    title: 'kro Creates 7 Resources From One CR',
+    body: "kro's dungeon-graph RGD watches your Dungeon CR. The moment you apply it, kro automatically creates a Namespace, Hero CR, Monster CRs, Boss CR, Treasure CR, and two ConfigMaps — all from a single spec.",
+    snippet: `# dungeon-graph RGD orchestrates:
+resources:
+  - id: ns          # Namespace
+  - id: heroCR      # Hero CR → hero-graph
+  - id: monsterCRs  # Monster CR ×N (forEach)
+  - id: bossCR      # Boss CR → boss-graph
+  - id: treasureCR  # Treasure CR → treasure-graph
+  - id: gameConfig  # ConfigMap
+  - id: combatResult # ConfigMap (CEL combat engine)`,
+  },
+  {
+    title: 'Every Action is a kubectl patch',
+    body: 'When you attack, equip an item, or open a door, the backend runs a kubectl patch on the Dungeon CR spec. kro watches the change and re-reconciles the entire resource graph within seconds.',
+    snippet: `# Attack → backend patches Dungeon CR
+kubectl patch dungeon my-dungeon --type=merge \\
+  -p '{"spec": {"bossHP": 350, "heroHP": 180,
+       "lastHeroAction": "Hero deals 50 damage"}}'
+# kro re-evaluates all CEL → updates ConfigMaps`,
+  },
+  {
+    title: 'Watch the kro Tab as You Play',
+    body: "Open the kro tab in the event log to see concepts unlock in real time. Each game event maps to a kro pattern. By the end of the dungeon, you'll have seen 15 core kro concepts in action.",
+    snippet: `# Concepts you'll unlock:
+✓ ResourceGraphDefinition (RGD)
+✓ spec.schema validation
+✓ forEach fan-out
+✓ includeWhen conditional resources
+✓ CEL expressions
+✓ externalRef watch loop
+  ... and 9 more`,
+  },
+]
+
+export function KroOnboardingOverlay({ onDismiss }: { onDismiss: () => void }) {
+  const [slide, setSlide] = useState(0)
+  const total = ONBOARDING_SLIDES.length
+  const s = ONBOARDING_SLIDES[slide]
+  const isLast = slide === total - 1
+
+  const handleDismiss = () => {
+    localStorage.setItem('kroOnboardingDone', '1')
+    onDismiss()
+  }
+
+  return (
+    <div className="kro-onboard-overlay">
+      <div className="kro-onboard-modal">
+        <div className="kro-onboard-header">
+          <span className="kro-insight-badge">kro</span>
+          <span className="kro-onboard-step">{slide + 1} / {total}</span>
+        </div>
+        <div className="kro-onboard-title">{s.title}</div>
+        <div className="kro-onboard-body">{s.body}</div>
+        <pre className="kro-onboard-snippet">{s.snippet}</pre>
+        <div className="kro-onboard-actions">
+          {slide > 0 && (
+            <button className="btn" onClick={() => setSlide(slide - 1)} style={{ fontSize: 8 }}>← Back</button>
+          )}
+          <div style={{ flex: 1 }} />
+          {isLast ? (
+            <button className="btn btn-primary" onClick={handleDismiss} style={{ fontSize: 8 }}>Start Playing →</button>
+          ) : (
+            <button className="btn btn-primary" onClick={() => setSlide(slide + 1)} style={{ fontSize: 8 }}>Next →</button>
+          )}
+        </div>
+        <button className="kro-onboard-skip" onClick={handleDismiss}>Skip intro</button>
       </div>
     </div>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1360,3 +1360,32 @@ body {
 .kro-cert-hint { font-size: 7px; color: #888; text-align: center; margin-bottom: 16px; line-height: 1.8; }
 .kro-cert-hint strong { color: #f5c518; }
 .kro-cert-actions { display: flex; gap: 8px; justify-content: center; }
+
+/* ─── kro Onboarding Overlay ─────────────────────────────────────────────── */
+.kro-onboard-overlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.92); z-index: 2100;
+  display: flex; align-items: center; justify-content: center;
+}
+.kro-onboard-modal {
+  background: #0a0e1a; border: 2px solid #00ff41; border-radius: 6px;
+  padding: 28px; max-width: 500px; width: 92%; font-family: 'Press Start 2P', monospace;
+  box-shadow: 0 0 40px rgba(0,255,65,0.15);
+  animation: certEntrance 0.3s ease-out;
+  position: relative;
+}
+.kro-onboard-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
+.kro-onboard-step { font-size: 7px; color: #555; }
+.kro-onboard-title { font-size: 11px; color: #00ff41; margin-bottom: 12px; line-height: 1.6; }
+.kro-onboard-body { font-size: 8px; color: #ccc; margin-bottom: 14px; line-height: 2; white-space: pre-line; }
+.kro-onboard-snippet {
+  background: #050810; border: 1px solid #1a2a3a; border-radius: 3px;
+  padding: 10px; font-size: 7px; color: #9b59b6; line-height: 1.8;
+  margin-bottom: 16px; overflow-x: auto; white-space: pre;
+}
+.kro-onboard-actions { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
+.kro-onboard-skip {
+  display: block; width: 100%; background: none; border: none;
+  color: #444; font-family: 'Press Start 2P', monospace; font-size: 7px;
+  cursor: pointer; text-align: center; padding: 4px;
+}
+.kro-onboard-skip:hover { color: #888; }


### PR DESCRIPTION
## Summary

### #204 — First-run onboarding overlay
4-slide modal shown once (localStorage `kroOnboardingDone`) before first dungeon creation:
1. Your Dungeon is a Kubernetes CR (shows YAML)
2. kro creates 7 resources from one CR (shows RGD resource list)
3. Every action is a kubectl patch (shows patch command)
4. Watch the kro tab as you play (concept preview)
Skip button + Next/Back navigation. Pixel-art green-border style.

### #211 — `externalRef` concept (15th concept)
The watch/trigger loop that makes the combat engine work — how dungeon-graph re-reconciles when an Attack CR is upserted. Fires on first attack. Added to CONCEPT_ORDER.

### #212 — `status-conditions` concept (15th → 16th concept)
kro's health signalling via `status.conditions`. Fires when the engine warning banner shows an error condition. YAML snippet shows both Ready and Error condition types.

### #208 — CelTrace always shows seeded-random row
Previously gated on `log.seq` — invisible on the first attack of any session. Now always rendered with `data.combatLog || '(new-seed)'`.

### #209 — Glossary tab badge uses dynamic count
`/13` hardcode replaced with `Object.keys(KRO_CONCEPTS).length` — now `{N}/15` automatically as concepts are added.

### #210 — inRoomTransition race condition guard
Added `&& (spec.room2MonsterHP?.length ?? 0) > 0` to prevent false VICTORY flash during the room-transition polling window.

Closes #204, Closes #208, Closes #209, Closes #210, Closes #211, Closes #212