### PR TITLE
feat: victory replay button + stats, modifier badge on list tiles (#217 #218)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -231,6 +231,7 @@ func (h *Handler) ListDungeons(w http.ResponseWriter, r *http.Request) {
 		LivingMonsters interface{} `json:"livingMonsters"`
 		BossState      interface{} `json:"bossState"`
 		Victory        interface{} `json:"victory"`
+		Modifier       interface{} `json:"modifier"`
 	}
 	items := []summary{}
 	for _, d := range list.Items {
@@ -246,6 +247,7 @@ func (h *Handler) ListDungeons(w http.ResponseWriter, r *http.Request) {
 			LivingMonsters: status["livingMonsters"],
 			BossState:      status["bossState"],
 			Victory:        status["victory"],
+			Modifier:       spec["modifier"],
 		})
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -613,6 +613,11 @@ function DungeonList({ dungeons, onSelect, onDelete, deleting, lastDungeon }: {
             <span className={`tag tag-${d.difficulty}`}>{d.difficulty}</span>
             <span>Monsters: {d.livingMonsters ?? '?'}</span>
             <span>Boss: {d.bossState === 'pending' ? 'Locked' : d.bossState === 'ready' ? 'Ready' : d.bossState === 'defeated' ? 'Defeated' : d.bossState ?? '?'}</span>
+            {d.modifier && d.modifier !== 'none' && (
+              <span className={`tag tag-modifier-${d.modifier.startsWith('curse') ? 'curse' : 'blessing'}`} title={d.modifier}>
+                {d.modifier.startsWith('curse') ? '⚠' : '✦'} {d.modifier.replace(/^(curse|blessing)-/, '')}
+              </span>
+            )}
             {d.victory && <span className="victory">VICTORY!</span>}
             {!d.victory && <span style={{ color: 'var(--green)' }}>In Progress</span>}
           </div>
@@ -1143,14 +1148,33 @@ function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, o
         <div className="defeat-banner">
           <h2><PixelIcon name="skull" size={18} /> DEFEAT <PixelIcon name="skull" size={18} /></h2>
           <p className="defeat-text">Your hero has fallen...</p>
+          <div style={{ marginTop: 8 }}>
+            <button className="btn" style={{ fontSize: 7 }} onClick={onBack}>← New Dungeon</button>
+          </div>
         </div>
       )}
 
       {gameOver && !isDefeated && (spec.currentRoom || 1) === 2 && (
-        <div className="victory-banner" style={{ cursor: 'pointer' }} onClick={() => setShowCertificate(true)}>
+        <div className="victory-banner">
           <h2><PixelIcon name="crown" size={18} /> VICTORY! <PixelIcon name="crown" size={18} /></h2>
           <p className="loot">The dungeon has been conquered!</p>
-          <p style={{ fontSize: 7, color: 'var(--text-dim)', marginTop: 4 }}>Click for your kro certificate →</p>
+          <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap', margin: '8px 0', fontSize: 7, color: 'var(--text-dim)' }}>
+            <span>Turns: <span style={{ color: 'var(--gold)' }}>{spec.attackSeq ?? 0}</span></span>
+            <span>Hero: <span style={{ color: 'var(--gold)' }}>{spec.heroClass ?? 'warrior'}</span></span>
+            <span>Difficulty: <span style={{ color: 'var(--gold)' }}>{spec.difficulty}</span></span>
+            {spec.weaponBonus ? <span>⚔ Weapon +{spec.weaponBonus}</span> : null}
+            {spec.armorBonus ? <span>🛡 Armor {spec.armorBonus}%</span> : null}
+            {spec.helmetBonus ? <span>⛑ Helmet +{spec.helmetBonus}%crit</span> : null}
+            {spec.pantsBonus ? <span>👖 Pants +{spec.pantsBonus}%dodge</span> : null}
+          </div>
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'center', marginTop: 8 }}>
+            <button className="btn btn-gold" style={{ fontSize: 7 }} onClick={() => setShowCertificate(true)}>
+              View kro Certificate →
+            </button>
+            <button className="btn" style={{ fontSize: 7 }} onClick={onBack}>
+              ← New Dungeon
+            </button>
+          </div>
         </div>
       )}
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,6 +3,7 @@ const BASE = '/api/v1'
 export interface DungeonSummary {
   name: string; namespace: string; difficulty: string
   livingMonsters: number | null; bossState: string | null; victory: boolean | null
+  modifier?: string | null
 }
 
 // GetDungeon now returns the raw Dungeon CR — all state is in spec + status

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -94,6 +94,8 @@ body {
 .tag-easy { color: var(--green); border-color: var(--green); }
 .tag-normal { color: var(--gold); border-color: var(--gold); }
 .tag-hard { color: var(--accent); border-color: var(--accent); }
+.tag-modifier-curse { color: #e74c3c; border-color: #e74c3c; }
+.tag-modifier-blessing { color: #2ecc71; border-color: #2ecc71; }
 
 /* Create Form */
 .ns-filter { display: flex; gap: 6px; margin-bottom: 12px; }


### PR DESCRIPTION
## Summary
- Victory banner now shows turn count, hero class, difficulty, equipped weapon/armor/helmet/pants stats, plus a "New Dungeon" button (calls onBack) and a "View kro Certificate" button — no more dead end after Room 2 win
- Defeat banner gets a "New Dungeon" button too
- Dungeon list tiles now show a modifier badge (curse = red ⚠, blessing = green ✦) so players can distinguish dungeons at a glance
- Backend ListDungeons adds `modifier` field from `spec.modifier`; `api.ts` DungeonSummary updated

Closes #217
Closes #218