### PR TITLE
fix: suppress always-visible engine warning for transient kro reconcile conditions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -197,9 +197,13 @@ export default function App() {
               if (d.spec.modifier && d.spec.modifier !== 'none') triggerInsight('modifier-present')
               // Teach resource chaining once status is populated (Hero CR → dungeon status)
               if (d.status?.maxHeroHP) triggerInsight('resource-chaining')
-              // Teach status.conditions when kro reports an error/not-ready condition
+              // Teach status.conditions when kro reports a genuine (non-transient) error condition
               const conditions = (d.status?.conditions as any[]) || []
-              if (conditions.some((c: any) => c.type === 'Error' || (c.type === 'Ready' && c.status === 'False'))) {
+              const TRANSIENT = ['cluster mutated', 'reconciliation failed', 'NotReady', 'not ready']
+              if (conditions.some((c: any) =>
+                (c.type === 'Error' || (c.type === 'Ready' && c.status === 'False')) &&
+                c.message && !TRANSIENT.some(t => c.message.includes(t))
+              )) {
                 triggerInsight('status-conditions')
               }
             }
@@ -1365,11 +1369,12 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
     const raw = errCond?.message ?? falseCond?.message ?? null
     if (!raw) return null
 
-    // Map known transient kro messages to plain English
-    if (raw.includes('cluster mutated') || raw.includes('reconciliation failed'))
-      return 'Game engine is syncing — actions may be delayed a few seconds.'
-    if (raw.includes('NotReady') || raw.includes('not ready'))
-      return 'Dungeon is still loading, please wait…'
+    // Suppress known-transient kro reconcile messages — these fire on every
+    // reconcile cycle and are not actionable. Only surface genuinely unexpected
+    // condition messages that the user could act on.
+    if (raw.includes('cluster mutated') || raw.includes('reconciliation failed') ||
+        raw.includes('NotReady') || raw.includes('not ready'))
+      return null
     return raw
   })()
 

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -389,7 +389,7 @@ resources:
 - \`type: Ready\` — the resource graph is fully reconciled and all readyWhen checks passed
 - \`type: Error\` — kro hit a problem (CEL evaluation error, missing dependency, webhook timeout)
 
-You just saw a kro condition in the engine warning banner. This is the same mechanism Kubernetes uses for Pods (\`PodReady\`, \`ContainersReady\`) and Deployments (\`Available\`, \`Progressing\`). kro follows the same contract.`,
+This is the same mechanism Kubernetes uses for Pods (\`PodReady\`, \`ContainersReady\`) and Deployments (\`Available\`, \`Progressing\`). kro follows the same contract. You can inspect your dungeon's conditions directly: \`kubectl get dungeon <name> -o yaml\`.`,
     snippet: `# kubectl get dungeon <name> -o yaml
 status:
   conditions:


### PR DESCRIPTION
## Summary
- The "Engine warning: Game engine is syncing" banner was permanently visible because kro emits `cluster mutated` / `reconciliation failed` conditions transiently on every reconcile cycle — this is normal kro behaviour, not an error
- Instead of mapping those known-transient messages to a user-visible banner, they are now suppressed (return null); only genuinely unexpected condition messages surface
- Same fix applied to the `status-conditions` insight trigger: it now ignores the same transient message patterns so the teaching concept only fires for real errors
- Updated `status-conditions` concept body to remove "You just saw a kro condition in the engine warning banner" (the banner is now silent during normal play)

The banner and its dismiss logic remain intact for any future genuine error conditions.