### PR TITLE
fix: leaderboard renders from any screen; bigger hamburger; CEL Playground in dungeon view

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -636,9 +636,6 @@ export default function App() {
             </div>
           )}
           <DungeonList dungeons={dungeons} onSelect={handleSelect} onDelete={handleDelete} deleting={deleting} lastDungeon={resumePrompt ?? undefined} />
-          {showLeaderboard && (
-            <LeaderboardPanel entries={leaderboard} loading={leaderboardLoading} onClose={() => setShowLeaderboard(false)} />
-          )}
         </>
       ) : loading ? (
         <div className="loading">Initializing dungeon</div>
@@ -684,6 +681,11 @@ export default function App() {
           onDismiss={() => setInsightQueue(q => q.slice(1))}
           onViewConcept={setKroConceptModal}
         />
+      )}
+
+      {/* Leaderboard — rendered globally so it works from any screen */}
+      {showLeaderboard && (
+        <LeaderboardPanel entries={leaderboard} loading={leaderboardLoading} onClose={() => setShowLeaderboard(false)} />
       )}
 
       {/* kro Concept Modal */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1944,31 +1944,31 @@ body {
 /* Hamburger menu */
 .hamburger-btn {
   font-family: 'Press Start 2P', monospace;
-  font-size: 12px;
-  width: 28px; height: 28px;
+  font-size: 13px;
+  width: 32px; height: 32px;
   background: var(--bg-card);
-  color: var(--text-dim);
-  border: 1px solid #444;
+  color: var(--gold);
+  border: 2px solid var(--gold);
   cursor: pointer;
   display: flex; align-items: center; justify-content: center;
 }
-.hamburger-btn:hover { color: var(--text); border-color: #666; }
+.hamburger-btn:hover { background: var(--gold); color: #000; }
 .hamburger-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  margin-top: 2px;
+  margin-top: 3px;
   background: var(--bg-card);
-  border: 1px solid #444;
+  border: 2px solid var(--gold);
   z-index: 500;
-  min-width: 120px;
+  min-width: 160px;
   display: flex;
   flex-direction: column;
 }
 .hamburger-item {
   font-family: 'Press Start 2P', monospace;
-  font-size: 7px;
-  padding: 7px 10px;
+  font-size: 8px;
+  padding: 10px 14px;
   background: none;
   border: none;
   border-bottom: 1px solid #2a2a2a;


### PR DESCRIPTION
## Summary
- **Leaderboard from dungeon view**: `LeaderboardPanel` was only rendered inside the `!selected` (home screen) branch — calling it from inside a dungeon silently did nothing. Moved it to a global position outside the conditional so it renders regardless of which screen is active.
- **Hamburger more prominent**: button is now gold-bordered (matches `help-btn` style), 32×32px, gold text; menu border is gold, min-width 160px; items have larger font (8px) and more padding (10×14px).
- **CEL Playground in dungeon menu**: was already wired correctly — the fix above makes the leaderboard work; CEL Playground was never broken in the dungeon view, just hard to reach.
- **Leaderboard empty**: expected when no dungeons have been completed and deleted yet — entries are written by the backend on dungeon deletion.