### PR TITLE
fix: replace dangling 'secrets' concept with 'secret-output' in KroGraph (#243)

### DIFF
--- a/frontend/src/KroGraph.tsx
+++ b/frontend/src/KroGraph.tsx
@@ -170,7 +170,7 @@ export function buildGraph(cr: DungeonCR, reconciling: boolean): { nodes: GraphN
       kind: 'Secret',
       state: lootExists ? 'ok' : 'locked',
       exists: lootExists,
-      concept: 'secrets',
+      concept: 'secret-output',
       detail: lootExists ? 'item data in Secret' : 'created by loot-graph',
     })
     edges.push({ from: lootId, to: lootSecretId, label: 'loot-graph', dashed: !lootExists })
@@ -237,7 +237,7 @@ export function buildGraph(cr: DungeonCR, reconciling: boolean): { nodes: GraphN
     kind: 'Secret',
     state: bossLootExists ? 'ok' : 'locked',
     exists: bossLootExists,
-    concept: 'secrets',
+    concept: 'secret-output',
     detail: bossLootExists ? 'boss item in Secret' : 'created by loot-graph',
   })
   edges.push({ from: 'boss-loot', to: 'boss-loot-secret', label: 'loot-graph', dashed: !bossLootExists })

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -350,6 +350,10 @@ grep -q "boss-phase2\|boss-phase3" frontend/src/App.tsx && pass "Frontend applie
 grep -q "boss-phase-badge" frontend/src/App.tsx && pass "Frontend renders boss phase badge" || fail "Frontend missing boss phase badge"
 grep -q "ENRAGED\|BERSERK" frontend/src/App.tsx && pass "Frontend emits phase transition events to combat log" || fail "Frontend missing phase transition log events"
 
+# --- KroGraph concept reference sanity ---
+echo "=== KroGraph concept reference guardrails"
+! grep -q "concept: 'secrets'" frontend/src/KroGraph.tsx && pass "KroGraph has no dangling 'secrets' concept reference" || fail "KroGraph references unknown concept 'secrets' — use 'secret-output'"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary
- `KroGraph.tsx` referenced `concept: 'secrets'` on `LootSecret` and `BossLootSecret` nodes — `'secrets'` is not in the `KroConceptId` union type, causing a TS error and a broken click handler (clicking these nodes opened nothing)
- Fixed both occurrences to use `'secret-output'` which is the existing, correct concept for Kubernetes Secrets as RGD output
- Added guardrail to `tests/guardrails.sh`: fails if `'secrets'` ever appears again in `KroGraph.tsx`

Closes #243