### PR TITLE
fix: use post-reconcile combatModal.spec for CelTrace fields (#230)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1164,13 +1164,13 @@ function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, o
                   <CelTrace
                     data={{
                       formula: combatModal.formula,
-                      difficulty: spec.difficulty || 'normal',
-                      heroClass: spec.heroClass || 'warrior',
+                      difficulty: combatModal.spec?.difficulty || spec.difficulty || 'normal',
+                      heroClass: combatModal.spec?.heroClass || spec.heroClass || 'warrior',
                       heroAction: combatModal.heroAction,
                       combatLog: combatModal.spec?.lastCombatLog || '',
-                      modifier: spec.modifier,
-                      helmetBonus: spec.helmetBonus,
-                      pantsBonus: spec.pantsBonus,
+                      modifier: combatModal.spec?.modifier ?? spec.modifier,
+                      helmetBonus: combatModal.spec?.helmetBonus ?? spec.helmetBonus,
+                      pantsBonus: combatModal.spec?.pantsBonus ?? spec.pantsBonus,
                     }}
                     onLearnMore={() => onViewKroConcept('cel-basics')}
                   />

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -874,7 +874,7 @@ export function CelTrace({ data, onLearnMore }: { data: CelTraceData; onLearnMor
       </button>
       {open && (
         <div className="cel-trace-body">
-          <div className="cel-trace-header">dungeon-graph → combatResult ConfigMap</div>
+          <div className="cel-trace-header">dungeon-graph → combatResult ConfigMap <span style={{ fontSize: 10, color: '#888', marginLeft: 6 }}>post-reconcile state</span></div>
           <table className="cel-trace-table">
             <thead>
               <tr>


### PR DESCRIPTION
## Summary
- Fixes stale `spec` bug in CelTrace: `modifier`, `helmetBonus`, `pantsBonus` now read from `combatModal.spec` (post-reconcile snapshot) with fallback to live `spec`
- Same fix applied to `difficulty` and `heroClass` for consistency
- Adds "post-reconcile state" label to CelTrace header to teach users why the snapshot matters

Closes #230