### PR TITLE
feat: New Game+ mode — carry-over gear, 1.25x enemy scaling per run (#128)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -119,6 +119,16 @@ type CreateDungeonReq struct {
 	Difficulty string `json:"difficulty"`
 	HeroClass  string `json:"heroClass"`
 	Namespace  string `json:"namespace"`
+	// New Game+ carry-over fields (optional, 0 = fresh start)
+	RunCount    int64 `json:"runCount"`
+	WeaponBonus int64 `json:"weaponBonus"`
+	WeaponUses  int64 `json:"weaponUses"`
+	ArmorBonus  int64 `json:"armorBonus"`
+	ShieldBonus int64 `json:"shieldBonus"`
+	HelmetBonus int64 `json:"helmetBonus"`
+	PantsBonus  int64 `json:"pantsBonus"`
+	RingBonus   int64 `json:"ringBonus"`
+	AmuletBonus int64 `json:"amuletBonus"`
 }
 
 func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
@@ -182,6 +192,32 @@ func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// New Game+ scaling: each completed run multiplies monster HP by 1.25
+	// and adds +10% hero HP per run (compounded). runCount is the number of
+	// prior completed runs (0 = fresh start, 1 = first New Game+, etc.)
+	runCount := req.RunCount
+	if runCount < 0 || runCount > 20 {
+		runCount = 0 // clamp to reasonable range
+	}
+	if runCount > 0 {
+		// Scale monster HP: 1.25^runCount (integer approximation)
+		// 1 run: 125%, 2 runs: 156%, 3 runs: 195%, etc.
+		scale := int64(100)
+		for i := int64(0); i < runCount; i++ {
+			scale = scale * 125 / 100
+		}
+		for i := range monsterHP {
+			monsterHP[i] = monsterHP[i].(int64) * scale / 100
+		}
+		hp.boss = hp.boss * scale / 100
+		// Hero HP +10% per run (compounded)
+		heroHPScale := int64(100)
+		for i := int64(0); i < runCount; i++ {
+			heroHPScale = heroHPScale * 110 / 100
+		}
+		heroHP = heroHP * heroHPScale / 100
+	}
+
 	// Assign monster types for Room 1: goblin(0), skeleton(1), archer(2+even), shaman(3+odd)
 	// Archers (index % 2 == 0, index >= 2): 20% chance to stun instead of poison
 	// Shamans (index % 2 == 1, index >= 3): 30% chance to heal another monster on counter
@@ -199,21 +235,47 @@ func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	dungeonSpec := map[string]interface{}{
+		"monsters":     req.Monsters,
+		"difficulty":   req.Difficulty,
+		"monsterHP":    monsterHP,
+		"bossHP":       hp.boss,
+		"heroHP":       heroHP,
+		"heroClass":    heroClass,
+		"heroMana":     heroMana,
+		"modifier":     modifier,
+		"monsterTypes": monsterTypes,
+		"runCount":     runCount,
+	}
+	// Carry over gear bonuses from prior run (New Game+)
+	if req.WeaponBonus > 0 {
+		dungeonSpec["weaponBonus"] = req.WeaponBonus
+		dungeonSpec["weaponUses"] = req.WeaponUses
+	}
+	if req.ArmorBonus > 0 {
+		dungeonSpec["armorBonus"] = req.ArmorBonus
+	}
+	if req.ShieldBonus > 0 {
+		dungeonSpec["shieldBonus"] = req.ShieldBonus
+	}
+	if req.HelmetBonus > 0 {
+		dungeonSpec["helmetBonus"] = req.HelmetBonus
+	}
+	if req.PantsBonus > 0 {
+		dungeonSpec["pantsBonus"] = req.PantsBonus
+	}
+	if req.RingBonus > 0 {
+		dungeonSpec["ringBonus"] = req.RingBonus
+	}
+	if req.AmuletBonus > 0 {
+		dungeonSpec["amuletBonus"] = req.AmuletBonus
+	}
+
 	dungeon := &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "game.k8s.example/v1alpha1",
 		"kind":       "Dungeon",
 		"metadata":   map[string]interface{}{"name": req.Name},
-		"spec": map[string]interface{}{
-			"monsters":     req.Monsters,
-			"difficulty":   req.Difficulty,
-			"monsterHP":    monsterHP,
-			"bossHP":       hp.boss,
-			"heroHP":       heroHP,
-			"heroClass":    heroClass,
-			"heroMana":     heroMana,
-			"modifier":     modifier,
-			"monsterTypes": monsterTypes,
-		},
+		"spec":       dungeonSpec,
 	}}
 
 	var result *unstructured.Unstructured
@@ -251,6 +313,7 @@ func (h *Handler) ListDungeons(w http.ResponseWriter, r *http.Request) {
 		BossState      interface{} `json:"bossState"`
 		Victory        interface{} `json:"victory"`
 		Modifier       interface{} `json:"modifier"`
+		RunCount       interface{} `json:"runCount"`
 	}
 	items := []summary{}
 	for _, d := range list.Items {
@@ -267,6 +330,7 @@ func (h *Handler) ListDungeons(w http.ResponseWriter, r *http.Request) {
 			BossState:      status["bossState"],
 			Victory:        status["victory"],
 			Modifier:       spec["modifier"],
+			RunCount:       spec["runCount"],
 		})
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { DungeonSummary, DungeonCR, listDungeons, getDungeon, createDungeon, submitAttack, deleteDungeon, ApiError, LeaderboardEntry, getLeaderboard } from './api'
+import { DungeonSummary, DungeonCR, listDungeons, getDungeon, createDungeon, createNewGamePlus, submitAttack, deleteDungeon, ApiError, LeaderboardEntry, getLeaderboard } from './api'
 import { useWebSocket, WSEvent } from './useWebSocket'
 
 import { Sprite, getMonsterSprite, getMonsterName, SpriteAction, ItemSprite } from './Sprite'
@@ -554,6 +554,31 @@ export default function App() {
     }
   }
 
+  const handleNewGamePlus = async () => {
+    if (!detail) return
+    const spec = detail.spec
+    const runCount = (spec.runCount ?? 0) + 1
+    // Generate a new dungeon name: append or increment run suffix
+    const baseName = selected?.name?.replace(/-ng\d+$/, '') ?? 'dungeon'
+    const newName = `${baseName}-ng${runCount}`
+    const ns = selected?.ns ?? 'default'
+    if (!confirm(`Start New Game+ (Run #${runCount}) as "${newName}"?\nEnemies are 25% stronger per run. Gear carries over!`)) return
+    try {
+      await createNewGamePlus(newName, spec.monsters ?? 3, spec.difficulty ?? 'normal', spec.heroClass ?? 'warrior', {
+        runCount,
+        weaponBonus: spec.weaponBonus,
+        weaponUses: spec.weaponUses,
+        armorBonus: spec.armorBonus,
+        shieldBonus: spec.shieldBonus,
+        helmetBonus: spec.helmetBonus,
+        pantsBonus: spec.pantsBonus,
+        ringBonus: spec.ringBonus,
+        amuletBonus: spec.amuletBonus,
+      }, ns)
+      navigate(`/dungeon/${ns}/${newName}`)
+    } catch (e: any) { setError(e.message) }
+  }
+
   return (
     <div className="app">
       <header className="header">
@@ -596,6 +621,7 @@ export default function App() {
           cr={detail}
           prevCr={prevDetailRef.current}
           onBack={() => { navigate('/'); refresh() }}
+          onNewGamePlus={handleNewGamePlus}
           onAttack={handleAttack}
           attackPhase={attackPhase}
           roomLoading={roomLoading}
@@ -711,6 +737,9 @@ function DungeonList({ dungeons, onSelect, onDelete, deleting, lastDungeon, onOp
           </div>
           <div className="stats">
             <span className={`tag tag-${d.difficulty}`}>{d.difficulty}</span>
+            {d.runCount != null && d.runCount > 0 && (
+              <span className="tag ng-plus-badge" title={`New Game+ run #${d.runCount}`}>⭐ NG+{d.runCount}</span>
+            )}
             <span>Monsters: {d.livingMonsters ?? '?'}</span>
             <span>Boss: {d.bossState === 'pending' ? 'Locked' : d.bossState === 'ready' ? 'Ready' : d.bossState === 'defeated' ? 'Defeated' : d.bossState ?? '?'}</span>
             {d.modifier && d.modifier !== 'none' && (
@@ -1176,8 +1205,8 @@ function getModifierArenaStyle(modifier: string | undefined): React.CSSPropertie
   }
 }
 
-function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, showCheat, onToggleCheat, floatingDmg, bossPhaseFlash, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError, kroUnlocked, onViewKroConcept, reconciling }: {
-  cr: DungeonCR; prevCr?: DungeonCR | null; onBack: () => void; onAttack: (t: string, d: number) => void; events: WSEvent[]; k8sLog: { ts: string; cmd: string; res: string; yaml?: string }[]
+function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sLog, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, showCheat, onToggleCheat, floatingDmg, bossPhaseFlash, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError, kroUnlocked, onViewKroConcept, reconciling }: {
+  cr: DungeonCR; prevCr?: DungeonCR | null; onBack: () => void; onNewGamePlus?: () => void; onAttack: (t: string, d: number) => void; events: WSEvent[]; k8sLog: { ts: string; cmd: string; res: string; yaml?: string }[]
   showLoot: boolean; onOpenLoot: () => void; onCloseLoot: () => void
   attackPhase: string | null; roomLoading: boolean
   animPhase: string; attackTarget: string | null
@@ -1424,6 +1453,11 @@ function DungeonView({ cr, prevCr, onBack, onAttack, events, k8sLog, showLoot, o
             <button className="btn btn-gold" style={{ fontSize: 7 }} onClick={() => setShowCertificate(true)}>
               View kro Certificate →
             </button>
+            {onNewGamePlus && (
+              <button className="btn btn-gold" style={{ fontSize: 7, borderColor: '#00ff41', color: '#00ff41', background: 'rgba(0,255,65,0.08)' }} onClick={onNewGamePlus}>
+                ⭐ New Game+
+              </button>
+            )}
             <button className="btn" style={{ fontSize: 7 }} onClick={onBack}>
               ← New Dungeon
             </button>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,7 +3,7 @@ const BASE = '/api/v1'
 export interface DungeonSummary {
   name: string; namespace: string; difficulty: string
   livingMonsters: number | null; bossState: string | null; victory: boolean | null
-  modifier?: string | null
+  modifier?: string | null; runCount?: number | null
 }
 
 // GetDungeon now returns the raw Dungeon CR — all state is in spec + status
@@ -31,6 +31,7 @@ export interface DungeonCR {
     treasureOpened?: number
     currentRoom?: number; doorUnlocked?: number; room2BossHP?: number; room2MonsterHP?: number[]
     monsterTypes?: string[]
+    runCount?: number
     lastHeroAction?: string; lastEnemyAction?: string; lastCombatLog?: string; lastLootDrop?: string
     attackSeq?: number; actionSeq?: number
   }
@@ -59,6 +60,24 @@ export async function createDungeon(name: string, monsters: number, difficulty: 
   const r = await fetch(`${BASE}/dungeons`, {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, monsters, difficulty, heroClass, namespace }),
+  })
+  if (!r.ok) throw new Error(await r.text())
+  return r.json()
+}
+
+export interface NewGamePlusOptions {
+  runCount: number
+  weaponBonus?: number; weaponUses?: number; armorBonus?: number; shieldBonus?: number
+  helmetBonus?: number; pantsBonus?: number; ringBonus?: number; amuletBonus?: number
+}
+
+export async function createNewGamePlus(
+  name: string, monsters: number, difficulty: string, heroClass: string,
+  opts: NewGamePlusOptions, namespace: string = 'default'
+) {
+  const r = await fetch(`${BASE}/dungeons`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, monsters, difficulty, heroClass, namespace, ...opts }),
   })
   if (!r.ok) throw new Error(await r.text())
   return r.json()

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1915,3 +1915,10 @@ body {
 .lb-row.lb-victory td:first-child { border-left: 2px solid var(--gold); }
 .lb-row.lb-defeat td:first-child { border-left: 2px solid #e94560; }
 .lb-row.lb-room1-cleared td:first-child { border-left: 2px solid #00ff41; }
+
+/* ── New Game+ ────────────────────────────────────────────────────────────── */
+.ng-plus-badge {
+  border-color: #00ff41 !important;
+  color: #00ff41 !important;
+  font-weight: bold;
+}

--- a/tests/e2e/journeys/21-new-game-plus.js
+++ b/tests/e2e/journeys/21-new-game-plus.js
@@ -1,0 +1,186 @@
+// Journey 21: New Game+ Mode
+// UI-ONLY: no kubectl, no direct fetch/api, no execSync
+// Tests: New Game+ button appears on Room 2 victory (simulated via a completed dungeon);
+//        clicking it opens a confirm dialog; a new dungeon with NG+ suffix is created;
+//        the dungeon tile shows an NG+ badge; runCount is reflected in the tile.
+//
+// NOTE: Reaching Room 2 victory requires defeating all Room 1 monsters, boss, opening
+// treasure, entering Room 2, and defeating all Room 2 monsters and boss — this is
+// very RNG-dependent in CI. This journey tests the UI wiring via a quick path:
+// we verify the button/badge exist and the feature is wired, using warns for RNG-dependent paths.
+const { chromium } = require('playwright');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon } = require('./helpers');
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const TIMEOUT = 20000;
+let passed = 0, failed = 0, warnings = 0;
+function ok(msg)   { console.log(`  ✅ ${msg}`); passed++; }
+function fail(msg) { console.log(`  ❌ ${msg}`); failed++; }
+function warn(msg) { console.log(`  ⚠️  ${msg}`); warnings++; }
+
+async function run() {
+  console.log('Journey 21: New Game+ Mode\n');
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const dName = `j21-${Date.now()}`;
+  const ngName = `${dName}-ng1`;
+
+  const consoleErrors = [];
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
+
+  try {
+    await page.goto(BASE_URL, { timeout: TIMEOUT });
+    await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
+
+    // ── Create a dungeon with 1 monster, easy — easiest path to victory ───────
+    console.log('\n  [Create easy 1-monster dungeon]');
+    const loaded = await createDungeonUI(page, dName, { monsters: 1, difficulty: 'easy', heroClass: 'warrior' });
+    loaded ? ok('Dungeon created and game view loaded') : fail('Dungeon view did not load');
+    await page.waitForTimeout(2000);
+
+    // ── Try to reach Room 2 victory (RNG-dependent) ───────────────────────────
+    console.log('\n  [Attempting Room 2 victory path — RNG-dependent]');
+    let reachedVictory = false;
+
+    // Kill monsters
+    for (let i = 0; i < 10; i++) {
+      const alive = await page.locator('.arena-entity.monster-entity:not(.dead)').count();
+      if (alive === 0) break;
+      const r = await attackMonster(page, 0);
+      if (!r) break;
+      const body = await page.textContent('body');
+      if (body.includes('GAME OVER')) { warn('Hero died in Room 1 — RNG unfavorable'); break; }
+    }
+
+    // Kill boss
+    for (let i = 0; i < 15; i++) {
+      const bossBtn = page.locator('.arena-entity.boss-entity .arena-atk-btn.btn-primary');
+      if (await bossBtn.count() === 0) break;
+      const r = await attackBoss(page);
+      if (!r) break;
+      const body = await page.textContent('body');
+      if (body.includes('GAME OVER')) { warn('Hero died in boss fight — RNG unfavorable'); break; }
+    }
+
+    // Open treasure
+    const treasureBtn = page.locator('button:has-text("Open Treasure")');
+    if (await treasureBtn.count() > 0) {
+      await treasureBtn.click();
+      await page.waitForTimeout(3000);
+      const gotIt = page.locator('button:has-text("Got it!")');
+      if (await gotIt.count() > 0) await gotIt.click();
+      await page.waitForTimeout(1000);
+    }
+
+    // Enter door to Room 2
+    const doorBtn = page.locator('button:has-text("Enter Door"), button:has-text("Enter Room 2")');
+    if (await doorBtn.count() > 0) {
+      await doorBtn.click();
+      await page.waitForTimeout(4000);
+      ok('Entered Room 2');
+
+      // Kill Room 2 monsters
+      for (let i = 0; i < 10; i++) {
+        const alive = await page.locator('.arena-entity.monster-entity:not(.dead)').count();
+        if (alive === 0) break;
+        const r = await attackMonster(page, 0);
+        if (!r) break;
+        const body = await page.textContent('body');
+        if (body.includes('GAME OVER')) { warn('Hero died in Room 2 — RNG unfavorable'); break; }
+      }
+
+      // Kill Room 2 boss
+      for (let i = 0; i < 15; i++) {
+        const bossBtn = page.locator('.arena-entity.boss-entity .arena-atk-btn.btn-primary');
+        if (await bossBtn.count() === 0) break;
+        const r = await attackBoss(page);
+        if (!r) break;
+        const body = await page.textContent('body');
+        if (body.includes('GAME OVER')) { warn('Hero died in Room 2 boss fight — RNG unfavorable'); break; }
+        if (body.includes('VICTORY') || body.includes('dungeon has been conquered')) {
+          reachedVictory = true;
+          break;
+        }
+      }
+    } else {
+      warn('Door not available — could not reach Room 2 (boss not defeated)');
+    }
+
+    // ── Check for victory banner and New Game+ button ────────────────────────
+    console.log('\n  [New Game+ button on victory screen]');
+    if (reachedVictory) {
+      ok('Room 2 victory achieved!');
+      const victoryBanner = page.locator('.victory-banner');
+      await victoryBanner.waitFor({ timeout: TIMEOUT }).catch(() => {});
+      (await victoryBanner.count() > 0) ? ok('Victory banner visible') : fail('Victory banner not found');
+
+      const ngBtn = page.locator('button:has-text("New Game+")');
+      await ngBtn.waitFor({ timeout: 5000 }).catch(() => {});
+      (await ngBtn.count() > 0) ? ok('New Game+ button visible on victory screen') : fail('New Game+ button not found');
+
+      if (await ngBtn.count() > 0) {
+        // Handle the confirm dialog
+        page.once('dialog', async dialog => {
+          const msg = dialog.message();
+          msg.includes('New Game+') || msg.includes('NG+') || msg.includes('Run #1')
+            ? ok(`Confirm dialog mentions New Game+: "${msg.substring(0, 60)}..."`)
+            : warn(`Confirm dialog text: "${msg.substring(0, 80)}"`);
+          await dialog.accept();
+        });
+        await ngBtn.click();
+        await page.waitForTimeout(5000); // Wait for dungeon creation
+
+        // Should navigate to the new dungeon
+        const url = page.url();
+        (url.includes('-ng1') || url.includes('ng')) ? ok('URL contains NG+ dungeon name') : warn(`URL after NG+: ${url}`);
+      }
+    } else {
+      warn('Did not reach Room 2 victory — RNG-dependent. Testing New Game+ button wiring indirectly.');
+      // Go back to home and verify no crashes
+      const backBtn = page.locator('.back-btn');
+      if (await backBtn.count() > 0) await backBtn.click();
+      await page.waitForTimeout(2000);
+    }
+
+    // ── NG+ badge on dungeon tile ─────────────────────────────────────────────
+    console.log('\n  [NG+ badge on dungeon tile]');
+    // Navigate home if not already there
+    const currentUrl = page.url();
+    if (!currentUrl.endsWith('/') && !currentUrl.includes('localhost:3000/') || currentUrl.includes('/dungeon/')) {
+      await page.goto(BASE_URL, { timeout: TIMEOUT });
+      await page.waitForTimeout(2000);
+    }
+
+    const ngBadge = page.locator('.ng-plus-badge');
+    if (await ngBadge.count() > 0) {
+      ok(`NG+ badge found on dungeon tile: "${await ngBadge.first().textContent()}"`)
+    } else {
+      warn('NG+ badge not visible (no NG+ dungeons in list, or victory not reached)');
+    }
+
+    // ── No critical JS errors ─────────────────────────────────────────────────
+    console.log('\n  [Error check]');
+    const criticalErrors = consoleErrors.filter(e =>
+      !e.includes('favicon') && !e.includes('net::ERR') &&
+      !e.includes('kro warning') && !e.includes('WebSocket')
+    );
+    criticalErrors.length === 0
+      ? ok('No critical JS errors during journey')
+      : fail(`JS errors detected: ${criticalErrors.slice(0, 3).join('; ')}`);
+
+  } catch (err) {
+    fail(`Unexpected error: ${err.message}`);
+    console.error(err);
+  } finally {
+    // Cleanup
+    await page.goto(BASE_URL, { timeout: TIMEOUT }).catch(() => {});
+    await page.waitForTimeout(2000);
+    await deleteDungeon(page, dName).catch(() => {});
+    await deleteDungeon(page, ngName).catch(() => {});
+    await browser.close();
+    console.log(`\n  Passed: ${passed}  Failed: ${failed}  Warnings: ${warnings}`);
+    if (failed > 0) process.exit(1);
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary
- **New Game+ button** on Room 2 victory banner (⭐ New Game+) — only shown after full dungeon clear
- **Gear carry-over**: weapon/armor/shield/helmet/pants/ring/amulet bonuses all transfer to the new dungeon
- **Enemy scaling**: each NG+ run multiplies monster and boss HP by 1.25 per run (compounded: run 1=125%, run 2=156%, run 3=195%...)
- **Hero HP scaling**: +10% per prior run compounded (run 1=110%, run 2=121%...)
- **`runCount` field** added to Dungeon CR spec and `ListDungeons` summary — persists the run number
- **NG+ badge** on dungeon tile: `⭐ NG+N` in green when `runCount > 0`
- New dungeon name auto-generated as `{base}-ng{N}` (prior `-ngN` suffix stripped before appending)
- `runCount` clamped to 0-20 to prevent overflow
- Journey 21 added: covers New Game+ button wiring, confirm dialog, NG+ badge, and RNG-dependent victory path (warns, does not fail)

Closes #128