### PR TITLE
fix: kubectl rollout restart in CI (replaces set image — fixes Argo CD race)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -94,13 +94,6 @@ jobs:
       - uses: azure/setup-kubectl@v4
       - run: aws eks update-kubeconfig --region us-west-2 --name krombat
       - run: |
-          kubectl set image deployment/rpg-backend \
-            backend=$REGISTRY/krombat/backend:${{ github.sha }} \
-            -n rpg-system
-          kubectl set image deployment/rpg-frontend \
-            frontend=$REGISTRY/krombat/frontend:${{ github.sha }} \
-            -n rpg-system
+          kubectl rollout restart deployment/rpg-backend deployment/rpg-frontend -n rpg-system
           kubectl rollout status deployment/rpg-backend -n rpg-system --timeout=120s
           kubectl rollout status deployment/rpg-frontend -n rpg-system --timeout=120s
-        env:
-          REGISTRY: 569190534191.dkr.ecr.us-west-2.amazonaws.com


### PR DESCRIPTION
## Summary
- `kubectl set image` with a SHA tag gets immediately reverted by Argo CD syncing the manifest back to `:latest`, leaving pods running stale code
- `kubectl rollout restart` adds a `restartedAt` annotation that triggers a rolling restart and pulls the current `:latest` image (imagePullPolicy: Always) — Argo CD does not revert annotations added post-sync
- This caused all merges today to deploy new ECR images without actually restarting pods

No issue number — immediate production fix.