### PR TITLE
feat: glossary search/filter bar (#239)

### DIFF
--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -631,6 +631,14 @@ interface KroGlossaryProps {
 export function KroGlossary({ unlocked, onViewConcept }: KroGlossaryProps) {
   const total = CONCEPT_ORDER.length
   const count = unlocked.size
+  const [search, setSearch] = useState('')
+
+  const filtered = CONCEPT_ORDER.filter(id => {
+    if (!search) return true
+    const c = KRO_CONCEPTS[id]
+    const q = search.toLowerCase()
+    return c.title.toLowerCase().includes(q) || c.tagline.toLowerCase().includes(q)
+  })
 
   return (
     <div className="kro-glossary">
@@ -640,8 +648,22 @@ export function KroGlossary({ unlocked, onViewConcept }: KroGlossaryProps) {
         <span style={{ fontSize: 8, color: 'var(--gold)', marginLeft: 4 }}>{count} / {total}</span>
         {count === total && <span style={{ fontSize: 7, color: '#2ecc71', marginLeft: 6 }}>kro expert!</span>}
       </div>
+      {count >= 4 && (
+        <div className="kro-glossary-search">
+          <input
+            className="kro-glossary-search-input"
+            type="text"
+            placeholder="filter concepts..."
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+          {search && (
+            <button className="kro-glossary-search-clear" onClick={() => setSearch('')}>×</button>
+          )}
+        </div>
+      )}
       <div className="kro-glossary-grid">
-        {CONCEPT_ORDER.map(id => {
+        {filtered.map(id => {
           const c = KRO_CONCEPTS[id]
           const isUnlocked = unlocked.has(id)
           return (
@@ -660,6 +682,9 @@ export function KroGlossary({ unlocked, onViewConcept }: KroGlossaryProps) {
           )
         })}
       </div>
+      {search && filtered.length === 0 && (
+        <div className="kro-glossary-empty">no concepts match "{search}"</div>
+      )}
       {count === 0 && (
         <div style={{ fontSize: 7, color: '#555', textAlign: 'center', padding: '16px 0' }}>
           Start playing to discover kro concepts in action.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1531,3 +1531,49 @@ body {
   cursor: pointer; text-align: center; padding: 4px;
 }
 .kro-onboard-skip:hover { color: #888; }
+
+.kro-glossary-search {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: 8px 0 6px;
+}
+
+.kro-glossary-search-input {
+  flex: 1;
+  background: #0a1420;
+  border: 1px solid #1e3a5f;
+  color: #ccc;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 7px;
+  padding: 4px 6px;
+  outline: none;
+}
+
+.kro-glossary-search-input:focus {
+  border-color: #00d4ff;
+  box-shadow: 0 0 4px rgba(0,212,255,0.3);
+}
+
+.kro-glossary-search-clear {
+  background: none;
+  border: 1px solid #1e3a5f;
+  color: #aaa;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 6px;
+  line-height: 1;
+}
+
+.kro-glossary-search-clear:hover {
+  color: #00d4ff;
+  border-color: #00d4ff;
+}
+
+.kro-glossary-empty {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 7px;
+  color: #555;
+  text-align: center;
+  padding: 16px 0;
+}


### PR DESCRIPTION
## Summary
- Adds search/filter input above the glossary grid, shown only once 4+ concepts are unlocked
- Real-time filtering across concept title and tagline (case-insensitive)
- Locked concepts that match a search still appear as locked — player can see what's coming
- Empty-state message when no concepts match the search term
- Clear (×) button dismisses search
- CSS uses existing pixel-art aesthetic

Closes #239