### PR TITLE
feat: DoT floating damage numbers, boss phase transition flash+shake (#226 #228)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -212,6 +212,7 @@ export default function App() {
   }
 
   const [floatingDmg, setFloatingDmg] = useState<{ target: string; amount: string; color: string } | null>(null)
+  const [bossPhaseFlash, setBossPhaseFlash] = useState<'enraged' | 'berserk' | null>(null)
 
   const [combatModal, setCombatModal] = useState<{ phase: 'rolling' | 'resolved'; formula: string; heroAction: string; enemyAction: string; spec: any; oldHP: number } | null>(null)
 
@@ -382,9 +383,32 @@ export default function App() {
         const newMaxBossHP = Number(updated.status?.maxBossHP) || prevMaxBossHP
         const prevPct = newMaxBossHP > 0 ? (prevBossHP / newMaxBossHP) * 100 : 100
         const newPct = newMaxBossHP > 0 ? (newBossHP / newMaxBossHP) * 100 : 100
-        if (prevPct > 50 && newPct <= 50 && newBossHP > 0) addEvent('🔥', '⚠️ The boss becomes ENRAGED! (Phase 2: ×1.5 damage)')
-        if (prevPct > 25 && newPct <= 25 && newBossHP > 0) addEvent('💀', '💀 BERSERK MODE! Boss attacks with fury! (Phase 3: ×2.0 damage)')
+        if (prevPct > 50 && newPct <= 50 && newBossHP > 0) {
+          addEvent('🔥', '⚠️ The boss becomes ENRAGED! (Phase 2: ×1.5 damage)')
+          setBossPhaseFlash('enraged')
+          setTimeout(() => setBossPhaseFlash(null), 1500)
+        }
+        if (prevPct > 25 && newPct <= 25 && newBossHP > 0) {
+          addEvent('💀', '💀 BERSERK MODE! Boss attacks with fury! (Phase 3: ×2.0 damage)')
+          setBossPhaseFlash('berserk')
+          setTimeout(() => setBossPhaseFlash(null), 1500)
+        }
         if ((updated.spec.heroHP ?? 100) <= 0 && (detail?.spec.heroHP ?? 100) > 0) addEvent('💀', 'Hero has fallen...')
+        // DoT floating damage on hero
+        const prevHeroHP = detail?.spec.heroHP ?? 100
+        const newHeroHP = updated.spec.heroHP ?? 100
+        const hpDropped = newHeroHP < prevHeroHP
+        const poisonActive = (detail?.spec.poisonTurns ?? 0) > 0
+        const burnActive = (detail?.spec.burnTurns ?? 0) > 0
+        if (hpDropped && (poisonActive || burnActive)) {
+          const dotDmg = prevHeroHP - newHeroHP
+          // Only show DoT float if the drop is consistent with DoT amounts
+          if (dotDmg === 5 || dotDmg === 8 || (dotDmg > 0 && dotDmg <= 13)) {
+            const color = poisonActive ? '#2ecc71' : '#e74c3c'
+            setFloatingDmg({ target: 'hero', amount: `-${dotDmg}`, color })
+            setTimeout(() => setFloatingDmg(null), 1200)
+          }
+        }
         // Detect monster kill
         const prevDeadCount = (detail?.spec.monsterHP || []).filter((hp: number) => hp <= 0).length
         const newDeadCount = (updated.spec.monsterHP || []).filter((hp: number) => hp <= 0).length
@@ -511,6 +535,7 @@ export default function App() {
           animPhase={animPhase}
           attackTarget={attackTarget}
           floatingDmg={floatingDmg}
+          bossPhaseFlash={bossPhaseFlash}
           combatModal={combatModal}
           onDismissCombat={dismissCombat}
           lootDrop={lootDrop}
@@ -955,7 +980,7 @@ function HelpModal({ onClose, onCheat }: { onClose: () => void; onCheat: () => v
     </div>
   )
 }
-function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, showCheat, onToggleCheat, floatingDmg, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError, kroUnlocked, onViewKroConcept, reconciling }: {
+function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, showCheat, onToggleCheat, floatingDmg, bossPhaseFlash, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError, kroUnlocked, onViewKroConcept, reconciling }: {
   cr: DungeonCR; prevCr?: DungeonCR | null; onBack: () => void; onAttack: (t: string, d: number) => void; events: WSEvent[]; k8sLog: { ts: string; cmd: string; res: string; yaml?: string }[]
   showLoot: boolean; onOpenLoot: () => void; onCloseLoot: () => void
   attackPhase: string | null; roomLoading: boolean
@@ -963,6 +988,7 @@ function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, o
   showHelp: boolean; onToggleHelp: () => void
   showCheat: boolean; onToggleCheat: () => void
   floatingDmg: { target: string; amount: string; color: string } | null
+  bossPhaseFlash: 'enraged' | 'berserk' | null
   combatModal: { phase: string; formula: string; heroAction: string; enemyAction: string; spec: any; oldHP: number } | null
   onDismissCombat: () => void
   lootDrop: string | null; onDismissLoot: () => void
@@ -1329,14 +1355,20 @@ function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, o
               if (!inCombatB && (status?.victory || spec.bossHP <= 0)) bAction = 'victory'
               const bossName = `${dungeonName}-boss`
               const phaseClass = bossState === 'ready' ? (bossPhase === 'phase3' ? ' boss-phase3' : bossPhase === 'phase2' ? ' boss-phase2' : '') : ''
+              const phaseFlashClass = bossPhaseFlash ? ` boss-phase-flash-${bossPhaseFlash}` : ''
               return (
-                <div className={`arena-entity boss-entity${phaseClass}`}
+                <div className={`arena-entity boss-entity${phaseClass}${phaseFlashClass}`}
                   style={{ top: '40%', left: '50%' }}
                   role={bossState === 'ready' && !gameOver && !attackPhase ? 'button' : undefined}
                   tabIndex={bossState === 'ready' && !gameOver && !attackPhase ? 0 : undefined}
                   aria-label={`Boss · HP: ${spec.bossHP}/${maxBossHP}${bossState === 'defeated' ? ' (defeated)' : ''}`}
                   onKeyDown={bossState === 'ready' && !gameOver && !attackPhase ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onAttack(bossName, 0) } } : undefined}>
                   {floatingDmg?.target?.includes('boss') && <div className="floating-dmg" style={{ color: '#e94560' }}>{floatingDmg.amount}</div>}
+                  {bossPhaseFlash && (
+                    <div className={`boss-phase-flash-overlay ${bossPhaseFlash}`}>
+                      {bossPhaseFlash === 'enraged' ? '🔥 ENRAGED!' : '💀 BERSERK!'}
+                    </div>
+                  )}
                   {bossState === 'ready' && bossPhase !== 'phase1' && (
                     <div className={`boss-phase-badge ${bossPhase}`}>
                       {bossPhase === 'phase2' ? '🔥 ENRAGED' : '💀 BERSERK'}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -727,6 +727,52 @@ body {
   50% { opacity: 0.7; }
 }
 
+/* Boss phase transition flash overlay */
+.boss-phase-flash-overlay {
+  position: absolute;
+  top: -60px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  padding: 4px 8px;
+  border-radius: 3px;
+  white-space: nowrap;
+  z-index: 15;
+  animation: phaseFlashIn 1.5s ease forwards;
+  pointer-events: none;
+}
+.boss-phase-flash-overlay.enraged {
+  background: rgba(255, 100, 0, 0.95);
+  color: #fff;
+  border: 1px solid #ff8800;
+  box-shadow: 0 0 16px #ff8800, 0 0 32px #ff4400;
+}
+.boss-phase-flash-overlay.berserk {
+  background: rgba(180, 0, 0, 0.95);
+  color: #fff;
+  border: 1px solid #ff0000;
+  box-shadow: 0 0 16px #ff0000, 0 0 32px #cc0000;
+}
+@keyframes phaseFlashIn {
+  0%   { opacity: 0; transform: translateX(-50%) scale(0.6); }
+  20%  { opacity: 1; transform: translateX(-50%) scale(1.2); }
+  40%  { transform: translateX(-50%) scale(1); }
+  70%  { opacity: 1; }
+  100% { opacity: 0; transform: translateX(-50%) scale(1) translateY(-12px); }
+}
+
+/* Boss entity shake on phase transition */
+.boss-phase-flash-enraged { animation: bossEntrance 0.8s ease-out, bossShake 0.4s ease 0.1s; }
+.boss-phase-flash-berserk { animation: bossEntrance 0.8s ease-out, bossShake 0.4s ease 0.1s, bossShake 0.3s ease 0.6s; }
+@keyframes bossShake {
+  0%, 100% { transform: translateX(-50%); }
+  20% { transform: translateX(calc(-50% - 8px)); }
+  40% { transform: translateX(calc(-50% + 8px)); }
+  60% { transform: translateX(calc(-50% - 5px)); }
+  80% { transform: translateX(calc(-50% + 5px)); }
+}
+
 /* Hero entity */
 .hero-entity { z-index: 3; }
 


### PR DESCRIPTION
## Summary
- **#226 DoT floats**: After each combat action, if hero HP dropped and poison/burn was active, a floating damage number appears on the hero card (green for poison, red for burn). Triggered when HP delta matches expected DoT amounts (5 for poison, 8 for burn, or up to 13 combined). Auto-clears after 1.2s.
- **#228 Boss phase pop**: When boss crosses ENRAGED (≤50%) or BERSERK (≤25%) thresholds, an animated text banner pops above the boss (scales in from 0.6× to 1.2× then fades out over 1.5s). The boss entity card also gets a CSS shake animation. Implemented via `bossPhaseFlash` state threaded from top-level App → DungeonView → boss entity render.

Closes #226
Closes #228