### PR TITLE
fix: CEL Playground button now visible — dismiss onboarding overlay in test helper

### DIFF
--- a/tests/e2e/journeys/17-cel-playground.js
+++ b/tests/e2e/journeys/17-cel-playground.js
@@ -228,17 +228,17 @@ async function run() {
     await glossary.waitFor({ timeout: TIMEOUT }).catch(() => {});
     (await glossary.count() > 0) ? ok('kro Glossary visible in kro tab') : fail('kro Glossary not found');
 
-    // Total concept count should be 21
+    // Total concept count should be 23
     const headerText = await page.locator('.kro-glossary-header').textContent();
-    headerText.includes('/ 21') ? ok('Glossary shows 21 total concepts') : fail(`Glossary concept count incorrect: "${headerText}"`);
+    headerText.includes('/ 23') ? ok('Glossary shows 23 total concepts') : fail(`Glossary concept count incorrect: "${headerText}"`);
 
     // ── Concept count badge ───────────────────────────────────────────────────
     console.log('\n  [kro tab badge]');
     await switchToTab(page, 'kro'); // ensure we're on kro tab; re-read badge in tabs row
     const kroTabBtn = page.locator('button.kro-tab');
     const badgeText = await kroTabBtn.textContent();
-    // Format: "kro (N/21)" — check it ends with /21)
-    /\/21\)/.test(badgeText) ? ok(`kro tab badge shows /21: "${badgeText.trim()}"`) : fail(`kro tab badge does not show /21: "${badgeText.trim()}"`);
+    // Format: "kro (N/23)" — check it ends with /23)
+    /\/23\)/.test(badgeText) ? ok(`kro tab badge shows /23: "${badgeText.trim()}"`) : fail(`kro tab badge does not show /23: "${badgeText.trim()}"`);
 
     // ── No critical JS errors ─────────────────────────────────────────────────
     console.log('\n  [Error check]');

--- a/tests/e2e/journeys/helpers.js
+++ b/tests/e2e/journeys/helpers.js
@@ -2,6 +2,12 @@
 // NO kubectl, NO direct API calls — everything through the browser UI
 
 async function createDungeonUI(page, name, { monsters = 2, difficulty = 'easy', heroClass = 'warrior' } = {}) {
+  // Dismiss onboarding overlay if present — it intercepts pointer events for new browser sessions
+  const skipBtn = page.locator('button.kro-onboard-skip');
+  if (await skipBtn.count() > 0) {
+    await skipBtn.click();
+    await page.waitForTimeout(400);
+  }
   await page.fill('input[placeholder="my-dungeon"]', name);
   await page.selectOption('select >> nth=0', difficulty);
   await page.selectOption('select >> nth=1', heroClass);


### PR DESCRIPTION
## Summary

- `tests/e2e/journeys/helpers.js`: `createDungeonUI` now dismisses the onboarding overlay (clicks "Skip intro") before interacting with the form. The overlay intercepts all pointer events in fresh browser sessions (no `kroOnboardingDone` in localStorage), which was the root cause of the CEL Playground button being unreachable in journey tests.
- `tests/e2e/journeys/17-cel-playground.js`: Updated stale concept total from 21 → 23 (two new concepts were added in PRs #312/#313 but the assertion was not updated).

## Result

Journey 17: 29/29 ✅  
Journey 32: 21/21 ✅