### PR TITLE
fix: move leaderboard and CEL Playground into hamburger menu in toolbar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -115,6 +115,7 @@ export default function App() {
   const [showLeaderboard, setShowLeaderboard] = useState(false)
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([])
   const [leaderboardLoading, setLeaderboardLoading] = useState(false)
+  const [showHamburger, setShowHamburger] = useState(false)
 
   const triggerInsight = useCallback((event: string) => {
     const trigger = getInsightForEvent(event)
@@ -614,6 +615,16 @@ export default function App() {
       {!selected ? (
         <>
           {showOnboarding && <KroOnboardingOverlay onDismiss={() => setShowOnboarding(false)} />}
+          <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
+            <div style={{ position: 'relative' }}>
+              <button className="hamburger-btn" aria-label="Menu" onClick={() => setShowHamburger(v => !v)}>☰</button>
+              {showHamburger && (
+                <div className="hamburger-menu" onMouseLeave={() => setShowHamburger(false)}>
+                  <button className="hamburger-item" onClick={() => { setShowHamburger(false); handleOpenLeaderboard() }}>Leaderboard</button>
+                </div>
+              )}
+            </div>
+          </div>
           <CreateForm onCreate={handleCreate} />
           {resumePrompt && (
             <div className="card" style={{ borderColor: '#f5c518', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, padding: '8px 12px' }}>
@@ -624,7 +635,7 @@ export default function App() {
               </div>
             </div>
           )}
-          <DungeonList dungeons={dungeons} onSelect={handleSelect} onDelete={handleDelete} deleting={deleting} lastDungeon={resumePrompt ?? undefined} onOpenLeaderboard={handleOpenLeaderboard} />
+          <DungeonList dungeons={dungeons} onSelect={handleSelect} onDelete={handleDelete} deleting={deleting} lastDungeon={resumePrompt ?? undefined} />
           {showLeaderboard && (
             <LeaderboardPanel entries={leaderboard} loading={leaderboardLoading} onClose={() => setShowLeaderboard(false)} />
           )}
@@ -662,6 +673,7 @@ export default function App() {
           kroUnlocked={unlocked}
           onViewKroConcept={setKroConceptModal}
           reconciling={reconciling}
+          onOpenLeaderboard={handleOpenLeaderboard}
         />
       ) : null}
 
@@ -721,19 +733,13 @@ function CreateForm({ onCreate }: { onCreate: (n: string, m: number, d: string, 
   )
 }
 
-function DungeonList({ dungeons, onSelect, onDelete, deleting, lastDungeon, onOpenLeaderboard }: {
+function DungeonList({ dungeons, onSelect, onDelete, deleting, lastDungeon }: {
   dungeons: DungeonSummary[]; onSelect: (ns: string, name: string) => void
   onDelete: (ns: string, name: string) => void; deleting: Set<string>
   lastDungeon?: { ns: string; name: string }
-  onOpenLeaderboard: () => void
 }) {
   return (
     <div className="dungeon-list">
-      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 6 }}>
-        <button className="btn leaderboard-btn" onClick={onOpenLeaderboard} title="View top run leaderboard">
-          Leaderboard
-        </button>
-      </div>
       {!dungeons.length && <div className="loading">No dungeons yet — create one above</div>}
       {dungeons.map(d => {
         const isLast = lastDungeon && lastDungeon.ns === d.namespace && lastDungeon.name === d.name
@@ -899,18 +905,20 @@ function FlyingBat({ startX, startY, endX, endY, dur, onDone }: { startX: number
       style={{ left: `${pos.x}%`, top: `${pos.y}%`, transform: `translate(-50%,-50%) scaleX(${endX > startX ? 1 : -1})` }} />
   )
 }
-function EventLogTabs({ events, k8sLog, kroUnlocked, onViewKroConcept, dungeonNs, dungeonName }: {
+function EventLogTabs({ events, k8sLog, kroUnlocked, onViewKroConcept, dungeonNs, dungeonName, showPlayground, onOpenPlayground, onClosePlayground }: {
   events: WSEvent[]
   k8sLog: { ts: string; cmd: string; res: string; yaml?: string }[]
   kroUnlocked: Set<KroConceptId>
   onViewKroConcept: (id: KroConceptId) => void
   dungeonNs?: string
   dungeonName?: string
+  showPlayground: boolean
+  onOpenPlayground: () => void
+  onClosePlayground: () => void
 }) {
   const [tab, setTab] = useState<'game' | 'k8s' | 'kro'>('game')
   const [yamlModal, setYamlModal] = useState<{ yaml: string; cmd: string } | null>(null)
   const [kroConceptModal, setKroConceptModal] = useState<KroConceptId | null>(null)
-  const [showPlayground, setShowPlayground] = useState(false)
   return (
     <div style={{ marginTop: 16 }}>
       <div className="log-tabs">
@@ -956,8 +964,8 @@ function EventLogTabs({ events, k8sLog, kroUnlocked, onViewKroConcept, dungeonNs
         <KroCelPlayground
           dungeonNs={dungeonNs}
           dungeonName={dungeonName}
-          onLearnConcept={id => { setKroConceptModal(id); setShowPlayground(false) }}
-          onClose={() => setShowPlayground(false)}
+          onLearnConcept={id => { setKroConceptModal(id); onClosePlayground() }}
+          onClose={onClosePlayground}
         />
       )}
 
@@ -984,17 +992,6 @@ function EventLogTabs({ events, k8sLog, kroUnlocked, onViewKroConcept, dungeonNs
         </div>
       ) : (
         <div>
-          {dungeonNs && dungeonName && (
-            <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '4px 0 0' }}>
-              <button
-                className="kro-glossary-playground-btn"
-                onClick={() => setShowPlayground(true)}
-                aria-label="Open CEL Playground"
-              >
-                CEL Playground →
-              </button>
-            </div>
-          )}
           <KroGlossary unlocked={kroUnlocked} onViewConcept={id => setKroConceptModal(id)} />
         </div>
       )}
@@ -1282,7 +1279,7 @@ function getModifierArenaStyle(modifier: string | undefined): React.CSSPropertie
   }
 }
 
-function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sLog, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, showCheat, onToggleCheat, floatingDmg, bossPhaseFlash, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError, kroUnlocked, onViewKroConcept, reconciling }: {
+function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sLog, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, showCheat, onToggleCheat, floatingDmg, bossPhaseFlash, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError, kroUnlocked, onViewKroConcept, reconciling, onOpenLeaderboard }: {
   cr: DungeonCR; prevCr?: DungeonCR | null; onBack: () => void; onNewGamePlus?: () => void; onAttack: (t: string, d: number) => void; events: WSEvent[]; k8sLog: { ts: string; cmd: string; res: string; yaml?: string }[]
   showLoot: boolean; onOpenLoot: () => void; onCloseLoot: () => void
   attackPhase: string | null; roomLoading: boolean
@@ -1299,6 +1296,7 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
   kroUnlocked: Set<KroConceptId>
   onViewKroConcept: (id: KroConceptId) => void
   reconciling: boolean
+  onOpenLeaderboard: () => void
 }) {
   if (!cr?.metadata?.name) return <div className="loading">Loading dungeon</div>
   const spec = cr.spec || { monsters: 0, difficulty: 'normal', monsterHP: [], bossHP: 0, heroHP: 100 }
@@ -1328,6 +1326,8 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
   const gameOver = isDefeated || (!inRoomTransition && spec.bossHP <= 0 && allMonstersDead)
   const isVictory = gameOver && !isDefeated && (spec.currentRoom || 1) === 2
   const [showCertificate, setShowCertificate] = useState(false)
+  const [showDungeonHamburger, setShowDungeonHamburger] = useState(false)
+  const [showPlayground, setShowPlayground] = useState(false)
   // Auto-show certificate once on room-2 victory
   const certShownRef = useRef(false)
   useEffect(() => {
@@ -1413,6 +1413,15 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
          <h2><PixelIcon name="sword" size={14} /> {dungeonName}{spec.runCount != null && spec.runCount > 0 ? <span className="ng-plus-badge" style={{ fontSize: '6px', marginLeft: 6 }}>⭐NG+{spec.runCount}</span> : null}</h2>
          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
            <button className="help-btn" aria-label="Help" onClick={onToggleHelp}>?</button>
+           <div style={{ position: 'relative' }}>
+             <button className="hamburger-btn" aria-label="Menu" onClick={() => setShowDungeonHamburger(v => !v)}>☰</button>
+             {showDungeonHamburger && (
+               <div className="hamburger-menu" onMouseLeave={() => setShowDungeonHamburger(false)}>
+                 <button className="hamburger-item" onClick={() => { setShowDungeonHamburger(false); onOpenLeaderboard() }}>Leaderboard</button>
+                 <button className="hamburger-item" onClick={() => { setShowDungeonHamburger(false); setShowPlayground(true) }}>CEL Playground</button>
+               </div>
+             )}
+           </div>
            <button className="back-btn" onClick={onBack}>← Back</button>
          </div>
        </div>
@@ -1955,7 +1964,8 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
       <KroGraphPanel cr={cr} prevCr={prevCr} reconciling={reconciling} onViewConcept={onViewKroConcept} />
 
       <EventLogTabs events={events} k8sLog={k8sLog} kroUnlocked={kroUnlocked} onViewKroConcept={onViewKroConcept}
-        dungeonNs={cr.metadata.namespace} dungeonName={cr.metadata.name} />
+        dungeonNs={cr.metadata.namespace} dungeonName={cr.metadata.name}
+        showPlayground={showPlayground} onOpenPlayground={() => setShowPlayground(true)} onClosePlayground={() => setShowPlayground(false)} />
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1940,3 +1940,42 @@ body {
   font-size: 8px; color: #555; padding: 0 2px; transition: color 0.3s;
 }
 .minimap-icon { font-size: 9px; margin-left: 2px; }
+
+/* Hamburger menu */
+.hamburger-btn {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 12px;
+  width: 28px; height: 28px;
+  background: var(--bg-card);
+  color: var(--text-dim);
+  border: 1px solid #444;
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+}
+.hamburger-btn:hover { color: var(--text); border-color: #666; }
+.hamburger-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 2px;
+  background: var(--bg-card);
+  border: 1px solid #444;
+  z-index: 500;
+  min-width: 120px;
+  display: flex;
+  flex-direction: column;
+}
+.hamburger-item {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 7px;
+  padding: 7px 10px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid #2a2a2a;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+  white-space: nowrap;
+}
+.hamburger-item:last-child { border-bottom: none; }
+.hamburger-item:hover { background: rgba(255,255,255,0.06); color: var(--gold); }

--- a/tests/e2e/journeys/17-cel-playground.js
+++ b/tests/e2e/journeys/17-cel-playground.js
@@ -45,16 +45,23 @@ async function run() {
     const tabSwitched = await switchToTab(page, 'kro');
     tabSwitched ? ok('kro tab is present and clickable') : fail('kro tab not found');
 
-    // ── CEL Playground button present ─────────────────────────────────────────
-    console.log('\n  [Playground button]');
-    const pgBtn = page.locator('button.kro-glossary-playground-btn');
-    await pgBtn.waitFor({ timeout: TIMEOUT }).catch(() => {});
-    (await pgBtn.count() > 0) ? ok('CEL Playground button visible in kro tab') : fail('CEL Playground button not found');
-    (await pgBtn.textContent()).includes('CEL Playground') ? ok('Button text contains "CEL Playground"') : fail('Button text incorrect');
+    // ── CEL Playground button present in hamburger menu ──────────────────────
+    console.log('\n  [Playground button in hamburger menu]');
+    const hamburgerBtn = page.locator('button.hamburger-btn[aria-label="Menu"]');
+    await hamburgerBtn.waitFor({ timeout: TIMEOUT }).catch(() => {});
+    (await hamburgerBtn.count() > 0) ? ok('Hamburger menu button present in dungeon toolbar') : fail('Hamburger button not found');
+
+    await hamburgerBtn.click();
+    await page.waitForTimeout(300);
+
+    const pgItem = page.locator('button.hamburger-item:has-text("CEL Playground")');
+    await pgItem.waitFor({ timeout: TIMEOUT }).catch(() => {});
+    (await pgItem.count() > 0) ? ok('CEL Playground item visible in hamburger menu') : fail('CEL Playground item not found in hamburger menu');
+    (await pgItem.textContent()).includes('CEL Playground') ? ok('Item text contains "CEL Playground"') : fail('Item text incorrect');
 
     // ── Open playground ───────────────────────────────────────────────────────
     console.log('\n  [Open Playground]');
-    await pgBtn.click();
+    await pgItem.click();
     await page.waitForTimeout(500);
 
     const modal = page.locator('.kro-playground-modal');
@@ -191,12 +198,16 @@ async function run() {
     // Re-open playground if it was closed by learn button
     const modalVisible = await page.locator('.kro-playground-modal').count() > 0;
     if (!modalVisible) {
-      // Switch to kro tab and re-open
-      await switchToTab(page, 'kro');
-      const pgBtn2 = page.locator('button.kro-glossary-playground-btn');
-      if (await pgBtn2.count() > 0) {
-        await pgBtn2.click();
-        await page.waitForTimeout(400);
+      // Re-open via hamburger menu
+      const hBtn = page.locator('button.hamburger-btn[aria-label="Menu"]');
+      if (await hBtn.count() > 0) {
+        await hBtn.click();
+        await page.waitForTimeout(300);
+        const pgItem2 = page.locator('button.hamburger-item:has-text("CEL Playground")');
+        if (await pgItem2.count() > 0) {
+          await pgItem2.click();
+          await page.waitForTimeout(400);
+        }
       }
     }
 

--- a/tests/e2e/journeys/20-leaderboard.js
+++ b/tests/e2e/journeys/20-leaderboard.js
@@ -25,18 +25,24 @@ async function run() {
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 
-    // ── Leaderboard button visible on home screen ──────────────────────────────
-    console.log('\n  [Leaderboard button on home screen]');
-    const lbBtn = page.locator('button.leaderboard-btn');
-    await lbBtn.waitFor({ timeout: TIMEOUT }).catch(() => {});
-    (await lbBtn.count() > 0) ? ok('Leaderboard button visible') : fail('Leaderboard button not found (.leaderboard-btn)');
-    (await lbBtn.textContent()).toLowerCase().includes('leaderboard')
-      ? ok('Leaderboard button text correct')
-      : fail('Leaderboard button text incorrect');
+    // ── Leaderboard accessible via hamburger menu on home screen ──────────────
+    console.log('\n  [Leaderboard via hamburger menu]');
+    const hamBtn = page.locator('button.hamburger-btn[aria-label="Menu"]');
+    await hamBtn.waitFor({ timeout: TIMEOUT }).catch(() => {});
+    (await hamBtn.count() > 0) ? ok('Hamburger menu button visible on home screen') : fail('Hamburger button not found (.hamburger-btn)');
+
+    await hamBtn.click();
+    await page.waitForTimeout(300);
+
+    const lbItem = page.locator('button.hamburger-item:has-text("Leaderboard")');
+    (await lbItem.count() > 0) ? ok('Leaderboard item present in hamburger menu') : fail('Leaderboard item not found in hamburger menu');
+    (await lbItem.textContent()).toLowerCase().includes('leaderboard')
+      ? ok('Leaderboard item text correct')
+      : fail('Leaderboard item text incorrect');
 
     // ── Open leaderboard panel ────────────────────────────────────────────────
     console.log('\n  [Open leaderboard panel]');
-    await lbBtn.click();
+    await lbItem.click();
     await page.waitForTimeout(1000);
 
     const panel = page.locator('.leaderboard-panel');

--- a/tests/e2e/journeys/32-cel-playground-live-eval.js
+++ b/tests/e2e/journeys/32-cel-playground-live-eval.js
@@ -31,10 +31,14 @@ async function switchToTab(page, label) {
 }
 
 async function openPlayground(page) {
-  const pgBtn = page.locator('button.kro-glossary-playground-btn');
-  await pgBtn.waitFor({ timeout: TIMEOUT }).catch(() => {});
-  if (await pgBtn.count() === 0) return false;
-  await pgBtn.click();
+  const hamburgerBtn = page.locator('button.hamburger-btn[aria-label="Menu"]');
+  await hamburgerBtn.waitFor({ timeout: TIMEOUT }).catch(() => {});
+  if (await hamburgerBtn.count() === 0) return false;
+  await hamburgerBtn.click();
+  await page.waitForTimeout(300);
+  const pgItem = page.locator('button.hamburger-item:has-text("CEL Playground")');
+  if (await pgItem.count() === 0) return false;
+  await pgItem.click();
   await page.waitForTimeout(500);
   return (await page.locator('.kro-playground-modal').count()) > 0;
 }
@@ -84,14 +88,11 @@ async function run() {
     loaded ? ok('Dungeon created and game view loaded') : fail('Dungeon view did not load');
     await page.waitForTimeout(2000);
 
-    // ── Open CEL Playground via kro tab ──────────────────────────────────────
-    console.log('\n  [Open CEL Playground]');
-    const tabOk = await switchToTab(page, 'kro');
-    tabOk ? ok('kro tab accessible') : fail('kro tab not found');
-
+    // ── Open CEL Playground via hamburger menu ───────────────────────────────
+    console.log('\n  [Open CEL Playground via hamburger menu]');
     const pgOpened = await openPlayground(page);
     pgOpened
-      ? ok('CEL Playground modal opened')
+      ? ok('CEL Playground modal opened via hamburger menu')
       : fail('CEL Playground modal did not open');
 
     // ── Verify context shows dungeon name ─────────────────────────────────────

--- a/tests/e2e/smoke-test.js
+++ b/tests/e2e/smoke-test.js
@@ -433,22 +433,28 @@ async function runTests() {
      const roomText = await page.textContent('body');
      roomText.includes('Room') || roomText.includes('room') ? ok('Room indicator present') : ok('Room indicator (may not show for room 1)');
 
-     // === SECTION 21: Leaderboard button on home screen ===
+     // === SECTION 21: Leaderboard via hamburger menu on home screen ===
      console.log('\n=== Leaderboard ===');
      await page.goto(BASE_URL, { timeout: TIMEOUT });
      await page.waitForTimeout(1500);
-     const lbBtn = page.locator('button.leaderboard-btn');
-     (await lbBtn.count() > 0) ? ok('Leaderboard button present on home screen') : fail('Leaderboard button missing (.leaderboard-btn)');
-     if (await lbBtn.count() > 0) {
-       await lbBtn.click();
-       await page.waitForTimeout(800);
-       const panel = page.locator('.leaderboard-panel');
-       (await panel.count() > 0) ? ok('Leaderboard panel opens on click') : fail('Leaderboard panel not visible after click');
-       // Close it
-       const closeBtn = page.locator('.leaderboard-close');
-       if (await closeBtn.count() > 0) await closeBtn.click();
+     const hamBtn = page.locator('button.hamburger-btn[aria-label="Menu"]');
+     (await hamBtn.count() > 0) ? ok('Hamburger menu button present on home screen') : fail('Hamburger button missing (.hamburger-btn)');
+     if (await hamBtn.count() > 0) {
+       await hamBtn.click();
        await page.waitForTimeout(300);
-       (await panel.count() === 0) ? ok('Leaderboard panel closes') : ok('Leaderboard panel close (may have animation)');
+       const lbItem = page.locator('button.hamburger-item:has-text("Leaderboard")');
+       (await lbItem.count() > 0) ? ok('Leaderboard item visible in hamburger menu') : fail('Leaderboard item missing in hamburger menu');
+       if (await lbItem.count() > 0) {
+         await lbItem.click();
+         await page.waitForTimeout(800);
+         const panel = page.locator('.leaderboard-panel');
+         (await panel.count() > 0) ? ok('Leaderboard panel opens on click') : fail('Leaderboard panel not visible after click');
+         // Close it
+         const closeBtn = page.locator('.leaderboard-close');
+         if (await closeBtn.count() > 0) await closeBtn.click();
+         await page.waitForTimeout(300);
+         (await panel.count() === 0) ? ok('Leaderboard panel closes') : ok('Leaderboard panel close (may have animation)');
+       }
      }
 
      // === SECTION 22: NG+ badge hidden for fresh dungeons ===


### PR DESCRIPTION
## Summary
- Removes the Leaderboard button from inside the `DungeonList` component (where it broke the list layout)
- Adds a `☰` hamburger button to the top-right of both the home screen and the dungeon view toolbar
- Home screen hamburger: Leaderboard
- Dungeon view hamburger: Leaderboard + CEL Playground
- Removes the standalone "CEL Playground →" button from the kro glossary tab (now in hamburger)
- `showPlayground` state lifted from `EventLogTabs` into `DungeonView`; passed down as props
- Updates journeys 17, 20, 32 and smoke test section 21 to open via hamburger menu instead of old button classes