### PR TITLE
feat: RGD diff viewer, shield fix, warrior multiplier (#205 #214 #215)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -678,11 +678,12 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			counter = applyModifierToCounter(modifier, counter)
 			if armorBonus > 0 {
 				counter = counter * (100 - armorBonus) / 100
-				if shieldBonus > 0 {
-					if seededRoll(attackUID+"-shield", 100) < shieldBonus {
-						counter = 0
-						classNote += " Shield blocked!"
-					}
+			}
+			// Shield block is independent of armor — works even with no armor equipped
+			if shieldBonus > 0 && counter > 0 {
+				if seededRoll(attackUID+"-shield", 100) < shieldBonus {
+					counter = 0
+					classNote += " Shield blocked!"
 				}
 			}
 			if heroClass == "warrior" {
@@ -849,10 +850,17 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 		if armorBonus > 0 {
 			totalCounter = totalCounter * (100 - armorBonus) / 100
 		}
+		// Shield block is independent of armor — works even with no armor equipped
+		if shieldBonus > 0 && totalCounter > 0 {
+			if seededRoll(attackUID+"-shield-m", 100) < shieldBonus {
+				totalCounter = 0
+				classNote += " Shield blocked!"
+			}
+		}
 		enemyAction := ""
 		if totalCounter > 0 {
 			if heroClass == "warrior" {
-				totalCounter = totalCounter * 4 / 5
+				totalCounter = totalCounter * 3 / 4 // 25% reduction (consistent with boss path)
 			} else if heroClass == "rogue" {
 				if seededRoll(attackUID+"-dodge-monster", 100) < 25 {
 					totalCounter = 0

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ export default function App() {
   const [detail, setDetail] = useState<DungeonCR | null>(null)
   const detailRef = useRef(detail)
   detailRef.current = detail
+  const prevDetailRef = useRef<DungeonCR | null>(null)
   const [events, setEvents] = useState<WSEvent[]>([])
   const [k8sLog, setK8sLog] = useState<{ ts: string; cmd: string; res: string; yaml?: string }[]>([])
   const addK8s = (cmd: string, res: string, yaml?: string) => {
@@ -91,6 +92,7 @@ export default function App() {
       const sel = selectedRef.current
       if (sel) {
         const d = await getDungeon(sel.ns, sel.name)
+        prevDetailRef.current = detailRef.current
         setDetail(d)
       }
       consecutiveFailures.current = 0
@@ -112,6 +114,7 @@ export default function App() {
     if (lastEvent?.type === 'DUNGEON_UPDATE' && lastEvent.payload && selected) {
       const cr = lastEvent.payload as DungeonCR
       if (cr?.metadata?.name === selected.name) {
+        prevDetailRef.current = detailRef.current
         setDetail(cr)
       }
       // WS delivered the full CR — skip redundant HTTP round-trip while connected
@@ -134,6 +137,7 @@ export default function App() {
           try {
             const d = await getDungeon(selected.ns, selected.name)
             if (!cancelled) {
+              prevDetailRef.current = detailRef.current
               setDetail(d)
               setLoading(false)
               // Teach modifier concept if this dungeon has one
@@ -497,6 +501,7 @@ export default function App() {
       ) : detail ? (
         <DungeonView
           cr={detail}
+          prevCr={prevDetailRef.current}
           onBack={() => { navigate('/'); refresh() }}
           onAttack={handleAttack}
           attackPhase={attackPhase}
@@ -943,8 +948,8 @@ function HelpModal({ onClose, onCheat }: { onClose: () => void; onCheat: () => v
     </div>
   )
 }
-function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, showCheat, onToggleCheat, floatingDmg, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError, kroUnlocked, onViewKroConcept, reconciling }: {
-  cr: DungeonCR; onBack: () => void; onAttack: (t: string, d: number) => void; events: WSEvent[]; k8sLog: { ts: string; cmd: string; res: string; yaml?: string }[]
+function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, showCheat, onToggleCheat, floatingDmg, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError, kroUnlocked, onViewKroConcept, reconciling }: {
+  cr: DungeonCR; prevCr?: DungeonCR | null; onBack: () => void; onAttack: (t: string, d: number) => void; events: WSEvent[]; k8sLog: { ts: string; cmd: string; res: string; yaml?: string }[]
   showLoot: boolean; onOpenLoot: () => void; onCloseLoot: () => void
   attackPhase: string | null; roomLoading: boolean
   animPhase: string; attackTarget: string | null
@@ -1518,7 +1523,7 @@ function DungeonView({ cr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoo
         </div>
       </div>
 
-      <KroGraphPanel cr={cr} reconciling={reconciling} onViewConcept={onViewKroConcept} />
+      <KroGraphPanel cr={cr} prevCr={prevCr} reconciling={reconciling} onViewConcept={onViewKroConcept} />
 
       <EventLogTabs events={events} k8sLog={k8sLog} kroUnlocked={kroUnlocked} onViewKroConcept={onViewKroConcept} />
     </div>

--- a/frontend/src/KroGraph.tsx
+++ b/frontend/src/KroGraph.tsx
@@ -660,12 +660,88 @@ export function KroGraph({ cr, reconciling, onNodeClick }: KroGraphProps) {
 
 interface KroGraphPanelProps {
   cr: DungeonCR
+  prevCr?: DungeonCR | null
   reconciling: boolean
   onViewConcept: (id: KroConceptId) => void
 }
 
-export function KroGraphPanel({ cr, reconciling, onViewConcept }: KroGraphPanelProps) {
+interface DiffEntry {
+  field: string
+  from: string
+  to: string
+  note?: string
+}
+
+function computeRGDDiff(prev: DungeonCR | null | undefined, curr: DungeonCR): DiffEntry[] {
+  if (!prev) return []
+  const diff: DiffEntry[] = []
+  const ps: any = prev.spec || {}
+  const cs: any = curr.spec || {}
+  const pst: any = prev.status || {}
+  const cst: any = curr.status || {}
+
+  const check = (field: string, note?: string) => {
+    const a = ps[field], b = cs[field]
+    if (a !== b && (a !== undefined || b !== undefined)) {
+      diff.push({ field, from: String(a ?? '—'), to: String(b ?? '—'), note })
+    }
+  }
+  const checkSt = (field: string, note?: string) => {
+    const a = pst[field], b = cst[field]
+    if (a !== b && (a !== undefined || b !== undefined)) {
+      diff.push({ field: `status.${field}`, from: String(a ?? '—'), to: String(b ?? '—'), note })
+    }
+  }
+
+  check('heroHP', 'spec.heroHP')
+  check('bossHP', 'spec.bossHP')
+  check('heroMana', 'spec.heroMana')
+  check('poisonTurns', 'spec.poisonTurns')
+  check('burnTurns', 'spec.burnTurns')
+  check('stunTurns', 'spec.stunTurns')
+  check('weaponBonus', 'spec.weaponBonus')
+  check('weaponUses', 'spec.weaponUses')
+  check('armorBonus', 'spec.armorBonus')
+  check('currentRoom', 'spec.currentRoom')
+  check('treasureOpened', 'spec.treasureOpened')
+  check('doorUnlocked', 'spec.doorUnlocked')
+  check('lastLootDrop', 'spec.lastLootDrop')
+
+  // monsterHP array — show per-index changes
+  const pm: number[] = (ps.monsterHP as number[]) || []
+  const cm: number[] = (cs.monsterHP as number[]) || []
+  const maxM = Math.max(pm.length, cm.length)
+  for (let i = 0; i < maxM; i++) {
+    if ((pm[i] ?? -1) !== (cm[i] ?? -1)) {
+      const killed = (pm[i] ?? 0) > 0 && (cm[i] ?? 0) === 0
+      diff.push({ field: `spec.monsterHP[${i}]`, from: String(pm[i] ?? '—'), to: String(cm[i] ?? '—'), note: killed ? '→ Loot CR includeWhen fires' : undefined })
+    }
+  }
+
+  checkSt('livingMonsters', 'kro re-aggregated from Monster CRs')
+  checkSt('bossState', 'boss-graph CEL ternary')
+  checkSt('bossPhase', 'boss-graph phase CEL')
+  checkSt('victory', 'dungeon-graph status')
+  checkSt('defeat', 'dungeon-graph status')
+
+  return diff
+}
+
+export function KroGraphPanel({ cr, prevCr, reconciling, onViewConcept }: KroGraphPanelProps) {
   const [collapsed, setCollapsed] = useState(false)
+  const [diff, setDiff] = useState<DiffEntry[]>([])
+  const [diffVisible, setDiffVisible] = useState(false)
+  const diffTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const entries = computeRGDDiff(prevCr, cr)
+    if (entries.length > 0) {
+      setDiff(entries)
+      setDiffVisible(true)
+      if (diffTimerRef.current) clearTimeout(diffTimerRef.current)
+      diffTimerRef.current = setTimeout(() => setDiffVisible(false), 8000)
+    }
+  }, [cr?.spec?.attackSeq, cr?.spec?.actionSeq])
 
   return (
     <div className="kro-graph-panel">
@@ -695,6 +771,32 @@ export function KroGraphPanel({ cr, reconciling, onViewConcept }: KroGraphPanelP
           <div className="kro-graph-scroll">
             <KroGraph cr={cr} reconciling={reconciling} onNodeClick={onViewConcept} />
           </div>
+
+          {/* RGD Diff Viewer — transient before→after on every reconcile */}
+          {diffVisible && diff.length > 0 && (
+            <div className="kro-rgd-diff">
+              <div className="kro-rgd-diff-header">
+                <span className="kro-insight-badge" style={{ fontSize: 6 }}>kro</span>
+                <span style={{ fontSize: 7, color: '#00d4ff', marginLeft: 6 }}>What just changed (spec patch → kro reconcile)</span>
+                <button
+                  onClick={() => setDiffVisible(false)}
+                  style={{ marginLeft: 'auto', background: 'none', border: 'none', color: '#555', cursor: 'pointer', fontFamily: 'inherit', fontSize: 10 }}
+                >✕</button>
+              </div>
+              <div className="kro-rgd-diff-rows">
+                {diff.map((d, i) => (
+                  <div key={i} className="kro-rgd-diff-row">
+                    <span className="kro-rgd-diff-field">{d.field}</span>
+                    <span className="kro-rgd-diff-from">{d.from}</span>
+                    <span className="kro-rgd-diff-arrow">→</span>
+                    <span className="kro-rgd-diff-to">{d.to}</span>
+                    {d.note && <span className="kro-rgd-diff-note">{d.note}</span>}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
           <div className="kro-graph-hint">
             Hover nodes for details · Click to learn the kro concept
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1268,6 +1268,71 @@ body {
   letter-spacing: 0.5px;
 }
 
+/* ─── RGD Diff Viewer (graph panel) ─────────────────────────────────────── */
+
+.kro-rgd-diff {
+  margin-top: 8px;
+  border: 1px solid #0f3460;
+  border-radius: 3px;
+  background: #05070f;
+  overflow: hidden;
+  animation: slideInBottom 0.2s ease;
+}
+
+.kro-rgd-diff-header {
+  display: flex;
+  align-items: center;
+  padding: 4px 8px;
+  background: #0a0f20;
+  border-bottom: 1px solid #0f3460;
+  gap: 4px;
+}
+
+.kro-rgd-diff-rows {
+  padding: 4px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  max-height: 120px;
+  overflow-y: auto;
+}
+
+.kro-rgd-diff-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 6px;
+  font-family: 'Press Start 2P', monospace;
+  flex-wrap: wrap;
+}
+
+.kro-rgd-diff-field {
+  color: #7ec8e3;
+  min-width: 120px;
+}
+
+.kro-rgd-diff-from {
+  color: #ff6b6b;
+  text-decoration: line-through;
+}
+
+.kro-rgd-diff-arrow {
+  color: #555;
+}
+
+.kro-rgd-diff-to {
+  color: #6bff8e;
+  font-weight: bold;
+}
+
+.kro-rgd-diff-note {
+  color: #00d4ff;
+  font-size: 5px;
+  font-style: italic;
+  margin-left: 4px;
+  opacity: 0.8;
+}
+
 /* ─── CEL Trace (combat modal) ───────────────────────────────────────────── */
 
 .cel-trace {


### PR DESCRIPTION
## Summary
- Adds RGD Diff Viewer in the kro Graph panel: after every reconcile, shows a transient (8s) field-level before→after table of spec and status changes, with kro teaching annotations (e.g. "→ Loot CR includeWhen fires" when a monster HP hits 0)
- Fixes shield block being nested inside the armor check — shield now works independently even with no armor equipped (#214)
- Fixes Warrior damage reduction multiplier from 4/5 (20%) to 3/4 (25%), consistent with the Warrior class description (#215)

Closes #205
Closes #214
Closes #215