### PR TITLE
feat: expand kro Inspector to monster, treasure, modifier, and combat-result nodes (#266)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -1546,11 +1546,12 @@ func sliceInt(v interface{}) int64 {
 }
 
 // GetDungeonResource fetches a child resource of a dungeon for the kro Inspector panel.
-// GET /api/v1/dungeons/{namespace}/{name}/resources?kind=hero
+// GET /api/v1/dungeons/{namespace}/{name}/resources?kind=hero[&index=0]
 func (h *Handler) GetDungeonResource(w http.ResponseWriter, r *http.Request) {
 	ns := r.PathValue("namespace")
 	name := r.PathValue("name")
 	kind := r.URL.Query().Get("kind")
+	index := r.URL.Query().Get("index") // optional, for indexed resources (monster-N, loot-N)
 	ctx := r.Context()
 
 	type resourceDef struct {
@@ -1571,14 +1572,34 @@ func (h *Handler) GetDungeonResource(w http.ResponseWriter, r *http.Request) {
 		def = &resourceDef{schema.GroupVersionResource{Group: grp, Version: ver, Resource: "heroes"}, name + "-hero"}
 	case "boss":
 		def = &resourceDef{schema.GroupVersionResource{Group: grp, Version: ver, Resource: "bosses"}, name + "-boss"}
+	case "treasure":
+		def = &resourceDef{schema.GroupVersionResource{Group: grp, Version: ver, Resource: "treasures"}, name + "-treasure"}
+	case "modifier":
+		def = &resourceDef{schema.GroupVersionResource{Group: grp, Version: ver, Resource: "modifiers"}, name + "-modifier"}
+	case "monster":
+		if index == "" {
+			index = "0"
+		}
+		def = &resourceDef{schema.GroupVersionResource{Group: grp, Version: ver, Resource: "monsters"}, name + "-monster-" + index}
 	case "namespace":
 		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "namespaces"}, ns}
 	case "herostate":
 		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-hero-state"}
 	case "bossstate":
 		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-boss-state"}
+	case "monsterstate":
+		if index == "" {
+			index = "0"
+		}
+		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-monster-" + index}
 	case "gameconfig":
 		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-game-config"}
+	case "combatresult":
+		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-combat-result"}
+	case "treasurecm":
+		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-treasure"}
+	case "treasuresecret":
+		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "secrets"}, name + "-treasure-secret"}
 	default:
 		writeError(w, "unknown kind: "+kind, http.StatusBadRequest)
 		return

--- a/frontend/src/KroGraph.tsx
+++ b/frontend/src/KroGraph.tsx
@@ -835,6 +835,7 @@ export function KroGraphPanel({ cr, prevCr, reconciling, onViewConcept }: KroGra
   const [inspectorLoading, setInspectorLoading] = useState(false)
 
   const handleNodeSelect = useCallback(async (nodeId: string, nodeKind: string) => {
+    // Static kind map for non-indexed nodes
     const kindMap: Record<string, ResourceKind> = {
       'dungeon': 'dungeon',
       'hero': 'hero',
@@ -843,8 +844,35 @@ export function KroGraphPanel({ cr, prevCr, reconciling, onViewConcept }: KroGra
       'boss-state': 'bossstate',
       'namespace': 'namespace',
       'game-config': 'gameconfig',
+      'treasure': 'treasure',
+      'treasure-cm': 'treasurecm',
+      'treasure-secret': 'treasuresecret',
+      'modifier': 'modifier',
+      'modifier-state': 'modifier',  // same CR
+      'combat-result': 'combatresult',
     }
-    const kind = kindMap[nodeId]
+
+    // Extract index from monster-N / monster-cm-N / loot-mN / loot-secret-mN node IDs
+    const monsterMatch = nodeId.match(/^monster-(\d+)$/)
+    const monsterCmMatch = nodeId.match(/^monster-cm-(\d+)$/)
+    const lootMatch = nodeId.match(/^loot-m(\d+)$/)
+    const lootSecretMatch = nodeId.match(/^loot-secret-m(\d+)$/)
+
+    let kind: ResourceKind | undefined
+    let index: number | undefined
+
+    if (monsterMatch) {
+      kind = 'monster'; index = parseInt(monsterMatch[1])
+    } else if (monsterCmMatch) {
+      kind = 'monsterstate'; index = parseInt(monsterCmMatch[1])
+    } else if (lootMatch) {
+      kind = 'monster'; index = parseInt(lootMatch[1])  // loot node maps to its Monster CR
+    } else if (lootSecretMatch) {
+      kind = 'monster'; index = parseInt(lootSecretMatch[1])
+    } else {
+      kind = kindMap[nodeId] as ResourceKind | undefined
+    }
+
     if (!kind) return
 
     const ns = cr.metadata.namespace
@@ -857,7 +885,7 @@ export function KroGraphPanel({ cr, prevCr, reconciling, onViewConcept }: KroGra
 
     try {
       const { getDungeonResource } = await import('./api')
-      const data = await getDungeonResource(ns, name, kind)
+      const data = await getDungeonResource(ns, name, kind, index)
       setInspectorData(data)
     } catch {
       setInspectorData(null)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -75,15 +75,20 @@ export class ApiError extends Error {
   }
 }
 
-const VALID_RESOURCE_KINDS = ['dungeon', 'hero', 'herostate', 'boss', 'bossstate', 'namespace', 'gameconfig'] as const
+const VALID_RESOURCE_KINDS = [
+  'dungeon', 'hero', 'herostate', 'boss', 'bossstate', 'namespace', 'gameconfig',
+  'monster', 'monsterstate', 'treasure', 'treasurecm', 'treasuresecret', 'modifier', 'combatresult',
+] as const
 export type ResourceKind = typeof VALID_RESOURCE_KINDS[number]
 
 /** Sanitize Kubernetes resource name/namespace to safe path chars */
 function safePath(s: string): string { return s.replace(/[^a-zA-Z0-9\-_.]/g, '').slice(0, 253) }
 
-export async function getDungeonResource(ns: string, name: string, kind: ResourceKind): Promise<any> {
+export async function getDungeonResource(ns: string, name: string, kind: ResourceKind, index?: number): Promise<any> {
   // Same-origin call to /api/v1 only. ns/name are K8s identifiers, sanitized.
-  const r = await fetch(`${BASE}/dungeons/${safePath(ns)}/${safePath(name)}/resources?kind=${kind}`)
+  let url = `${BASE}/dungeons/${safePath(ns)}/${safePath(name)}/resources?kind=${kind}`
+  if (index !== undefined) url += `&index=${index}`
+  const r = await fetch(url)
   if (!r.ok) return null
   return r.json()
 }


### PR DESCRIPTION
## Summary
- kro Inspector now supports clicking monster, treasure, modifier, and combat-result nodes in addition to dungeon, hero, boss, namespace, and game-config
- Monster CRs use indexed node IDs (monster-0, monster-1, ...) — index is extracted and passed to backend
- MonsterState ConfigMaps (monster-cm-N) and Loot nodes also supported
- Backend: added monster, monsterstate, treasure, treasurecm, treasuresecret, modifier, combatresult kinds to GetDungeonResource handler with optional &index= query param
- Frontend: api.ts `getDungeonResource` accepts optional `index` parameter; KroGraph `kindMap` expanded with regex-based monster/loot node matching

Closes #266