### PR TITLE
feat: Room 1 cleared celebration overlay — 3s banner on boss kill (#227)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1006,6 +1006,18 @@ function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, o
       setTimeout(() => setShowCertificate(true), 800)
     }
   }, [isVictory])
+
+  // Room 1 cleared celebration — show for 3s when boss defeated in room 1
+  const [showRoom1Cleared, setShowRoom1Cleared] = useState(false)
+  const room1ClearedRef = useRef(false)
+  const room1IsCleared = (spec.currentRoom || 1) === 1 && spec.bossHP <= 0 && allMonstersDead && !isDefeated
+  useEffect(() => {
+    if (room1IsCleared && !room1ClearedRef.current) {
+      room1ClearedRef.current = true
+      setShowRoom1Cleared(true)
+      setTimeout(() => setShowRoom1Cleared(false), 3000)
+    }
+  }, [room1IsCleared])
   const [showDoorModal, setShowDoorModal] = useState(false)
   const [doorPassword, setDoorPassword] = useState('')
   const autoTriggeredRef = useRef('')
@@ -1408,6 +1420,14 @@ function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, o
             {/* Victory glow */}
             {/* Flying bats */}
             <DungeonBats />
+
+            {/* Room 1 cleared — 3s celebration overlay */}
+            {showRoom1Cleared && (
+              <div className="arena-room1-cleared">
+                <div className="arena-room1-cleared-text">★ ROOM CLEARED! ★</div>
+                <div style={{ fontSize: 7, color: 'var(--text-dim)', marginTop: 6 }}>Treasure awaits...</div>
+              </div>
+            )}
 
             {status?.victory && <div className="arena-victory-glow" />}
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -773,6 +773,35 @@ body {
 .arena-atk-btn { font-size: 7px !important; padding: 2px 6px !important; }
 
 /* Victory glow overlay */
+/* Room 1 cleared celebration overlay */
+.arena-room1-cleared {
+  position: absolute; inset: 0;
+  border-radius: inherit;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 25;
+  pointer-events: none;
+  animation: room1ClearedIn 0.4s ease;
+}
+.arena-room1-cleared-text {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 13px;
+  color: var(--gold);
+  text-shadow: 0 0 16px rgba(245,197,24,0.8), 0 0 32px rgba(245,197,24,0.4);
+  animation: room1ClearedPulse 0.6s ease-in-out 3;
+}
+@keyframes room1ClearedIn {
+  from { opacity: 0; transform: scale(0.85); }
+  to   { opacity: 1; transform: scale(1); }
+}
+@keyframes room1ClearedPulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.08); }
+}
+
 .arena-victory-glow {
   position: absolute; inset: 0;
   border-radius: inherit;


### PR DESCRIPTION
## Summary
- After defeating the Room 1 boss, a 3-second "★ ROOM CLEARED! ★" overlay appears in the arena with a scale-in animation and gold text glow
- The overlay is non-interactive (pointer-events: none) and auto-dismisses after 3s
- Prevents the jump directly into treasure/door UI feeling abrupt
- Uses a `useRef` guard so the animation only fires once per dungeon visit

Closes #227