### PR TITLE
fix: move hamburger onMouseLeave to outer wrapper to prevent premature close

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -616,10 +616,10 @@ export default function App() {
         <>
           {showOnboarding && <KroOnboardingOverlay onDismiss={() => setShowOnboarding(false)} />}
           <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
-            <div style={{ position: 'relative' }}>
+            <div style={{ position: 'relative' }} onMouseLeave={() => setShowHamburger(false)}>
               <button className="hamburger-btn" aria-label="Menu" onClick={() => setShowHamburger(v => !v)}>☰</button>
               {showHamburger && (
-                <div className="hamburger-menu" onMouseLeave={() => setShowHamburger(false)}>
+                <div className="hamburger-menu">
                   <button className="hamburger-item" onClick={() => { setShowHamburger(false); handleOpenLeaderboard() }}>Leaderboard</button>
                 </div>
               )}
@@ -1415,15 +1415,15 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
          <h2><PixelIcon name="sword" size={14} /> {dungeonName}{spec.runCount != null && spec.runCount > 0 ? <span className="ng-plus-badge" style={{ fontSize: '6px', marginLeft: 6 }}>⭐NG+{spec.runCount}</span> : null}</h2>
          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
            <button className="help-btn" aria-label="Help" onClick={onToggleHelp}>?</button>
-           <div style={{ position: 'relative' }}>
-             <button className="hamburger-btn" aria-label="Menu" onClick={() => setShowDungeonHamburger(v => !v)}>☰</button>
-             {showDungeonHamburger && (
-               <div className="hamburger-menu" onMouseLeave={() => setShowDungeonHamburger(false)}>
-                 <button className="hamburger-item" onClick={() => { setShowDungeonHamburger(false); onOpenLeaderboard() }}>Leaderboard</button>
-                 <button className="hamburger-item" onClick={() => { setShowDungeonHamburger(false); setShowPlayground(true) }}>CEL Playground</button>
-               </div>
-             )}
-           </div>
+            <div style={{ position: 'relative' }} onMouseLeave={() => setShowDungeonHamburger(false)}>
+              <button className="hamburger-btn" aria-label="Menu" onClick={() => setShowDungeonHamburger(v => !v)}>☰</button>
+              {showDungeonHamburger && (
+                <div className="hamburger-menu">
+                  <button className="hamburger-item" onClick={() => { setShowDungeonHamburger(false); onOpenLeaderboard() }}>Leaderboard</button>
+                  <button className="hamburger-item" onClick={() => { setShowDungeonHamburger(false); setShowPlayground(true) }}>CEL Playground</button>
+                </div>
+              )}
+            </div>
            <button className="back-btn" onClick={onBack}>← Back</button>
          </div>
        </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1957,7 +1957,7 @@ body {
   position: absolute;
   top: 100%;
   right: 0;
-  margin-top: 3px;
+  margin-top: 0;
   background: var(--bg-card);
   border: 2px solid var(--gold);
   z-index: 500;


### PR DESCRIPTION
## Summary

- Moves `onMouseLeave` from the inner `.hamburger-menu` div to the outer wrapper `div` for both hamburger instances (home screen and dungeon view)
- Removes `margin-top: 3px` gap (now `0`) from `.hamburger-menu` in CSS — the 3px gap between button and dropdown was causing the menu to close before the cursor reached any items

## Root Cause

The `onMouseLeave` was on the dropdown div itself. The 3px CSS gap between the button and the dropdown meant crossing that gap triggered `onMouseLeave`, closing the menu before the user could reach any items.

## Fixes

- `frontend/src/App.tsx`: Both hamburger instances updated
- `frontend/src/index.css`: `.hamburger-menu { margin-top: 0 }` (was `3px`)