### PR TITLE
test: guardrails + backend-api for ring/amulet NG+ carry-over and boss-loot invariants (#294 #298)

### DIFF
--- a/tests/backend-api.sh
+++ b/tests/backend-api.sh
@@ -424,6 +424,28 @@ assert bb == 20, f'bootsBonus should be 20, got {bb}'
 print('bootsBonus=20 OK')
 " 2>/dev/null && pass "bootsBonus=20 carries over in NG+ dungeon spec" || fail "bootsBonus not found in NG+ dungeon spec"
 kubectl delete dungeon "$BOOTS_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
+
+# --- Test 26: NG+ ring/amulet carry-over ---
+log "Test 26: NG+ ring/amulet carry-over"
+RING_DUNGEON="api-test-ring-$(date +%s)"
+RR=$(curl -s -w "\n%{http_code}" -X POST "$BASE/api/v1/dungeons" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$RING_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\",\"runCount\":1,\"ringBonus\":5,\"amuletBonus\":10}")
+RR_CODE=$(echo "$RR" | tail -1)
+[ "$RR_CODE" = "201" ] && pass "POST /dungeons with ringBonus=5 amuletBonus=10 -> 201" || fail "NG+ ring/amulet dungeon creation -> $RR_CODE"
+sleep 15
+RING_SPEC=$(curl -s "$BASE/api/v1/dungeons/default/$RING_DUNGEON")
+echo "$RING_SPEC" | python3 -c "
+import json,sys
+spec=json.load(sys.stdin).get('spec',{})
+rb=spec.get('ringBonus')
+ab=spec.get('amuletBonus')
+assert rb == 5, f'ringBonus should be 5, got {rb}'
+assert ab == 10, f'amuletBonus should be 10, got {ab}'
+print(f'ringBonus={rb} amuletBonus={ab} OK')
+" 2>/dev/null && pass "ringBonus=5 and amuletBonus=10 carry over in NG+ dungeon spec" || fail "ringBonus/amuletBonus not found in NG+ dungeon spec"
+kubectl delete dungeon "$RING_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
+
 echo ""
 echo "========================================"
 echo "  Backend Tests: $PASS passed, $FAIL failed"

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -418,6 +418,19 @@ grep -q "ng-plus-badge" frontend/src/App.tsx && pass "App.tsx renders NG+ badge 
 grep -q "BootsBonus" backend/internal/handlers/handlers.go && pass "Backend CreateDungeonReq includes BootsBonus for NG+ carry-over" || fail "BootsBonus missing from CreateDungeonReq — boots not carried over on NG+"
 grep -q "bootsBonus.*req\.BootsBonus\|req\.BootsBonus.*bootsBonus" backend/internal/handlers/handlers.go && pass "Backend applies BootsBonus to dungeonSpec in CreateDungeon" || fail "BootsBonus not applied to dungeonSpec"
 grep -q "bootsBonus" frontend/src/App.tsx && pass "Frontend handleNewGamePlus sends bootsBonus" || fail "Frontend missing bootsBonus in handleNewGamePlus call"
+grep -q "RingBonus" backend/internal/handlers/handlers.go && pass "Backend CreateDungeonReq includes RingBonus for NG+ carry-over" || fail "RingBonus missing from CreateDungeonReq — ring not carried over on NG+"
+grep -q "ringBonus.*req\.RingBonus\|req\.RingBonus.*ringBonus" backend/internal/handlers/handlers.go && pass "Backend applies RingBonus to dungeonSpec in CreateDungeon" || fail "RingBonus not applied to dungeonSpec"
+grep -q "ringBonus" frontend/src/App.tsx && pass "Frontend handleNewGamePlus sends ringBonus" || fail "Frontend missing ringBonus in handleNewGamePlus call"
+grep -q "AmuletBonus" backend/internal/handlers/handlers.go && pass "Backend CreateDungeonReq includes AmuletBonus for NG+ carry-over" || fail "AmuletBonus missing from CreateDungeonReq — amulet not carried over on NG+"
+grep -q "amuletBonus.*req\.AmuletBonus\|req\.AmuletBonus.*amuletBonus" backend/internal/handlers/handlers.go && pass "Backend applies AmuletBonus to dungeonSpec in CreateDungeon" || fail "AmuletBonus not applied to dungeonSpec"
+grep -q "amuletBonus" frontend/src/App.tsx && pass "Frontend handleNewGamePlus sends amuletBonus" || fail "Frontend missing amuletBonus in handleNewGamePlus call"
+
+# --- Boss loot invariants ---
+echo "=== Boss loot invariants"
+grep -q "computeBossLoot" backend/internal/handlers/handlers.go && pass "computeBossLoot function exists in handlers.go" || fail "computeBossLoot function missing"
+! grep -A10 'func computeBossLoot' backend/internal/handlers/handlers.go | grep -q 'manapotion' && pass "computeBossLoot excludes manapotion (bosses do not drop mana pots)" || fail "computeBossLoot includes manapotion — unintentional"
+# classMaxHP must cover all 3 valid hero classes — ensure no fallthrough for known classes
+grep -q '"warrior"' backend/internal/handlers/handlers.go && grep -q '"mage"' backend/internal/handlers/handlers.go && grep -q '"rogue"' backend/internal/handlers/handlers.go && pass "classMaxHP covers all 3 hero classes (warrior/mage/rogue)" || fail "classMaxHP missing a hero class branch"
 
 # --- Mana potion class guard ---
 echo "=== Mana potion class guard"


### PR DESCRIPTION
## Summary
- Adds 6 guardrail checks for `RingBonus`/`AmuletBonus` NG+ carry-over (matching the existing BootsBonus pattern)
- Adds guardrail asserting `computeBossLoot` excludes `manapotion` (intentional invariant)
- Adds guardrail asserting `classMaxHP` covers all 3 hero classes
- Adds backend-api Test 26: ring/amulet carry-over verified in actual dungeon spec

Closes #294
Closes #298