### PR TITLE
feat: enemy variety — Archer/Shaman with stun and heal abilities (#132)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -182,19 +182,37 @@ func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Assign monster types for Room 1: goblin(0), skeleton(1), archer(2+even), shaman(3+odd)
+	// Archers (index % 2 == 0, index >= 2): 20% chance to stun instead of poison
+	// Shamans (index % 2 == 1, index >= 3): 30% chance to heal another monster on counter
+	monsterTypes := make([]interface{}, req.Monsters)
+	for i := range monsterTypes {
+		switch {
+		case i == 0:
+			monsterTypes[i] = "goblin"
+		case i == 1:
+			monsterTypes[i] = "skeleton"
+		case i%2 == 0:
+			monsterTypes[i] = "archer"
+		default:
+			monsterTypes[i] = "shaman"
+		}
+	}
+
 	dungeon := &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "game.k8s.example/v1alpha1",
 		"kind":       "Dungeon",
 		"metadata":   map[string]interface{}{"name": req.Name},
 		"spec": map[string]interface{}{
-			"monsters":   req.Monsters,
-			"difficulty": req.Difficulty,
-			"monsterHP":  monsterHP,
-			"bossHP":     hp.boss,
-			"heroHP":     heroHP,
-			"heroClass":  heroClass,
-			"heroMana":   heroMana,
-			"modifier":   modifier,
+			"monsters":     req.Monsters,
+			"difficulty":   req.Difficulty,
+			"monsterHP":    monsterHP,
+			"bossHP":       hp.boss,
+			"heroHP":       heroHP,
+			"heroClass":    heroClass,
+			"heroMana":     heroMana,
+			"modifier":     modifier,
+			"monsterTypes": monsterTypes,
 		},
 	}}
 
@@ -408,6 +426,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 	currentRoom := getInt(spec, "currentRoom")
 	bossHP := getInt(spec, "bossHP")
 	monsterHPRaw, _ := spec["monsterHP"].([]interface{})
+	monsterTypesRaw, _ := spec["monsterTypes"].([]interface{})
 
 	// Guard: reject if dungeon is over
 	allMonstersDead := true
@@ -923,6 +942,68 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			}
 		}
 
+		// Archer special: any alive archer (index % 2 == 0, index >= 2) has 20% stun chance
+		// Only triggers if hero wasn't already poisoned this round and stun not already active
+		if aliveCount > 0 && stunTurns == 0 {
+			for i, v := range monsterHPRaw {
+				hp := sliceInt(v)
+				mtype := ""
+				if i < len(monsterTypesRaw) {
+					mtype, _ = monsterTypesRaw[i].(string)
+				}
+				if hp > 0 && mtype == "archer" {
+					if seededRoll(attackUID+fmt.Sprintf("-archer%d-stun", i), 100) < 20 {
+						resistRoll := seededRoll(attackUID+"-boots-resist-archer", 100)
+						if bootsBonus > 0 && resistRoll < bootsBonus {
+							effectNote += fmt.Sprintf(" [RESISTED archer stun! boots +%d%% resist]", bootsBonus)
+						} else {
+							stunTurns = 1
+							effectNote += " Archer fires! STUNNED! (1 turn)"
+						}
+						break
+					}
+				}
+			}
+		}
+
+		// Shaman special: any alive shaman (index % 2 == 1, index >= 3) has 30% chance to
+		// heal the first alive non-shaman monster for 10 HP (not exceeding max creation HP)
+		if aliveCount > 0 {
+			for i, v := range monsterHPRaw {
+				hp := sliceInt(v)
+				mtype := ""
+				if i < len(monsterTypesRaw) {
+					mtype, _ = monsterTypesRaw[i].(string)
+				}
+				if hp > 0 && mtype == "shaman" {
+					if seededRoll(attackUID+fmt.Sprintf("-shaman%d-heal", i), 100) < 30 {
+						// Find the first alive non-shaman monster to heal
+						for j, vj := range newMonsterHP {
+							hpj := sliceInt(vj)
+							mtypej := ""
+							if j < len(monsterTypesRaw) {
+								mtypej, _ = monsterTypesRaw[j].(string)
+							}
+							if hpj > 0 && mtypej != "shaman" {
+								// Heal by 10, but not exceeding original creation HP
+								maxHP := defaultHP[difficulty].monster
+								if modifier == "curse-fortitude" {
+									maxHP = maxHP * 3 / 2
+								}
+								healedHP := min64(hpj+10, maxHP)
+								if healedHP > hpj {
+									newMonsterHP[j] = healedHP
+									effectNote += fmt.Sprintf(" Shaman heals %s-%d for %d HP!", mtypej, j, healedHP-hpj)
+								}
+								break // healed the first eligible monster; done
+							}
+						}
+						break // only one shaman heals per round
+					}
+				}
+			}
+		}
+
 		heroAction := dotNote + fmt.Sprintf("Hero (%s) deals %d damage to %s (HP: %d -> %d)%s%s", heroClass, effectiveDamage, realTarget, oldHP, newHP, classNote, tauntNote)
 		patchSpec["heroHP"] = heroHP
 		patchSpec["monsterHP"] = newMonsterHP
@@ -1205,11 +1286,21 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, cl
 		for i := range newMonsterHP {
 			newMonsterHP[i] = r2MonsterHP
 		}
+		// Room 2 monster types: troll(even), ghoul(odd) — no special classes in room 2
+		r2MonsterTypes := make([]interface{}, len(monsterHPRaw))
+		for i := range r2MonsterTypes {
+			if i%2 == 0 {
+				r2MonsterTypes[i] = "troll"
+			} else {
+				r2MonsterTypes[i] = "ghoul"
+			}
+		}
 		patchSpec["currentRoom"] = int64(2)
 		patchSpec["monsterHP"] = newMonsterHP
 		patchSpec["bossHP"] = r2BossHP
 		patchSpec["room2MonsterHP"] = newMonsterHP
 		patchSpec["room2BossHP"] = r2BossHP
+		patchSpec["monsterTypes"] = r2MonsterTypes
 		patchSpec["treasureOpened"] = int64(0)
 		patchSpec["doorUnlocked"] = int64(0)
 		patchSpec["lastHeroAction"] = "Entered Room 2! Stronger enemies await..."

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { DungeonSummary, DungeonCR, listDungeons, getDungeon, createDungeon, submitAttack, deleteDungeon, ApiError } from './api'
 import { useWebSocket, WSEvent } from './useWebSocket'
 
-import { Sprite, getMonsterSprite, SpriteAction, ItemSprite } from './Sprite'
+import { Sprite, getMonsterSprite, getMonsterName, SpriteAction, ItemSprite } from './Sprite'
 import { PixelIcon } from './PixelIcon'
 import {
   InsightCard, KroConceptModal, KroGlossary,
@@ -1515,7 +1515,8 @@ function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, o
               const count = spec.monsterHP.length
               const state = hp > 0 ? 'alive' : 'dead'
               const mName = `${dungeonName}-monster-${idx}`
-              const mSprite = getMonsterSprite(idx, spec.currentRoom || 1)
+              const mSprite = getMonsterSprite(idx, spec.currentRoom || 1, spec.monsterTypes)
+              const mDisplayName = getMonsterName(idx, spec.currentRoom || 1, spec.monsterTypes)
               let mAction: SpriteAction = state === 'dead' ? 'dead' : 'idle'
               const inCombat = combatModal && (combatModal.phase === 'rolling' || combatModal.phase === 'resolved')
               if (inCombat && state === 'alive') mAction = 'attack'
@@ -1534,14 +1535,14 @@ function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, o
                   style={{ left: `${cx}%`, top: `${cy}%` }}
                   role={state === 'alive' && !gameOver && !attackPhase ? 'button' : undefined}
                   tabIndex={state === 'alive' && !gameOver && !attackPhase ? 0 : undefined}
-                  aria-label={`${mSprite} · HP: ${hp}/${maxMonsterHP}${state === 'dead' ? ' (dead)' : ''}`}
+                  aria-label={`${mDisplayName} · HP: ${hp}/${maxMonsterHP}${state === 'dead' ? ' (dead)' : ''}`}
                   onKeyDown={state === 'alive' && !gameOver && !attackPhase ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onAttack(mName, 0) } } : undefined}>
                   {floatingDmg?.target === mName && <div className="floating-dmg" style={{ color: '#e94560' }}>{floatingDmg.amount}</div>}
                   <Sprite spriteType={mSprite} action={mAction} size={72} flip={!facingRight} />
                   <div className="arena-shadow" />
                   <div className="arena-hover-ui">
                     <div className="arena-hp-bar"><div className={`arena-hp-fill ${hp > maxMonsterHP * 0.6 ? 'high' : hp > maxMonsterHP * 0.3 ? 'mid' : 'low'}`} style={{ width: `${Math.min((hp / maxMonsterHP) * 100, 100)}%` }} /></div>
-                    <div className="arena-name">{mSprite} · {hp}/{maxMonsterHP}</div>
+                    <div className="arena-name">{mDisplayName} · {hp}/{maxMonsterHP}</div>
                     {state === 'alive' && !gameOver && !attackPhase && (
                       <div className="arena-actions">
                         <button className="btn btn-primary arena-atk-btn" onClick={() => onAttack(mName, 0)}>🎲 {status?.diceFormula || '2d12+6'}</button>

--- a/frontend/src/Sprite.tsx
+++ b/frontend/src/Sprite.tsx
@@ -87,8 +87,39 @@ export function Sprite({ spriteType, action, size = 64, flip = false }: SpritePr
   )
 }
 
-// Assign a deterministic monster sprite based on index
-export function getMonsterSprite(index: number, room: number = 1): string {
+// Assign a deterministic monster sprite based on index and optional type array.
+// Archer maps to 'goblin' sprite (ranged variant), Shaman maps to 'skeleton' sprite (magic variant).
+// Falls back to index-based assignment for old dungeons without monsterTypes.
+export function getMonsterSprite(index: number, room: number = 1, monsterTypes?: string[]): string {
+  const mtype = monsterTypes?.[index]
+  if (mtype) {
+    switch (mtype) {
+      case 'goblin': return 'goblin'
+      case 'skeleton': return 'skeleton'
+      case 'archer': return 'goblin'   // same sprite, different behavior
+      case 'shaman': return 'skeleton' // same sprite, different behavior
+      case 'troll': return 'troll'
+      case 'ghoul': return 'ghoul'
+      default: break
+    }
+  }
+  if (room === 2) return index % 2 === 0 ? 'troll' : 'ghoul'
+  return index % 2 === 0 ? 'goblin' : 'skeleton'
+}
+
+// Get the display name for a monster (shown in arena label)
+export function getMonsterName(index: number, room: number = 1, monsterTypes?: string[]): string {
+  const mtype = monsterTypes?.[index]
+  if (mtype) {
+    switch (mtype) {
+      case 'goblin': return 'Goblin'
+      case 'skeleton': return 'Skeleton'
+      case 'archer': return 'Archer'
+      case 'shaman': return 'Shaman'
+      case 'troll': return 'Troll'
+      case 'ghoul': return 'Ghoul'
+    }
+  }
   if (room === 2) return index % 2 === 0 ? 'troll' : 'ghoul'
   return index % 2 === 0 ? 'goblin' : 'skeleton'
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -30,6 +30,7 @@ export interface DungeonCR {
     poisonTurns?: number; burnTurns?: number; stunTurns?: number
     treasureOpened?: number
     currentRoom?: number; doorUnlocked?: number; room2BossHP?: number; room2MonsterHP?: number[]
+    monsterTypes?: string[]
     lastHeroAction?: string; lastEnemyAction?: string; lastCombatLog?: string; lastLootDrop?: string
     attackSeq?: number; actionSeq?: number
   }

--- a/tests/e2e/journeys/19-enemy-variety.js
+++ b/tests/e2e/journeys/19-enemy-variety.js
@@ -1,0 +1,188 @@
+// Journey 19: Enemy Variety
+// UI-ONLY: no kubectl, no direct fetch/api, no execSync
+// Tests: 4-monster dungeon shows Goblin/Skeleton/Archer/Shaman display names in arena;
+//        combat works against named monsters; stun/shaman-heal are RNG-based so we warn
+//        if not triggered by chance; Room 2 shows Troll/Ghoul display names.
+const { chromium } = require('playwright');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon } = require('./helpers');
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const TIMEOUT = 20000;
+let passed = 0, failed = 0, warnings = 0;
+function ok(msg)   { console.log(`  ✅ ${msg}`); passed++; }
+function fail(msg) { console.log(`  ❌ ${msg}`); failed++; }
+function warn(msg) { console.log(`  ⚠️  ${msg}`); warnings++; }
+
+async function run() {
+  console.log('Journey 19: Enemy Variety\n');
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const dName = `j19-${Date.now()}`;
+
+  const consoleErrors = [];
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
+
+  try {
+    await page.goto(BASE_URL, { timeout: TIMEOUT });
+    await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
+
+    // ── Create dungeon with 4 monsters (goblin/skeleton/archer/shaman) ─────────
+    console.log('\n  [Create dungeon — 4 monsters]');
+    const loaded = await createDungeonUI(page, dName, { monsters: 4, difficulty: 'easy', heroClass: 'warrior' });
+    loaded ? ok('Dungeon created and game view loaded') : fail('Dungeon view did not load');
+    await page.waitForTimeout(2000);
+
+    // ── Verify monster display names ──────────────────────────────────────────
+    console.log('\n  [Monster display names]');
+
+    // Names appear in .arena-name divs and in aria-label attributes
+    const arenaNames = page.locator('.arena-entity.monster-entity .arena-name');
+    await arenaNames.first().waitFor({ timeout: TIMEOUT }).catch(() => {});
+    const nameCount = await arenaNames.count();
+    nameCount === 4 ? ok(`4 monster arena-name elements found`) : fail(`Expected 4 arena-name elements, got ${nameCount}`);
+
+    let goblinFound = false, skeletonFound = false, archerFound = false, shamanFound = false;
+    for (let i = 0; i < nameCount; i++) {
+      const text = await arenaNames.nth(i).textContent();
+      if (text.includes('Goblin'))   goblinFound   = true;
+      if (text.includes('Skeleton')) skeletonFound = true;
+      if (text.includes('Archer'))   archerFound   = true;
+      if (text.includes('Shaman'))   shamanFound   = true;
+    }
+    goblinFound   ? ok('Goblin name shown in arena')   : fail('Goblin name not found in arena');
+    skeletonFound ? ok('Skeleton name shown in arena') : fail('Skeleton name not found in arena');
+    archerFound   ? ok('Archer name shown in arena')   : fail('Archer name not found in arena');
+    shamanFound   ? ok('Shaman name shown in arena')   : fail('Shaman name not found in arena');
+
+    // Also check aria-labels include the typed names
+    console.log('\n  [aria-labels updated]');
+    const ariaLabels = await page.locator('.arena-entity.monster-entity[aria-label]').evaluateAll(
+      els => els.map(el => el.getAttribute('aria-label'))
+    );
+    const hasArcherLabel = ariaLabels.some(l => l && l.includes('Archer'));
+    const hasShamanLabel = ariaLabels.some(l => l && l.includes('Shaman'));
+    hasArcherLabel ? ok('Archer aria-label present on monster entity') : fail('Archer aria-label not found');
+    hasShamanLabel ? ok('Shaman aria-label present on monster entity') : fail('Shaman aria-label not found');
+
+    // ── Combat against named monsters works ───────────────────────────────────
+    console.log('\n  [Combat against named monsters]');
+    let stunTriggered = false, shamanHealTriggered = false;
+
+    // Attack all 4 monsters until dead (easy mode, warrior — should be manageable)
+    for (let round = 0; round < 20; round++) {
+      const aliveCount = await page.locator('.arena-entity.monster-entity:not(.dead)').count();
+      if (aliveCount === 0) break;
+
+      const result = await attackMonster(page, 0);
+      if (!result) break;
+
+      if (result.includes('STUNNED') || result.includes('Archer fires')) stunTriggered = true;
+      if (result.includes('Shaman heals')) shamanHealTriggered = true;
+
+      // Check hero is still alive
+      const bodyText = await page.textContent('body');
+      if (bodyText.includes('GAME OVER') || bodyText.includes('You were defeated')) {
+        warn('Hero died during enemy variety test — RNG unfavorable');
+        break;
+      }
+    }
+
+    const finalAlive = await page.locator('.arena-entity.monster-entity:not(.dead)').count();
+    finalAlive === 0 ? ok('All 4 monsters defeated') : warn(`${finalAlive} monsters still alive (hero may have died)`);
+
+    stunTriggered
+      ? ok('Archer STUN effect triggered during combat')
+      : warn('Archer STUN not triggered by RNG (20% chance per alive archer per round — acceptable)');
+
+    shamanHealTriggered
+      ? ok('Shaman heal effect triggered during combat')
+      : warn('Shaman heal not triggered by RNG (30% chance per alive shaman per round — acceptable)');
+
+    // ── Combat log mentions effect notes ─────────────────────────────────────
+    console.log('\n  [Combat log — enemy actions]');
+    const lastEnemyLog = page.locator('.log-entry, .last-enemy-action, .combat-log').first();
+    await lastEnemyLog.waitFor({ timeout: 5000 }).catch(() => {});
+    ok('Combat completed without crash after enemy variety round');
+
+    // ── Boss fight works ──────────────────────────────────────────────────────
+    console.log('\n  [Boss fight]');
+    await page.waitForTimeout(1000);
+
+    // Check if boss is visible
+    const bossEntity = page.locator('.arena-entity.boss-entity');
+    const bossVisible = await bossEntity.count() > 0;
+    if (bossVisible) {
+      ok('Boss entity visible after all monsters defeated');
+      const bossBtn = page.locator('.arena-entity.boss-entity .arena-atk-btn.btn-primary');
+      const bossAlive = await bossBtn.count() > 0;
+      if (bossAlive) {
+        // Attack boss a couple of times
+        for (let i = 0; i < 5; i++) {
+          const r = await attackBoss(page);
+          if (!r) break;
+          const body = await page.textContent('body');
+          if (body.includes('CLEARED') || body.includes('Boss defeated') || body.includes('Open Treasure')) {
+            ok('Boss defeated — Room 1 cleared');
+            break;
+          }
+        }
+      }
+    } else {
+      warn('Boss entity not visible (hero may have died or monsters not all dead)');
+    }
+
+    // ── Room 2 monster names ──────────────────────────────────────────────────
+    console.log('\n  [Room 2 monster names — Troll/Ghoul]');
+
+    // Try to get to Room 2: open treasure, then click door
+    const openTreasureBtn = page.locator('button:has-text("Open Treasure")');
+    if (await openTreasureBtn.count() > 0) {
+      await openTreasureBtn.click();
+      await page.waitForTimeout(3000);
+      const gotIt = page.locator('button:has-text("Got it!")');
+      if (await gotIt.count() > 0) await gotIt.click();
+      await page.waitForTimeout(1000);
+    }
+
+    const enterDoorBtn = page.locator('button:has-text("Enter Door"), button:has-text("Enter Room 2")');
+    if (await enterDoorBtn.count() > 0) {
+      await enterDoorBtn.click();
+      await page.waitForTimeout(4000);
+
+      const r2Names = page.locator('.arena-entity.monster-entity .arena-name');
+      await r2Names.first().waitFor({ timeout: TIMEOUT }).catch(() => {});
+      let trollFound = false, ghoulFound = false;
+      const r2Count = await r2Names.count();
+      for (let i = 0; i < r2Count; i++) {
+        const text = await r2Names.nth(i).textContent();
+        if (text.includes('Troll')) trollFound = true;
+        if (text.includes('Ghoul')) ghoulFound = true;
+      }
+      trollFound ? ok('Troll name shown in Room 2 arena') : warn('Troll name not found in Room 2 (may not have reached Room 2)');
+      ghoulFound ? ok('Ghoul name shown in Room 2 arena') : warn('Ghoul name not found in Room 2 (may not have reached Room 2)');
+    } else {
+      warn('Door not available — could not verify Room 2 monster names (boss may still be alive)');
+    }
+
+    // ── No critical JS errors ─────────────────────────────────────────────────
+    console.log('\n  [Error check]');
+    const criticalErrors = consoleErrors.filter(e =>
+      !e.includes('favicon') && !e.includes('net::ERR') &&
+      !e.includes('kro warning') && !e.includes('WebSocket')
+    );
+    criticalErrors.length === 0
+      ? ok('No critical JS errors during journey')
+      : fail(`JS errors detected: ${criticalErrors.slice(0, 3).join('; ')}`);
+
+  } catch (err) {
+    fail(`Unexpected error: ${err.message}`);
+    console.error(err);
+  } finally {
+    await deleteDungeon(page, dName).catch(() => {});
+    await browser.close();
+    console.log(`\n  Passed: ${passed}  Failed: ${failed}  Warnings: ${warnings}`);
+    if (failed > 0) process.exit(1);
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary
- Adds `monsterTypes` field to dungeon spec — goblin/skeleton/archer/shaman in Room 1, troll/ghoul in Room 2
- **Archer** (index ≥ 2, even): 20% chance to stun hero on counter-attack (1 turn, boots-resistible)
- **Shaman** (index ≥ 3, odd): 30% chance to heal first alive non-shaman monster for 10 HP on counter-attack
- Frontend renders typed display names (Goblin, Skeleton, Archer, Shaman, Troll, Ghoul) in arena and aria-labels
- `getMonsterName()` and updated `getMonsterSprite()` added to `Sprite.tsx`; archer → goblin sprite, shaman → skeleton sprite
- Journey 19 added: verifies all 4 typed names appear, combat works, RNG effects warned if not triggered
- Fixed shaman heal loop bug: `break` was outside the `if` guard, preventing heals except on index-0 monsters

Closes #132