### PR TITLE
fix: add missing bossPhase and room2MonsterHP to DungeonCR type (#267)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -29,7 +29,7 @@ export interface DungeonCR {
     ringBonus?: number; amuletBonus?: number
     poisonTurns?: number; burnTurns?: number; stunTurns?: number
     treasureOpened?: number
-    currentRoom?: number; doorUnlocked?: number; room2BossHP?: number
+    currentRoom?: number; doorUnlocked?: number; room2BossHP?: number; room2MonsterHP?: number[]
     lastHeroAction?: string; lastEnemyAction?: string; lastCombatLog?: string; lastLootDrop?: string
     attackSeq?: number; actionSeq?: number
   }
@@ -37,7 +37,7 @@ export interface DungeonCR {
     livingMonsters: number; bossState: string; victory: boolean; defeated: boolean
     loot: string; maxMonsterHP: number; maxBossHP: number
     maxHeroHP: number; diceFormula: string; monsterCounter: number; bossCounter: number
-    modifier?: string; modifierType?: string; treasureState?: string
+    modifier?: string; modifierType?: string; treasureState?: string; bossPhase?: string
     conditions?: KroCondition[]
   }
 }


### PR DESCRIPTION
## Summary
- Adds `room2MonsterHP?: number[]` to `DungeonCR.spec` interface (was causing TS2339 error)
- Adds `bossPhase?: string` to `DungeonCR.status` interface (was causing TS2339 error)
- These fields are already used in App.tsx but were missing from the type definition

Closes #267