### PR TITLE
fix: KroGraph Inspector kindMap stale keys, RGD diff viewer missing item fields (#286)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -1982,6 +1982,12 @@ func (h *Handler) GetDungeonResource(w http.ResponseWriter, r *http.Request) {
 		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-game-config"}
 	case "combatresult":
 		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-combat-result"}
+	case "combatcm":
+		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-combat-result"}
+	case "modifiercm":
+		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-modifier-state"}
+	case "actioncm":
+		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-action-state"}
 	case "treasurecm":
 		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-treasure"}
 	case "treasuresecret":

--- a/frontend/src/KroGraph.tsx
+++ b/frontend/src/KroGraph.tsx
@@ -788,6 +788,12 @@ function computeRGDDiff(prev: DungeonCR | null | undefined, curr: DungeonCR): Di
   check('weaponBonus', 'spec.weaponBonus')
   check('weaponUses', 'spec.weaponUses')
   check('armorBonus', 'spec.armorBonus')
+  check('shieldBonus', 'spec.shieldBonus')
+  check('helmetBonus', 'spec.helmetBonus')
+  check('pantsBonus', 'spec.pantsBonus')
+  check('bootsBonus', 'spec.bootsBonus')
+  check('ringBonus', 'spec.ringBonus')
+  check('amuletBonus', 'spec.amuletBonus')
   check('currentRoom', 'spec.currentRoom')
   check('treasureOpened', 'spec.treasureOpened')
   check('doorUnlocked', 'spec.doorUnlocked')
@@ -819,6 +825,9 @@ function computeRGDDiff(prev: DungeonCR | null | undefined, curr: DungeonCR): Di
       else if (d.field === 'status.victory' || d.field === 'status.defeat') d.conceptLink = 'status-aggregation'
       else if (d.field === 'spec.treasureOpened') d.conceptLink = 'secret-output'
       else if (d.field === 'spec.currentRoom') d.conceptLink = 'spec-mutation'
+      else if (['spec.weaponBonus','spec.weaponUses','spec.armorBonus','spec.shieldBonus',
+                'spec.helmetBonus','spec.pantsBonus','spec.bootsBonus','spec.ringBonus','spec.amuletBonus'].includes(d.field))
+        d.conceptLink = 'spec-mutation'
     }
   }
 
@@ -835,21 +844,24 @@ export function KroGraphPanel({ cr, prevCr, reconciling, onViewConcept }: KroGra
   const [inspectorLoading, setInspectorLoading] = useState(false)
 
   const handleNodeSelect = useCallback(async (nodeId: string, nodeKind: string) => {
-    // Static kind map for non-indexed nodes
+    // Static kind map: keys are node IDs from buildGraph, values are ResourceKind
     const kindMap: Record<string, ResourceKind> = {
       'dungeon': 'dungeon',
       'hero': 'hero',
-      'hero-state': 'herostate',
+      'hero-cm': 'herostate',          // Hero ConfigMap (hero-graph output)
       'boss': 'boss',
-      'boss-state': 'bossstate',
+      'boss-cm': 'bossstate',          // Boss ConfigMap (boss-graph output)
       'namespace': 'namespace',
-      'game-config': 'gameconfig',
+      'gameconfig-cm': 'gameconfig',   // GameConfig ConfigMap
       'treasure': 'treasure',
       'treasure-cm': 'treasurecm',
       'treasure-secret': 'treasuresecret',
       'modifier': 'modifier',
-      'modifier-state': 'modifier',  // same CR
-      'combat-result': 'combatresult',
+      'modifier-cm': 'modifiercm',     // Modifier state ConfigMap
+      'combat-cm': 'combatcm',         // Combat result ConfigMap
+      'combat-result': 'combatresult', // backward-compat alias
+      'action-cm': 'actioncm',         // Action state ConfigMap
+      // attack-cr / action-cr are Jobs — no persistent resource to fetch, skip
     }
 
     // Extract index from monster-N / monster-cm-N / loot-mN / loot-secret-mN node IDs

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -113,7 +113,8 @@ export class ApiError extends Error {
 
 const VALID_RESOURCE_KINDS = [
   'dungeon', 'hero', 'herostate', 'boss', 'bossstate', 'namespace', 'gameconfig',
-  'monster', 'monsterstate', 'treasure', 'treasurecm', 'treasuresecret', 'modifier', 'combatresult',
+  'monster', 'monsterstate', 'treasure', 'treasurecm', 'treasuresecret', 'modifier',
+  'combatresult', 'combatcm', 'modifiercm', 'actioncm',
 ] as const
 export type ResourceKind = typeof VALID_RESOURCE_KINDS[number]
 

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -447,6 +447,15 @@ grep -q "playgroundFiredRef\|cel-playground-unlocked" frontend/src/App.tsx && pa
 grep -q "all-monsters-dead" frontend/src/App.tsx && pass "App.tsx triggers all-monsters-dead for status-aggregation" || fail "all-monsters-dead event missing from App.tsx"
 grep -q "loot-drop-string-ops" frontend/src/App.tsx && pass "App.tsx triggers loot-drop-string-ops for cel-string-ops" || fail "loot-drop-string-ops event missing from App.tsx"
 
+# --- KroGraph Inspector guardrails ---
+echo "=== KroGraph Inspector guardrails"
+grep -q "'hero-cm'" frontend/src/KroGraph.tsx && pass "KroGraph kindMap uses hero-cm (correct node ID)" || fail "KroGraph kindMap still has stale hero-state key"
+grep -q "'boss-cm'" frontend/src/KroGraph.tsx && pass "KroGraph kindMap uses boss-cm (correct node ID)" || fail "KroGraph kindMap still has stale boss-state key"
+grep -q "'gameconfig-cm'" frontend/src/KroGraph.tsx && pass "KroGraph kindMap uses gameconfig-cm (correct node ID)" || fail "KroGraph kindMap still has stale game-config key"
+grep -q "'modifier-cm'" frontend/src/KroGraph.tsx && pass "KroGraph kindMap includes modifier-cm" || fail "KroGraph kindMap missing modifier-cm"
+grep -q "helmetBonus\|pantsBonus\|bootsBonus" frontend/src/KroGraph.tsx && pass "KroGraph RGD diff viewer tracks all item bonus fields" || fail "KroGraph missing helmet/pants/boots in diff viewer"
+grep -q "modifiercm\|combatcm" frontend/src/api.ts && pass "api.ts VALID_RESOURCE_KINDS includes modifiercm/combatcm" || fail "api.ts missing modifiercm or combatcm kinds"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

- **KroGraph kindMap fixes**: The Inspector `handleNodeSelect` kindMap used stale node IDs that didn't match actual `buildGraph` output. Fixed: `hero-state` → `hero-cm`, `boss-state` → `boss-cm`, `game-config` → `gameconfig-cm`, `modifier-state` → `modifier-cm`, added `combat-cm`, `action-cm` entries. Clicking these nodes in the graph now actually opens the Inspector.
- **New backend `GetDungeonResource` cases**: `combatcm`, `modifiercm`, `actioncm` — so the Inspector can fetch these newly-wired nodes.
- **`VALID_RESOURCE_KINDS` in api.ts**: Added `combatcm`, `modifiercm`, `actioncm`.
- **RGD diff viewer**: Added `check()` calls for `shieldBonus`, `helmetBonus`, `pantsBonus`, `bootsBonus`, `ringBonus`, `amuletBonus` — all 6 item bonus fields now show in the RGD diff panel when equipped, with `spec-mutation` conceptLink.
- Guardrails updated with KroGraph Inspector correctness checks.