### PR TITLE
fix: dismiss onboarding overlay in smoke-test (#325)

### DIFF
--- a/tests/e2e/smoke-test.js
+++ b/tests/e2e/smoke-test.js
@@ -61,6 +61,9 @@ async function runTests() {
 
     // === SECTION 4: Create Dungeon (Warrior) ===
     console.log('\n=== Create Dungeon (Warrior) ===');
+    // Dismiss onboarding overlay if present — it intercepts pointer events in fresh browser sessions
+    const skipBtn = page.locator('button.kro-onboard-skip');
+    if (await skipBtn.count() > 0) { await skipBtn.click(); await page.waitForTimeout(300); }
     const dName = `ui-test-${Date.now()}`;
     await nameInput.fill(dName);
     await diffSelect.selectOption('easy');


### PR DESCRIPTION
## Summary

- Smoke test was failing at \"Create Dungeon (Warrior)\" because the kro onboarding overlay intercepts pointer events in fresh browser sessions
- The journey helpers.js already handles this with `page.locator('button.kro-onboard-skip').click()` — applying the same pattern to smoke-test.js
- Same fix that was previously applied to journeys via PR #315

Closes #325