### PR TITLE
fix: sanitize leaderboard ConfigMap key — RFC3339 colons are invalid

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -459,6 +459,7 @@ func (h *Handler) recordLeaderboard(spec map[string]interface{}, dungeonName str
 	existing, err := cmClient.Get(ctx, leaderboardCMName, metav1.GetOptions{})
 	if err != nil {
 		// Create new ConfigMap
+		keyTs := time.Now().UTC().Format("20060102-150405")
 		newCM := &unstructured.Unstructured{Object: map[string]interface{}{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",
@@ -467,7 +468,7 @@ func (h *Handler) recordLeaderboard(spec map[string]interface{}, dungeonName str
 				"namespace": leaderboardNamespace,
 			},
 			"data": map[string]interface{}{
-				entry.Timestamp + "-" + dungeonName: string(entryJSON),
+				keyTs + "-" + dungeonName: string(entryJSON),
 			},
 		}}
 		if _, createErr := cmClient.Create(ctx, newCM, metav1.CreateOptions{}); createErr != nil {
@@ -494,7 +495,10 @@ func (h *Handler) recordLeaderboard(spec map[string]interface{}, dungeonName str
 		delete(data, oldest)
 	}
 
-	key := entry.Timestamp + "-" + dungeonName
+	// ConfigMap keys must match [-._a-zA-Z0-9]+; RFC3339 timestamps contain colons.
+	// Use a compact sortable format instead: "20060102-150405-<name>".
+	keyTs := time.Now().UTC().Format("20060102-150405")
+	key := keyTs + "-" + dungeonName
 	data[key] = string(entryJSON)
 
 	patch := map[string]interface{}{


### PR DESCRIPTION
## Root Cause

ConfigMap data keys must match `[-._a-zA-Z0-9]+`. The leaderboard key was built as `entry.Timestamp + "-" + dungeonName` where `Timestamp` is RFC3339 format (`2026-03-09T17:23:31Z`) — the colons in `T17:23:31Z` make it an invalid key. Every patch call failed with:

> `data[2026-03-09T17:23:31Z-j20-...]: Invalid value: a valid config key must consist of alphanumeric characters, '-', '_' or '.'`

## Fix

Replace the key timestamp with `time.Now().UTC().Format("20060102-150405")` (e.g. `20260309-172331`), which is:
- All alphanumeric + dashes — valid ConfigMap key
- Lexicographically sortable — preserves the oldest-entry eviction logic
- Applied to both the create-new-CM path and the patch-existing-CM path