### PR TITLE
fix: add ${} wrapper to readyWhen CEL expressions — dungeon-graph and modifier-graph (#321)

### DIFF
--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -137,7 +137,7 @@ spec:
       includeWhen:
         - ${schema.spec.modifier != "none"}
       readyWhen:
-        - "self.status.?modifierType.orValue('') != ''"
+        - "${self.status.?modifierType.orValue('') != ''}"
       template:
         apiVersion: game.k8s.example/v1alpha1
         kind: Modifier

--- a/manifests/rgds/modifier-graph.yaml
+++ b/manifests/rgds/modifier-graph.yaml
@@ -21,7 +21,7 @@ spec:
   resources:
     - id: modifierState
       readyWhen:
-        - "self.data.modifierType != ''"
+        - "${self.data.modifierType != ''}"
       template:
         apiVersion: v1
         kind: ConfigMap


### PR DESCRIPTION
## Summary

- kro EKS Managed Capability was upgraded and now requires `readyWhen` expressions to be wrapped in `${}` (same as `includeWhen`) — previously bare strings were accepted
- Both `dungeon-graph` and `modifier-graph` had readyWhen expressions without the `${}` wrapper, causing both RGDs to fail with: `failed to parse readyWhen expressions: only standalone expressions are allowed`
- `modifier-graph` has been Inactive for ~10 days as a result; `dungeon-graph` was Inactive since I deleted+recreated it to debug the ring equip issue

## Root Cause

kro `ParseConditionExpressions` checks `isStandaloneExpression()` which requires the `${...}` wrapper. The older kro version accepted bare strings; the current EKS Managed version does not.

## Ring Equip Bug (the original issue)

The ring equip failure had a separate root cause: `spec.ringBonus` and `spec.amuletBonus` were **missing from the Dungeon CRD schema**. The backend patched them correctly but K8s pruned the unknown fields silently. Evidence: `unknown field "spec.ringBonus"` warnings in backend logs. The fix is to delete and recreate the `dungeon-graph` RGD so kro regenerates the CRD from the current RGD schema (which already includes `ringBonus` and `amuletBonus`).

**This PR fixes the readyWhen syntax so the RGD can become Active. After merge, `kubectl delete rgd dungeon-graph` is needed to force CRD regeneration with `ringBonus`/`amuletBonus` fields.**

## Files Changed

- `manifests/rgds/dungeon-graph.yaml` — `readyWhen` on `modifierCR`: add `${}` wrapper
- `manifests/rgds/modifier-graph.yaml` — `readyWhen` on `modifierState`: add `${}` wrapper

Closes #321