### PR TITLE
feat: forEach fan-out ×N count in graph, reconcile-loop concept + spinner link (#223 #224)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -391,6 +391,8 @@ export default function App() {
         if (newDeadCount > prevDeadCount) triggerInsight('monster-killed')
         // First attack
         if ((detail?.spec.attackSeq ?? 0) === 0 && (updated.spec.attackSeq ?? 0) > 0) triggerInsight('first-attack')
+        // Second attack — teach the reconcile loop concept
+        if ((detail?.spec.attackSeq ?? 0) === 1 && (updated.spec.attackSeq ?? 0) > 1) triggerInsight('second-attack')
       }
 
       // Don't clear attackPhase/attackTarget — user must dismiss combat modal
@@ -1112,6 +1114,7 @@ function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, o
                 <div style={{ marginTop: 8, fontSize: 6, color: '#2a4a6a', textAlign: 'center', lineHeight: 1.8 }}>
                   <span className="kro-insight-badge" style={{ fontSize: 5 }}>kro</span>
                   {' '}dungeon-graph reconciling → combatResult CEL computing {combatModal.formula}
+                  {' '}<button onClick={() => onViewKroConcept('reconcile-loop')} style={{ background: 'none', border: 'none', color: '#00d4ff', cursor: 'pointer', fontSize: 6, fontFamily: 'inherit', padding: 0, textDecoration: 'underline' }}>what is this?</button>
                 </div>
               </>
             ) : (

--- a/frontend/src/KroGraph.tsx
+++ b/frontend/src/KroGraph.tsx
@@ -116,7 +116,8 @@ export function buildGraph(cr: DungeonCR, reconciling: boolean): { nodes: GraphN
   edges.push({ from: 'hero', to: 'hero-cm', label: 'hero-graph' })
 
   // Monster CRs (show up to 4 collapsed if more)
-  const showMonsters = Math.min(monsterHP.length, 4)
+  const totalMonsters = monsterHP.length
+  const showMonsters = Math.min(totalMonsters, 4)
   for (let i = 0; i < showMonsters; i++) {
     const hp = monsterHP[i]
     const mState: NodeState = reconciling && hp > 0 ? 'reconciling' : hp > 0 ? 'alive' : 'dead'
@@ -128,10 +129,11 @@ export function buildGraph(cr: DungeonCR, reconciling: boolean): { nodes: GraphN
       state: mState,
       exists: true,
       concept: 'forEach',
-      detail: `HP: ${hp}/${status?.maxMonsterHP ?? '?'}`,
+      detail: `HP: ${hp}/${status?.maxMonsterHP ?? '?'} · forEach item ${i + 1}/${totalMonsters}`,
       pulse: reconciling && hp > 0,
     })
-    edges.push({ from: 'dungeon', to: mId, label: i === 0 ? 'forEach' : undefined })
+    // First edge shows forEach ×N count to make fan-out visible
+    edges.push({ from: 'dungeon', to: mId, label: i === 0 ? `forEach ×${totalMonsters}` : undefined })
 
     // monsterState ConfigMap
     const mcmId = `monster-cm-${i}`
@@ -173,15 +175,15 @@ export function buildGraph(cr: DungeonCR, reconciling: boolean): { nodes: GraphN
     })
     edges.push({ from: lootId, to: lootSecretId, label: 'loot-graph', dashed: !lootExists })
   }
-  if (monsterHP.length > 4) {
+  if (totalMonsters > 4) {
     nodes.push({
       id: 'monster-more',
-      label: `+${monsterHP.length - 4} more`,
+      label: `+${totalMonsters - 4} more`,
       kind: 'Monster CR',
       state: 'ok',
       exists: true,
       concept: 'forEach',
-      detail: `${monsterHP.length - 4} additional monsters`,
+      detail: `${totalMonsters - 4} additional monsters (forEach ×${totalMonsters} total)`,
     })
     edges.push({ from: 'dungeon', to: 'monster-more' })
   }

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -28,6 +28,7 @@ export type KroConceptId =
   | 'spec-mutation'
   | 'externalRef'
   | 'status-conditions'
+  | 'reconcile-loop'
 
 export interface KroConcept {
   id: KroConceptId
@@ -376,6 +377,31 @@ status:
     learnMore: 'manifests/rgds/dungeon-graph.yaml — status block',
   },
 
+  'reconcile-loop': {
+    id: 'reconcile-loop',
+    title: 'The kro Reconcile Loop',
+    tagline: 'Every action triggers a watch → eval → write cycle. The ~1s pause IS kro working.',
+    body: `After every attack or action, the game waits ~1 second before showing results. That pause is the kro reconcile loop:
+
+1. **Watch** — kro's controller detects the Dungeon CR spec changed (attackSeq incremented)
+2. **CEL eval** — dungeon-graph re-evaluates all CEL expressions: dice rolls, HP calculations, loot includeWhen checks
+3. **Resource write** — kro writes the combatResult ConfigMap with the results
+4. **Backend read** — the Go backend polls until attackSeq in the ConfigMap matches, then reads the results
+5. **Frontend update** — the React app receives the updated CR and re-renders
+
+This is standard Kubernetes controller-reconciler pattern. Every controller in your cluster does the same loop — Deployments, StatefulSets, HPA — just for different resource types.`,
+    snippet: `# The poll loop in the Go backend
+for {
+  cr, _ := client.Get(ctx, dungeonName)
+  if cr.Spec.AttackSeq > prevSeq {
+    // kro has reconciled — read results
+    break
+  }
+  time.Sleep(500 * time.Millisecond)
+}`,
+    learnMore: 'backend/internal/handlers/handlers.go — processCombat poll loop',
+  },
+
   'spec-mutation': {
     id: 'spec-mutation',
     title: 'Spec Mutation Triggers Full Reconcile',
@@ -416,6 +442,7 @@ export function getInsightForEvent(event: string): InsightTrigger | null {
   if (event === 'attack-cr') return { conceptId: 'empty-rgd', headline: 'Attack CR is defined by an RGD with resources:[] — a CRD factory' }
   if (event === 'externalRef') return { conceptId: 'externalRef', headline: 'Your attack created an Attack CR — kro watched it and re-reconciled the dungeon graph' }
   if (event === 'status-conditions') return { conceptId: 'status-conditions', headline: 'kro is reporting its reconcile status via status.conditions — the Kubernetes health contract' }
+  if (event === 'second-attack') return { conceptId: 'reconcile-loop', headline: 'The ~1s pause after every action is the kro reconcile loop: watch → CEL eval → write' }
   return null
 }
 
@@ -524,7 +551,7 @@ const CONCEPT_ORDER: KroConceptId[] = [
   'rgd', 'spec-schema', 'resource-chaining', 'cel-basics', 'cel-ternary',
   'forEach', 'includeWhen', 'readyWhen', 'status-aggregation',
   'seeded-random', 'secret-output', 'empty-rgd', 'spec-mutation',
-  'externalRef', 'status-conditions',
+  'externalRef', 'status-conditions', 'reconcile-loop',
 ]
 
 interface KroGlossaryProps {


### PR DESCRIPTION
## Summary
- **#223 forEach fan-out**: The `forEach` edge label in the kro Resource Graph now shows `forEach ×N` (actual monster count). Monster node tooltips show `forEach item i/N`. The "+more" node tooltip also reflects the full count.
- **#224 Reconcile loop concept**: Added `reconcile-loop` as the 16th kro concept in the glossary. Explains the watch → CEL eval → resource write → backend poll cycle and why the ~1s pause exists. The "Waiting for attack to resolve..." text in the combat modal spinner now has a clickable "what is this?" link to the concept. InsightCard fires on the second attack.

Closes #223
Closes #224