### PR TITLE
fix: journey 12 concept count regex broken since PR #231 added concepts

### DIFF
--- a/tests/e2e/journeys/12-kro-teaching.js
+++ b/tests/e2e/journeys/12-kro-teaching.js
@@ -77,9 +77,9 @@ async function run() {
     const kroTabSwitched = await switchToTab(page, 'kro');
     kroTabSwitched ? ok('kro tab is present and clickable') : fail('kro tab not found');
 
-    // Tab label should include concept count (e.g. "kro (2/13)")
-    const kroTabLabel = await page.locator('button.log-tab.kro-tab').textContent().catch(() => '');
-    kroTabLabel.match(/kro \(\d+\/13\)/) ? ok(`kro tab shows concept count: "${kroTabLabel.trim()}"`) : fail(`kro tab label unexpected: "${kroTabLabel}"`);
+     // Tab label should include concept count (e.g. "kro (2/16)") — total grows as concepts are added
+     const kroTabLabel = await page.locator('button.log-tab.kro-tab').textContent().catch(() => '');
+     kroTabLabel.match(/kro \(\d+\/\d+\)/) ? ok(`kro tab shows concept count: "${kroTabLabel.trim()}"`) : fail(`kro tab label unexpected: "${kroTabLabel}"`);
 
     // Glossary should be visible
     const glossary = page.locator('.kro-glossary');


### PR DESCRIPTION
## Summary
- Journey 12 line 82 hardcoded `/13` as the total concept count
- Current main has 16 concepts (`status-conditions` and `reconcile-loop` were added in #231, `status-phase` was added in #237)
- The check was failing on every run since PR #231 merged
- Fix: change regex from `/kro \(\d+\/13\)/` to `/kro \(\d+\/\d+\)/` so it passes regardless of total concept count

This is a test-only change; no production code affected.