### PR TITLE
fix: NG+ boots carry-over, mana potion class guard, API precondition tests (#284)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -127,6 +127,7 @@ type CreateDungeonReq struct {
 	ShieldBonus int64 `json:"shieldBonus"`
 	HelmetBonus int64 `json:"helmetBonus"`
 	PantsBonus  int64 `json:"pantsBonus"`
+	BootsBonus  int64 `json:"bootsBonus"`
 	RingBonus   int64 `json:"ringBonus"`
 	AmuletBonus int64 `json:"amuletBonus"`
 }
@@ -263,6 +264,9 @@ func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.PantsBonus > 0 {
 		dungeonSpec["pantsBonus"] = req.PantsBonus
+	}
+	if req.BootsBonus > 0 {
+		dungeonSpec["bootsBonus"] = req.BootsBonus
 	}
 	if req.RingBonus > 0 {
 		dungeonSpec["ringBonus"] = req.RingBonus
@@ -1355,16 +1359,28 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, cl
 			patchSpec["lastHeroAction"] = fmt.Sprintf("Used %s! HP: %d -> %d", item, heroHP, newHP)
 			patchSpec["lastEnemyAction"] = "Item used"
 		case "manapotion-common":
+			if heroClass != "mage" {
+				writeError(w, "mana potions can only be used by Mage", http.StatusBadRequest)
+				return fmt.Errorf("mana potion non-mage")
+			}
 			newMana := min64(heroMana+2, classMaxMana(heroClass))
 			patchSpec["heroMana"] = newMana
 			patchSpec["lastHeroAction"] = fmt.Sprintf("Used %s! Mana: %d -> %d", item, heroMana, newMana)
 			patchSpec["lastEnemyAction"] = "Item used"
 		case "manapotion-rare":
+			if heroClass != "mage" {
+				writeError(w, "mana potions can only be used by Mage", http.StatusBadRequest)
+				return fmt.Errorf("mana potion non-mage")
+			}
 			newMana := min64(heroMana+3, classMaxMana(heroClass))
 			patchSpec["heroMana"] = newMana
 			patchSpec["lastHeroAction"] = fmt.Sprintf("Used %s! Mana: %d -> %d", item, heroMana, newMana)
 			patchSpec["lastEnemyAction"] = "Item used"
 		case "manapotion-epic":
+			if heroClass != "mage" {
+				writeError(w, "mana potions can only be used by Mage", http.StatusBadRequest)
+				return fmt.Errorf("mana potion non-mage")
+			}
 			newMana := min64(heroMana+8, classMaxMana(heroClass))
 			patchSpec["heroMana"] = newMana
 			patchSpec["lastHeroAction"] = fmt.Sprintf("Used %s! Mana: %d -> %d", item, heroMana, newMana)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -572,6 +572,7 @@ export default function App() {
         shieldBonus: spec.shieldBonus,
         helmetBonus: spec.helmetBonus,
         pantsBonus: spec.pantsBonus,
+        bootsBonus: spec.bootsBonus,
         ringBonus: spec.ringBonus,
         amuletBonus: spec.amuletBonus,
       }, ns)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -68,7 +68,7 @@ export async function createDungeon(name: string, monsters: number, difficulty: 
 export interface NewGamePlusOptions {
   runCount: number
   weaponBonus?: number; weaponUses?: number; armorBonus?: number; shieldBonus?: number
-  helmetBonus?: number; pantsBonus?: number; ringBonus?: number; amuletBonus?: number
+  helmetBonus?: number; pantsBonus?: number; bootsBonus?: number; ringBonus?: number; amuletBonus?: number
 }
 
 export async function createNewGamePlus(

--- a/tests/backend-api.sh
+++ b/tests/backend-api.sh
@@ -364,7 +364,66 @@ print('monsterTypes:', mt)
   || fail "monsterTypes field missing or incorrect in dungeon spec"
 kubectl delete dungeon "$MT_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
 
-# --- Summary ---
+# --- Test 22: mana potion rejected for non-Mage hero ---
+log "Test 22: mana potion rejected for warrior"
+MANA_DUNGEON="api-test-mana-$(date +%s)"
+curl -s -X POST "$BASE/api/v1/dungeons" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$MANA_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
+sleep 15
+# Inject a manapotion-common into the warrior's inventory via kubectl patch
+kubectl patch dungeon "$MANA_DUNGEON" --type merge -p '{"spec":{"inventory":"manapotion-common"}}' 2>/dev/null || true
+sleep 3
+MP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$MANA_DUNGEON/action" \
+  -H "Content-Type: application/json" \
+  -d '{"target":"use-manapotion-common"}')
+[ "$MP_CODE" = "400" ] && pass "Mana potion rejected for warrior -> 400" || fail "Mana potion warrior -> $MP_CODE (expected 400)"
+kubectl delete dungeon "$MANA_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
+
+# --- Test 23: open-treasure rejected before boss is defeated ---
+log "Test 23: open-treasure rejected when boss alive"
+TR_DUNGEON="api-test-treasure-$(date +%s)"
+curl -s -X POST "$BASE/api/v1/dungeons" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$TR_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
+sleep 15
+TR_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$TR_DUNGEON/action" \
+  -H "Content-Type: application/json" \
+  -d '{"target":"open-treasure"}')
+[ "$TR_CODE" = "400" ] && pass "open-treasure rejected when boss alive -> 400" || fail "open-treasure -> $TR_CODE (expected 400)"
+kubectl delete dungeon "$TR_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
+
+# --- Test 24: unlock-door rejected before treasure opened ---
+log "Test 24: unlock-door rejected before treasure opened"
+DOOR_DUNGEON="api-test-door-$(date +%s)"
+curl -s -X POST "$BASE/api/v1/dungeons" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$DOOR_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
+sleep 15
+DOOR_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$DOOR_DUNGEON/action" \
+  -H "Content-Type: application/json" \
+  -d '{"target":"unlock-door"}')
+[ "$DOOR_CODE" = "400" ] && pass "unlock-door rejected before treasure opened -> 400" || fail "unlock-door -> $DOOR_CODE (expected 400)"
+kubectl delete dungeon "$DOOR_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
+
+# --- Test 25: NG+ boots carry-over ---
+log "Test 25: NG+ boots carry-over"
+BOOTS_DUNGEON="api-test-boots-$(date +%s)"
+BR=$(curl -s -w "\n%{http_code}" -X POST "$BASE/api/v1/dungeons" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$BOOTS_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\",\"runCount\":1,\"bootsBonus\":20}")
+BR_CODE=$(echo "$BR" | tail -1)
+[ "$BR_CODE" = "201" ] && pass "POST /dungeons with bootsBonus=20 -> 201" || fail "NG+ boots dungeon creation -> $BR_CODE"
+sleep 15
+BOOTS_SPEC=$(curl -s "$BASE/api/v1/dungeons/default/$BOOTS_DUNGEON")
+echo "$BOOTS_SPEC" | python3 -c "
+import json,sys
+spec=json.load(sys.stdin).get('spec',{})
+bb=spec.get('bootsBonus')
+assert bb == 20, f'bootsBonus should be 20, got {bb}'
+print('bootsBonus=20 OK')
+" 2>/dev/null && pass "bootsBonus=20 carries over in NG+ dungeon spec" || fail "bootsBonus not found in NG+ dungeon spec"
+kubectl delete dungeon "$BOOTS_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
 echo ""
 echo "========================================"
 echo "  Backend Tests: $PASS passed, $FAIL failed"

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -414,6 +414,14 @@ grep -q "1\.25\|125\|scale.*125\|125.*scale" backend/internal/handlers/handlers.
 grep -q "createNewGamePlus" frontend/src/api.ts && pass "Frontend api.ts exports createNewGamePlus" || fail "createNewGamePlus missing from api.ts"
 grep -q "onNewGamePlus\|handleNewGamePlus" frontend/src/App.tsx && pass "App.tsx wires New Game+ handler" || fail "App.tsx missing New Game+ handler"
 grep -q "ng-plus-badge" frontend/src/App.tsx && pass "App.tsx renders NG+ badge on dungeon tiles" || fail "App.tsx missing NG+ badge"
+# NG+ carry-over completeness: all 8 gear fields must be present in CreateDungeonReq and carry-over block
+grep -q "BootsBonus" backend/internal/handlers/handlers.go && pass "Backend CreateDungeonReq includes BootsBonus for NG+ carry-over" || fail "BootsBonus missing from CreateDungeonReq — boots not carried over on NG+"
+grep -q "bootsBonus.*req\.BootsBonus\|req\.BootsBonus.*bootsBonus" backend/internal/handlers/handlers.go && pass "Backend applies BootsBonus to dungeonSpec in CreateDungeon" || fail "BootsBonus not applied to dungeonSpec"
+grep -q "bootsBonus" frontend/src/App.tsx && pass "Frontend handleNewGamePlus sends bootsBonus" || fail "Frontend missing bootsBonus in handleNewGamePlus call"
+
+# --- Mana potion class guard ---
+echo "=== Mana potion class guard"
+grep -q 'manapotion.*mage\|heroClass.*mage.*mana\|mana.*heroClass.*mage' backend/internal/handlers/handlers.go && pass "Backend rejects mana potions for non-Mage heroes" || fail "Backend missing mana potion class guard"
 
 # --- Leaderboard guardrails ---
 echo "=== Leaderboard guardrails"


### PR DESCRIPTION
## Summary

- **BootsBonus carry-over in NG+**: `BootsBonus` field was missing from `CreateDungeonReq` and the carry-over block in `CreateDungeon` — boots resistance was silently reset on every New Game+ run. Now carried over like all other 8 gear fields.
- **`NewGamePlusOptions` in api.ts**: Added `bootsBonus?` field so the frontend can pass boots bonus to the backend.
- **`handleNewGamePlus` in App.tsx**: Now includes `bootsBonus: spec.bootsBonus` in the NG+ creation call.
- **Mana potion class guard**: Warriors and rogues can no longer use mana potions (returns 400). Mage-only mechanic now enforced at the API layer.
- **New backend-api.sh tests** (22–25): mana-potion-non-mage → 400, open-treasure-boss-alive → 400, unlock-door-before-treasure → 400, NG+ boots carry-over.
- **New guardrails**: BootsBonus in struct, mana potion class guard, NG+ carry-over completeness.