### PR TITLE
fix: stun permanent loop — guard reapplication the same turn stun expires

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -735,8 +735,10 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 
 	// Stun
 	isStunned := false
+	wasStunnedThisTurn := false // guard: don't reapply stun the same turn it was consumed
 	if stunTurns > 0 {
 		isStunned = true
+		wasStunnedThisTurn = true
 		stunTurns--
 		dotNote += "STUNNED! "
 	}
@@ -993,7 +995,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			resisted := bootsBonus > 0 && resistRoll < bootsBonus
 			if currentRoom == 2 {
 				// Bat-boss: poison 30%, stun 15%
-				if effectRoll < 15 && stunTurns == 0 {
+				if effectRoll < 15 && stunTurns == 0 && !wasStunnedThisTurn {
 					if resisted {
 						effectNote = fmt.Sprintf(" [RESISTED stun! boots +%d%% resist]", bootsBonus)
 					} else {
@@ -1010,7 +1012,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 				}
 			} else {
 				// Dragon: stun 15%, burn 25%
-				if effectRoll < 15 && stunTurns == 0 {
+				if effectRoll < 15 && stunTurns == 0 && !wasStunnedThisTurn {
 					if resisted {
 						effectNote = fmt.Sprintf(" [RESISTED stun! boots +%d%% resist]", bootsBonus)
 					} else {
@@ -1181,7 +1183,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 
 		// Archer special: any alive archer (index % 2 == 0, index >= 2) has 20% stun chance
 		// Only triggers if hero wasn't already poisoned this round and stun not already active
-		if aliveCount > 0 && stunTurns == 0 {
+		if aliveCount > 0 && stunTurns == 0 && !wasStunnedThisTurn {
 			for i, v := range monsterHPRaw {
 				hp := sliceInt(v)
 				mtype := ""


### PR DESCRIPTION
## Bug
When the hero is stunned and attacks, `stunTurns` is decremented to 0 on that same turn. The boss/archer stun reapplication checks use `stunTurns == 0` as their gate — so they would immediately reapply stun on the same turn it expired, potentially locking the hero in permanent stun if the RNG rolled < 15 on every counter-attack.

## Root cause
Three sites in `handlers.go` (dragon boss, bat-boss, archer counter) all checked `stunTurns == 0` after the decrement, seeing the freshly-zeroed value as "no stun active".

## Fix
Added `wasStunnedThisTurn bool` flag set before decrement. All three reapplication checks now also require `!wasStunnedThisTurn`, ensuring stun cannot be reapplied on the same turn it was consumed.

Affected code paths:
- `handlers.go:998` — bat-boss stun (room 2)
- `handlers.go:1015` — dragon boss stun (room 1)  
- `handlers.go:1186` — archer stun (monster counter)