### PR TITLE
fix: remove inRoomTransition guard blocking Room 2 victory banner and gameOver (#320)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1343,9 +1343,7 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
     }
     return 'phase1'
   })()
-  // During room 2 transition, bossHP=0 is stale from room 1 — not a real victory
-  const inRoomTransition = (spec.currentRoom || 1) === 2 && spec.bossHP <= 0 && allMonstersDead && (spec.room2BossHP || 0) > 0 && (spec.room2MonsterHP?.length ?? 0) > 0
-  const gameOver = isDefeated || (!inRoomTransition && spec.bossHP <= 0 && allMonstersDead)
+  const gameOver = isDefeated || (spec.bossHP <= 0 && allMonstersDead)
   const isVictory = gameOver && !isDefeated && (spec.currentRoom || 1) === 2
   const [showCertificate, setShowCertificate] = useState(false)
   const [showDungeonHamburger, setShowDungeonHamburger] = useState(false)


### PR DESCRIPTION
## Summary

- Removes the `inRoomTransition` guard that was incorrectly suppressing `gameOver` after Room 2 boss is defeated
- When Room 2 boss dies: `bossHP=0`, `room2BossHP>0` (never decremented — it stores the initial value), `currentRoom=2` → old guard fired `inRoomTransition=true` → `gameOver=false` → victory banner never showed and backpack buttons were never disabled
- The guard was originally meant to prevent a false-positive when transitioning from Room 1 to Room 2, but `enter-room-2` backend action sets `bossHP = r2BossHP` (> 0) before setting `currentRoom=2`, so the false-positive never occurs — the guard was dead code

## Root Cause

`inRoomTransition` checked `room2BossHP > 0`, but `room2BossHP` is the **initial** Room 2 boss HP stored in spec and is never decremented during combat (only `bossHP` is decremented). So the condition remained true after Room 2 boss death, permanently blocking victory.

## Fixes

1. **Victory banner not showing after Room 2 boss defeated** — `gameOver` now correctly becomes `true`, `isVictory` evaluates to `true`
2. **Backpack/equip buttons active after Room 2 victory** — already had `disabled={gameOver || !!attackPhase}`; now that `gameOver` is correctly `true`, they are properly disabled

Closes #320