### PR TITLE
feat: glossary search/filter bar (#239)

### DIFF
--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -562,6 +562,14 @@ interface KroGlossaryProps {
 export function KroGlossary({ unlocked, onViewConcept }: KroGlossaryProps) {
   const total = CONCEPT_ORDER.length
   const count = unlocked.size
+  const [search, setSearch] = useState('')
+
+  const filtered = CONCEPT_ORDER.filter(id => {
+    if (!search.trim()) return true
+    const c = KRO_CONCEPTS[id]
+    const q = search.toLowerCase()
+    return c.title.toLowerCase().includes(q) || c.tagline.toLowerCase().includes(q)
+  })
 
   return (
     <div className="kro-glossary">
@@ -571,8 +579,32 @@ export function KroGlossary({ unlocked, onViewConcept }: KroGlossaryProps) {
         <span style={{ fontSize: 8, color: 'var(--gold)', marginLeft: 4 }}>{count} / {total}</span>
         {count === total && <span style={{ fontSize: 7, color: '#2ecc71', marginLeft: 6 }}>kro expert!</span>}
       </div>
+      {count >= 4 && (
+        <div style={{ display: 'flex', alignItems: 'center', marginBottom: 8, gap: 4 }}>
+          <input
+            className="kro-glossary-search"
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search concepts..."
+            aria-label="Search kro concepts"
+          />
+          {search && (
+            <button
+              className="kro-glossary-search-clear"
+              onClick={() => setSearch('')}
+              aria-label="Clear search"
+            >×</button>
+          )}
+        </div>
+      )}
       <div className="kro-glossary-grid">
-        {CONCEPT_ORDER.map(id => {
+        {filtered.length === 0 && search && (
+          <div style={{ gridColumn: '1/-1', fontSize: 7, color: '#555', textAlign: 'center', padding: '12px 0' }}>
+            No concepts match "{search}"
+          </div>
+        )}
+        {filtered.map(id => {
           const c = KRO_CONCEPTS[id]
           const isUnlocked = unlocked.has(id)
           return (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1185,6 +1185,30 @@ body {
   padding-bottom: 8px;
   border-bottom: 1px solid #1e3a5f;
 }
+.kro-glossary-search {
+  flex: 1;
+  background: #0a1420;
+  border: 1px solid #1e3a5f;
+  border-radius: 2px;
+  color: #ccc;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 6px;
+  padding: 5px 7px;
+  outline: none;
+}
+.kro-glossary-search:focus { border-color: #00d4ff; }
+.kro-glossary-search::placeholder { color: #333; }
+.kro-glossary-search-clear {
+  background: none;
+  border: 1px solid #333;
+  border-radius: 2px;
+  color: #888;
+  font-size: 10px;
+  cursor: pointer;
+  padding: 2px 6px;
+  line-height: 1;
+}
+.kro-glossary-search-clear:hover { color: #fff; border-color: #555; }
 .kro-glossary-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
## Summary
- Adds a search/filter input above the glossary grid, shown only once 4+ concepts are unlocked (not useful when there's nothing to search)
- Real-time filtering across concept `title` and `tagline` (case-insensitive)
- Locked concepts that match a search still appear as locked — player can see what's coming
- Empty-state message when no concepts match the search term
- Clear (×) button dismisses search
- CSS uses existing pixel-art aesthetic (`Press Start 2P` font, `#0a1420` background, `#1e3a5f` border, focus ring `#00d4ff`)

Closes #239