### PR TITLE
game: add ring and amulet equipment slots to equipment panel (#268)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1281,7 +1281,9 @@ function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, o
                lootDrop.includes('manapotion') ? 'Use to restore mana' :
                lootDrop.includes('helmet') ? 'Equip for a chance to land critical hits' :
                lootDrop.includes('pants') ? 'Equip for a chance to dodge counter-attacks' :
-               lootDrop.includes('boots') ? 'Equip to resist status effects' : 'A mysterious item'}
+               lootDrop.includes('boots') ? 'Equip to resist status effects' :
+               lootDrop.includes('ring') ? 'Equip for passive HP regen each round' :
+               lootDrop.includes('amulet') ? 'Equip to boost all damage dealt' : 'A mysterious item'}
             </div>
             <button className="btn btn-gold" onClick={onDismissLoot}>Got it!</button>
           </div>
@@ -1593,18 +1595,18 @@ function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, o
                        </div>
                      </Tooltip>
                    </div>
-                   <div className="equip-row">
-                     <Tooltip text={rb > 0 ? `Ring equipped: +${rb} HP regen at start of each round` : 'Ring — none equipped'}>
-                       <div className={`equip-slot${rb > 0 ? ' filled' : ' empty'}`}>
-                         {rb > 0 ? <><ItemSprite id={rb >= 12 ? 'ring-epic' : rb >= 8 ? 'ring-rare' : 'ring-common'} size={22} /><span className="slot-stat">+{rb}</span></> : <PixelIcon name="ring" size={14} color="#333" />}
-                       </div>
-                     </Tooltip>
-                     <Tooltip text={amb > 0 ? `Amulet equipped: +${amb}% to all damage dealt` : 'Amulet — none equipped'}>
-                       <div className={`equip-slot${amb > 0 ? ' filled' : ' empty'}`}>
-                         {amb > 0 ? <><ItemSprite id={amb >= 30 ? 'amulet-epic' : amb >= 20 ? 'amulet-rare' : 'amulet-common'} size={22} /><span className="slot-stat">+{amb}%</span></> : <PixelIcon name="amulet" size={14} color="#333" />}
-                       </div>
-                     </Tooltip>
-                   </div>
+                    <div className="equip-row">
+                      <Tooltip text={rb > 0 ? `Ring equipped: +${rb} HP regen at start of each round` : 'Ring — none equipped'}>
+                        <div className={`equip-slot${rb > 0 ? ' filled' : ' empty'}`}>
+                          {rb > 0 ? <><span style={{ fontSize: 16, lineHeight: 1 }}>💍</span><span className="slot-stat">+{rb}/t</span></> : <PixelIcon name="ring" size={14} color="#333" />}
+                        </div>
+                      </Tooltip>
+                      <Tooltip text={amb > 0 ? `Amulet equipped: +${amb}% to all damage dealt` : 'Amulet — none equipped'}>
+                        <div className={`equip-slot${amb > 0 ? ' filled' : ' empty'}`}>
+                          {amb > 0 ? <><span style={{ fontSize: 16, lineHeight: 1 }}>📿</span><span className="slot-stat">+{amb}%</span></> : <PixelIcon name="amulet" size={14} color="#333" />}
+                        </div>
+                      </Tooltip>
+                    </div>
                 </div>
 
                 <div className="status-row">

--- a/frontend/src/PixelIcon.tsx
+++ b/frontend/src/PixelIcon.tsx
@@ -26,6 +26,8 @@ const ICONS: Record<string, { color: string; pixels: string }> = {
   helmet:   { color: '#a0a0c0', pixels: '3,1 4,1 5,1 2,2 6,2 1,3 7,3 1,4 7,4 2,5 6,5 1,6 2,6 6,6 7,6' },
   pants:    { color: '#6080a0', pixels: '2,1 3,1 4,1 5,1 6,1 2,2 6,2 2,3 6,3 3,4 5,4 3,5 5,5 3,6 5,6 3,7 5,7' },
   boots:    { color: '#8b6840', pixels: '3,1 4,1 3,2 4,2 3,3 4,3 2,4 3,4 4,4 5,4 2,5 3,5 4,5 5,5 6,5 2,6 6,6 3,7 4,7 5,7 6,7' },
+  ring:     { color: '#d4af37', pixels: '3,1 4,1 5,1 2,2 6,2 1,3 7,3 1,4 7,4 2,5 6,5 3,6 4,6 5,6' },
+  amulet:   { color: '#c084fc', pixels: '4,1 3,2 5,2 3,3 5,3 4,4 3,5 5,5 2,6 4,6 6,6 2,7 4,7 6,7' },
 }
 
 function parsePixels(pixels: string): [number, number][] {

--- a/frontend/src/Sprite.tsx
+++ b/frontend/src/Sprite.tsx
@@ -99,8 +99,8 @@ const ITEM_STRIP: Record<string, { frames: number; frameW: number; frameH: numbe
   armor:     { frames: 6, frameW: 848, frameH: 832, file: '/sprites/items/armor.png' },
 }
 
-// Map item type+rarity to strip and index, or direct file path
-type ItemMapEntry = { strip: string; index: number; file?: never } | { file: string; strip?: never; index?: never }
+// Map item type+rarity to strip and index, or direct file path, or emoji
+type ItemMapEntry = { strip: string; index: number; file?: never; emoji?: never } | { file: string; strip?: never; index?: never; emoji?: never } | { emoji: string; strip?: never; index?: never; file?: never }
 const ITEM_MAP: Record<string, ItemMapEntry> = {
   'weapon-common':     { strip: 'weapons', index: 0 },
   'weapon-rare':       { strip: 'weapons', index: 1 },
@@ -126,6 +126,12 @@ const ITEM_MAP: Record<string, ItemMapEntry> = {
   'boots-common':      { file: '/sprites/items/boots/1.png' },
   'boots-rare':        { file: '/sprites/items/boots/2.png' },
   'boots-epic':        { file: '/sprites/items/boots/3.png' },
+  'ring-common':       { emoji: '💍' },
+  'ring-rare':         { emoji: '💍' },
+  'ring-epic':         { emoji: '💍' },
+  'amulet-common':     { emoji: '📿' },
+  'amulet-rare':       { emoji: '📿' },
+  'amulet-epic':       { emoji: '📿' },
 }
 
 const MODIFIER_MAP: Record<string, { file: string }> = {
@@ -138,8 +144,13 @@ const MODIFIER_MAP: Record<string, { file: string }> = {
 }
 
 export function ItemSprite({ id, size = 24 }: { id: string; size?: number }) {
-  const mapping: { strip?: string; index?: number; file?: string } | undefined = ITEM_MAP[id] || MODIFIER_MAP[id]
+  const mapping: { strip?: string; index?: number; file?: string; emoji?: string } | undefined = ITEM_MAP[id] || MODIFIER_MAP[id]
   if (!mapping) return <span style={{ fontSize: size * 0.6 }}>📦</span>
+
+  // Emoji-based (no sprite file available)
+  if ('emoji' in mapping && mapping.emoji) {
+    return <span style={{ fontSize: size * 0.75, lineHeight: 1, display: 'inline-block', verticalAlign: 'middle' }}>{mapping.emoji}</span>
+  }
 
   // Individual image file
   if (mapping.file) {


### PR DESCRIPTION
## Summary
- Adds Ring and Amulet as dedicated visual equipment slots in the Tibia-style equipment panel
- Ring slot shows 💍 icon and +N/t bonus when equipped
- Amulet slot shows 📿 icon and +N%dmg bonus when equipped
- Matches visual style of existing equipment slots (helmet, pants, boots)
- Adds pixel art icons for empty ring/amulet slot states to PixelIcon.tsx
- Adds emoji-based ItemSprite entries for ring/amulet in backpack grid
- Fixes loot drop description text for ring and amulet items

Closes #268