### PR TITLE
fix: replace 'self' with resource ID in readyWhen — kro dropped 'self' alias (#321b)

### DIFF
--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -137,7 +137,7 @@ spec:
       includeWhen:
         - ${schema.spec.modifier != "none"}
       readyWhen:
-        - "${self.status.?modifierType.orValue('') != ''}"
+        - "${modifierCR.status.?modifierType.orValue('') != ''}"
       template:
         apiVersion: game.k8s.example/v1alpha1
         kind: Modifier

--- a/manifests/rgds/modifier-graph.yaml
+++ b/manifests/rgds/modifier-graph.yaml
@@ -21,7 +21,7 @@ spec:
   resources:
     - id: modifierState
       readyWhen:
-        - "${self.data.modifierType != ''}"
+        - "${modifierState.data.modifierType != ''}"
       template:
         apiVersion: v1
         kind: ConfigMap


### PR DESCRIPTION
## Summary

- Follow-up to #321: after fixing the `${}` wrapper, kro now rejects `self` as a variable name in readyWhen — only the resource's own ID is valid
- Updated `dungeon-graph.yaml`: `self.status.?...` → `modifierCR.status.?...`
- Updated `modifier-graph.yaml`: `self.data.modifierType` → `modifierState.data.modifierType`

This matches what `validateAndCompileNode` in kro's builder.go enforces: `allowedVar := node.Meta.ID` (not `"self"`).

After merge: both RGDs need to be deleted so Argo CD recreates them with the fixed YAML. `dungeon-graph` also needs recreation to regenerate the Dungeon CRD with the `ringBonus`/`amuletBonus` fields that are currently missing.