### PR TITLE
feat: combatResolve specPatch + generic CEL library names (#330)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -895,12 +895,8 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 		classNote += fmt.Sprintf(" [+%d%% amulet]", amuletBonus)
 	}
 
-	// Ring regen: restore HP at start of round (before enemy hits)
-	if ringBonus > 0 {
-		maxHP := classMaxHP(heroClass)
-		heroHP = min64(heroHP+ringBonus, maxHP)
-		classNote += fmt.Sprintf(" [+%d regen]", ringBonus)
-	}
+	// Ring regen is now handled by kro specPatch node (regenRing).
+	// The backend no longer applies ring HP regen here.
 
 	// Stun zeroes damage
 	if isStunned {

--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -47,6 +47,13 @@ spec:
       dotProcessedSeq: integer | default=0
       tauntProcessedSeq: integer | default=0
       cooldownProcessedSeq: integer | default=0
+      ringProcessedSeq: integer | default=0
+      lastAttackTarget: string | default=""
+      lastAttackSeed: string | default=""
+      lastAttackIndex: integer | default=-1
+      lastAttackIsBoss: boolean | default=false
+      lastAttackIsBackstab: boolean | default=false
+      combatProcessedSeq: integer | default=0
       runCount: integer | default=0
       monsterTypes: "[]string"
     status:
@@ -202,4 +209,250 @@ spec:
       patch:
         backstabCooldown: "${schema.spec.backstabCooldown - 1}"
         cooldownProcessedSeq: "${schema.spec.attackSeq + schema.spec.actionSeq}"
+
+    # --- Ring HP regen: restore ringBonus HP per attack turn, capped at class max ---
+    # Gate: attackSeq has advanced past ringProcessedSeq AND ringBonus is active.
+    # maxHP: warrior=200, mage=120, rogue=150, fallback=100.
+    - id: regenRing
+      type: specPatch
+      includeWhen:
+        - "${schema.spec.attackSeq > schema.spec.ringProcessedSeq && schema.spec.ringBonus > 0}"
+      patch:
+        heroHP: "${(schema.spec.heroHP + schema.spec.ringBonus) > (schema.spec.heroClass == 'warrior' ? 200 : schema.spec.heroClass == 'mage' ? 120 : schema.spec.heroClass == 'rogue' ? 150 : 100) ? (schema.spec.heroClass == 'warrior' ? 200 : schema.spec.heroClass == 'mage' ? 120 : schema.spec.heroClass == 'rogue' ? 150 : 100) : (schema.spec.heroHP + schema.spec.ringBonus)}"
+        ringProcessedSeq: "${schema.spec.attackSeq}"
+
+    # --- Combat resolution: compute all combat math in one atomic specPatch ---
+    # Gate: attackSeq has advanced past combatProcessedSeq AND there's a target.
+    # This replaces the Go backend's processCombat function.
+    # Uses cel.bind() for intermediate values and kro CEL extensions for RNG + arrays.
+    - id: combatResolve
+      type: specPatch
+      includeWhen:
+        - "${schema.spec.attackSeq > schema.spec.combatProcessedSeq && schema.spec.lastAttackTarget != ''}"
+      patch:
+        # --- Monster HP: apply hero damage to targeted monster ---
+        monsterHP: >-
+          ${!schema.spec.lastAttackIsBoss && schema.spec.lastAttackIndex >= 0 ?
+            cel.bind(s, schema.spec.lastAttackSeed,
+            cel.bind(diff, schema.spec.difficulty,
+            cel.bind(baseDmg,
+              diff == 'easy' ? random.seededInt(s + '-d1', 20) + 3
+              : diff == 'hard' ? random.seededInt(s + '-d1', 20) + random.seededInt(s + '-d2', 20) + random.seededInt(s + '-d3', 20) + 8
+              : random.seededInt(s + '-d1', 12) + random.seededInt(s + '-d2', 12) + 6,
+            cel.bind(classMult,
+              schema.spec.lastAttackIsBackstab ? baseDmg * 3
+              : schema.spec.heroClass == 'mage' ? (schema.spec.heroMana > 0 ? baseDmg * 13 / 10 : baseDmg / 2)
+              : schema.spec.heroClass == 'rogue' ? baseDmg * 11 / 10
+              : baseDmg,
+            cel.bind(modMult,
+              schema.spec.modifier == 'curse-darkness' ? classMult * 3 / 4
+              : schema.spec.modifier == 'blessing-strength' ? classMult * 3 / 2
+              : schema.spec.modifier == 'blessing-fortune' && random.seededInt(s + '-crit', 100) < 20 ? classMult * 2
+              : classMult,
+            cel.bind(wpnDmg, schema.spec.weaponUses > 0 ? modMult + schema.spec.weaponBonus : modMult,
+            cel.bind(helmDmg, schema.spec.helmetBonus > 0 && random.seededInt(s + '-helmet-crit', 100) < schema.spec.helmetBonus ? wpnDmg * 2 : wpnDmg,
+            cel.bind(amuDmg, schema.spec.amuletBonus > 0 ? helmDmg * (100 + schema.spec.amuletBonus) / 100 : helmDmg,
+            cel.bind(finalDmg, schema.spec.stunTurns > 0 ? 0 : amuDmg,
+            cel.bind(idx, schema.spec.lastAttackIndex,
+            cel.bind(oldHP, schema.spec.monsterHP[idx],
+            cel.bind(newHP, oldHP - finalDmg < 0 ? 0 : oldHP - finalDmg,
+              lists.set(schema.spec.monsterHP, idx, newHP)
+            ))))))))))))
+            : schema.spec.monsterHP}
+
+        # --- Boss HP: apply hero damage to boss ---
+        bossHP: >-
+          ${schema.spec.lastAttackIsBoss ?
+            cel.bind(s, schema.spec.lastAttackSeed,
+            cel.bind(diff, schema.spec.difficulty,
+            cel.bind(baseDmg,
+              (diff == 'easy' ? random.seededInt(s + '-d1', 20) + 3
+               : diff == 'hard' ? random.seededInt(s + '-d1', 20) + random.seededInt(s + '-d2', 20) + random.seededInt(s + '-d3', 20) + 8
+               : random.seededInt(s + '-d1', 12) + random.seededInt(s + '-d2', 12) + 6)
+              + random.seededInt(s + '-dboss', 20) + 3,
+            cel.bind(classMult,
+              schema.spec.lastAttackIsBackstab ? baseDmg * 3
+              : schema.spec.heroClass == 'mage' ? (schema.spec.heroMana > 0 ? baseDmg * 13 / 10 : baseDmg / 2)
+              : schema.spec.heroClass == 'rogue' ? baseDmg * 11 / 10
+              : baseDmg,
+            cel.bind(modMult,
+              schema.spec.modifier == 'curse-darkness' ? classMult * 3 / 4
+              : schema.spec.modifier == 'blessing-strength' ? classMult * 3 / 2
+              : schema.spec.modifier == 'blessing-fortune' && random.seededInt(s + '-crit', 100) < 20 ? classMult * 2
+              : classMult,
+            cel.bind(wpnDmg, schema.spec.weaponUses > 0 ? modMult + schema.spec.weaponBonus : modMult,
+            cel.bind(helmDmg, schema.spec.helmetBonus > 0 && random.seededInt(s + '-helmet-crit', 100) < schema.spec.helmetBonus ? wpnDmg * 2 : wpnDmg,
+            cel.bind(amuDmg, schema.spec.amuletBonus > 0 ? helmDmg * (100 + schema.spec.amuletBonus) / 100 : helmDmg,
+            cel.bind(finalDmg, schema.spec.stunTurns > 0 ? 0 : amuDmg,
+            cel.bind(newBossHP, schema.spec.bossHP - finalDmg < 0 ? 0 : schema.spec.bossHP - finalDmg,
+              newBossHP
+            ))))))))))
+            : schema.spec.bossHP}
+
+        # --- Weapon uses: decrement if weapon was used ---
+        weaponUses: >-
+          ${schema.spec.weaponUses > 0 ? schema.spec.weaponUses - 1 : 0}
+
+        # --- Weapon bonus: zero out if weapon broke ---
+        weaponBonus: >-
+          ${schema.spec.weaponUses > 0 && schema.spec.weaponUses - 1 == 0 ? 0 : schema.spec.weaponBonus}
+
+        # --- Hero mana: decrement if mage attacked with mana, regen on monster kill ---
+        heroMana: >-
+          ${cel.bind(s, schema.spec.lastAttackSeed,
+          cel.bind(mana, schema.spec.heroMana,
+          cel.bind(usedMana,
+            schema.spec.heroClass == 'mage' && mana > 0 && !schema.spec.lastAttackIsBackstab && schema.spec.stunTurns == 0,
+          cel.bind(manaAfterUse, usedMana ? mana - 1 : mana,
+          cel.bind(diff, schema.spec.difficulty,
+          cel.bind(baseDmg,
+            (diff == 'easy' ? random.seededInt(s + '-d1', 20) + 3
+             : diff == 'hard' ? random.seededInt(s + '-d1', 20) + random.seededInt(s + '-d2', 20) + random.seededInt(s + '-d3', 20) + 8
+             : random.seededInt(s + '-d1', 12) + random.seededInt(s + '-d2', 12) + 6)
+            + (schema.spec.lastAttackIsBoss ? random.seededInt(s + '-dboss', 20) + 3 : 0),
+          cel.bind(classMult,
+            schema.spec.lastAttackIsBackstab ? baseDmg * 3
+            : schema.spec.heroClass == 'mage' ? (mana > 0 ? baseDmg * 13 / 10 : baseDmg / 2)
+            : schema.spec.heroClass == 'rogue' ? baseDmg * 11 / 10
+            : baseDmg,
+          cel.bind(modMult,
+            schema.spec.modifier == 'curse-darkness' ? classMult * 3 / 4
+            : schema.spec.modifier == 'blessing-strength' ? classMult * 3 / 2
+            : schema.spec.modifier == 'blessing-fortune' && random.seededInt(s + '-crit', 100) < 20 ? classMult * 2
+            : classMult,
+          cel.bind(wpnDmg, schema.spec.weaponUses > 0 ? modMult + schema.spec.weaponBonus : modMult,
+          cel.bind(helmDmg, schema.spec.helmetBonus > 0 && random.seededInt(s + '-helmet-crit', 100) < schema.spec.helmetBonus ? wpnDmg * 2 : wpnDmg,
+          cel.bind(amuDmg, schema.spec.amuletBonus > 0 ? helmDmg * (100 + schema.spec.amuletBonus) / 100 : helmDmg,
+          cel.bind(finalDmg, schema.spec.stunTurns > 0 ? 0 : amuDmg,
+          cel.bind(killedMonster,
+            !schema.spec.lastAttackIsBoss && schema.spec.lastAttackIndex >= 0
+            && schema.spec.monsterHP[schema.spec.lastAttackIndex] > 0
+            && schema.spec.monsterHP[schema.spec.lastAttackIndex] - finalDmg <= 0,
+          cel.bind(regenMana,
+            killedMonster && schema.spec.heroClass == 'mage' && manaAfterUse < 8,
+            killedMonster && regenMana ? manaAfterUse + 1 : manaAfterUse
+          ))))))))))))))}
+
+        # --- Hero HP: apply counter-attack from boss or monsters ---
+        heroHP: >-
+          ${cel.bind(s, schema.spec.lastAttackSeed,
+          cel.bind(diff, schema.spec.difficulty,
+          cel.bind(hp, schema.spec.heroHP,
+          cel.bind(baseDmg,
+            (diff == 'easy' ? random.seededInt(s + '-d1', 20) + 3
+             : diff == 'hard' ? random.seededInt(s + '-d1', 20) + random.seededInt(s + '-d2', 20) + random.seededInt(s + '-d3', 20) + 8
+             : random.seededInt(s + '-d1', 12) + random.seededInt(s + '-d2', 12) + 6)
+            + (schema.spec.lastAttackIsBoss ? random.seededInt(s + '-dboss', 20) + 3 : 0),
+          cel.bind(classMult,
+            schema.spec.lastAttackIsBackstab ? baseDmg * 3
+            : schema.spec.heroClass == 'mage' ? (schema.spec.heroMana > 0 ? baseDmg * 13 / 10 : baseDmg / 2)
+            : schema.spec.heroClass == 'rogue' ? baseDmg * 11 / 10
+            : baseDmg,
+          cel.bind(modMult,
+            schema.spec.modifier == 'curse-darkness' ? classMult * 3 / 4
+            : schema.spec.modifier == 'blessing-strength' ? classMult * 3 / 2
+            : schema.spec.modifier == 'blessing-fortune' && random.seededInt(s + '-crit', 100) < 20 ? classMult * 2
+            : classMult,
+          cel.bind(wpnDmg, schema.spec.weaponUses > 0 ? modMult + schema.spec.weaponBonus : modMult,
+          cel.bind(helmDmg, schema.spec.helmetBonus > 0 && random.seededInt(s + '-helmet-crit', 100) < schema.spec.helmetBonus ? wpnDmg * 2 : wpnDmg,
+          cel.bind(amuDmg, schema.spec.amuletBonus > 0 ? helmDmg * (100 + schema.spec.amuletBonus) / 100 : helmDmg,
+          cel.bind(finalDmg, schema.spec.stunTurns > 0 ? 0 : amuDmg,
+          cel.bind(isBoss, schema.spec.lastAttackIsBoss,
+          cel.bind(newBossHP, isBoss ? (schema.spec.bossHP - finalDmg < 0 ? 0 : schema.spec.bossHP - finalDmg) : schema.spec.bossHP,
+          cel.bind(maxBossHP, diff == 'easy' ? 200 : diff == 'hard' ? 800 : 400,
+          cel.bind(bossCounter,
+            isBoss && newBossHP > 0 ?
+              cel.bind(bc, diff == 'easy' ? 3 : diff == 'hard' ? 8 : 5,
+              cel.bind(hpPct, newBossHP * 100 / maxBossHP,
+              cel.bind(dmgMult, hpPct > 50 ? 10 : hpPct > 25 ? 15 : 20,
+              cel.bind(phased, bc * dmgMult / 10,
+              cel.bind(modded,
+                schema.spec.modifier == 'curse-fury' ? phased * 2
+                : schema.spec.modifier == 'blessing-resilience' ? phased / 2
+                : phased,
+              cel.bind(armored, schema.spec.armorBonus > 0 ? modded * (100 - schema.spec.armorBonus) / 100 : modded,
+              cel.bind(shielded, schema.spec.shieldBonus > 0 && armored > 0 && random.seededInt(s + '-shield', 100) < schema.spec.shieldBonus ? 0 : armored,
+              cel.bind(classed,
+                schema.spec.heroClass == 'warrior' ? shielded * 3 / 4
+                : schema.spec.heroClass == 'rogue' && random.seededInt(s + '-dodge-boss', 100) < 25 ? 0
+                : shielded,
+              cel.bind(pantsed, schema.spec.pantsBonus > 0 && classed > 0 && random.seededInt(s + '-pants-dodge', 100) < schema.spec.pantsBonus ? 0 : classed,
+              cel.bind(taunted, schema.spec.tauntActive == 2 && pantsed > 0 ? pantsed * 2 / 5 : pantsed,
+              cel.bind(oneshotProtected, hp - taunted < 1 && taunted < hp ? hp - 1 : taunted,
+                oneshotProtected
+              )))))))))))
+            : 0,
+          cel.bind(idx, schema.spec.lastAttackIndex,
+          cel.bind(newMonsterArr,
+            (!isBoss && idx >= 0) ?
+              lists.set(schema.spec.monsterHP, idx, (schema.spec.monsterHP[idx] - finalDmg < 0 ? 0 : schema.spec.monsterHP[idx] - finalDmg))
+            : schema.spec.monsterHP,
+          cel.bind(aliveCount,
+            (!isBoss && idx >= 0) ? newMonsterArr.filter(h, h > 0).size() : 0,
+          cel.bind(monsterCounter,
+            !isBoss && idx >= 0 && aliveCount > 0 ?
+              cel.bind(mbc, diff == 'easy' ? 1 : diff == 'hard' ? 3 : 2,
+              cel.bind(mtotal, aliveCount * mbc,
+              cel.bind(mModded, schema.spec.modifier == 'blessing-resilience' ? mtotal / 2 : mtotal,
+              cel.bind(mArmored, schema.spec.armorBonus > 0 ? mModded * (100 - schema.spec.armorBonus) / 100 : mModded,
+              cel.bind(mShielded, schema.spec.shieldBonus > 0 && mArmored > 0 && random.seededInt(s + '-shield-m', 100) < schema.spec.shieldBonus ? 0 : mArmored,
+              cel.bind(mClassed,
+                schema.spec.heroClass == 'warrior' ? mShielded * 3 / 4
+                : schema.spec.heroClass == 'rogue' && random.seededInt(s + '-dodge-monster', 100) < 25 ? 0
+                : mShielded,
+              cel.bind(mPantsed, schema.spec.pantsBonus > 0 && mClassed > 0 && random.seededInt(s + '-pants-dodge', 100) < schema.spec.pantsBonus ? 0 : mClassed,
+              cel.bind(mTaunted, schema.spec.tauntActive == 2 && mPantsed > 0 ? mPantsed * 2 / 5 : mPantsed,
+              cel.bind(mOSP, hp - mTaunted < 1 && mTaunted < hp ? hp - 1 : mTaunted,
+                mOSP
+              )))))))))
+            : 0,
+          cel.bind(totalCounter, bossCounter + monsterCounter,
+            hp - totalCounter < 0 ? 0 : hp - totalCounter
+          )))))))))))))))))))}
+
+        # --- Status effects from boss/monster counter-attacks ---
+        poisonTurns: >-
+          ${cel.bind(s, schema.spec.lastAttackSeed,
+          cel.bind(pt, schema.spec.poisonTurns,
+          cel.bind(isBoss, schema.spec.lastAttackIsBoss,
+          cel.bind(effectRoll, random.seededInt(s + '-fx', 100),
+          cel.bind(resistRoll, random.seededInt(s + '-boots-resist', 100),
+          cel.bind(resisted, schema.spec.bootsBonus > 0 && resistRoll < schema.spec.bootsBonus,
+            isBoss ?
+              (schema.spec.currentRoom == 2 ?
+                (effectRoll >= 15 && effectRoll < 45 && pt == 0 && !resisted ? 3 : pt)
+                : pt)
+            : (!isBoss && pt == 0 && effectRoll < 20 && !resisted ? 3 : pt)
+          ))))))}
+
+        burnTurns: >-
+          ${cel.bind(s, schema.spec.lastAttackSeed,
+          cel.bind(bt, schema.spec.burnTurns,
+          cel.bind(isBoss, schema.spec.lastAttackIsBoss,
+          cel.bind(effectRoll, random.seededInt(s + '-fx', 100),
+          cel.bind(resistRoll, random.seededInt(s + '-boots-resist', 100),
+          cel.bind(resisted, schema.spec.bootsBonus > 0 && resistRoll < schema.spec.bootsBonus,
+            isBoss && schema.spec.currentRoom == 1 ?
+              (effectRoll >= 15 && effectRoll < 40 && bt == 0 && !resisted ? 2 : bt)
+            : bt
+          ))))))}
+
+        stunTurns: >-
+          ${cel.bind(s, schema.spec.lastAttackSeed,
+          cel.bind(st, schema.spec.stunTurns,
+          cel.bind(wasStunned, st > 0,
+          cel.bind(isBoss, schema.spec.lastAttackIsBoss,
+          cel.bind(effectRoll, random.seededInt(s + '-fx', 100),
+          cel.bind(resistRoll, random.seededInt(s + '-boots-resist', 100),
+          cel.bind(resisted, schema.spec.bootsBonus > 0 && resistRoll < schema.spec.bootsBonus,
+            isBoss ?
+              (effectRoll < 15 && st == 0 && !wasStunned && !resisted ? 1 : st)
+            : st
+          )))))))}
+
+        # --- Combat processed sentinel ---
+        combatProcessedSeq: "${schema.spec.attackSeq}"
+
+        # --- Clear attack context so specPatch doesn't re-fire ---
+        lastAttackTarget: "${''}"
 

--- a/manifests/rgds/loot-graph.yaml
+++ b/manifests/rgds/loot-graph.yaml
@@ -17,9 +17,22 @@ spec:
       dropped: boolean | default=false
     status:
       itemName: "${lootSecret.metadata.name}"
-      description: "${lootSecret.data.description}"
+      description: "${lootInfo.data.description}"
 
   resources:
+    - id: lootInfo
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: "${schema.metadata.name}-info"
+          namespace: ${schema.metadata.namespace}
+          labels:
+            game.k8s.example/dungeon: ${schema.spec.dungeonName}
+            game.k8s.example/entity: loot-info
+        data:
+          description: "${schema.spec.itemType == 'weapon' ? 'A ' + schema.spec.rarity + ' weapon (+' + string(schema.spec.stat) + ' damage, 3 uses)' : schema.spec.itemType == 'armor' ? 'A ' + schema.spec.rarity + ' armor (+' + string(schema.spec.stat) + '% defense)' : schema.spec.itemType == 'shield' ? 'A ' + schema.spec.rarity + ' shield (' + string(schema.spec.stat) + '% block chance)' : schema.spec.itemType == 'hppotion' ? 'A ' + schema.spec.rarity + ' HP potion (restores ' + string(schema.spec.stat) + ' HP)' : schema.spec.itemType == 'manapotion' ? 'A ' + schema.spec.rarity + ' mana potion (restores ' + string(schema.spec.stat) + ' mana)' : schema.spec.itemType == 'helmet' ? 'A ' + schema.spec.rarity + ' helmet (+' + string(schema.spec.stat) + '% crit chance)' : schema.spec.itemType == 'pants' ? 'A ' + schema.spec.rarity + ' pants (+' + string(schema.spec.stat) + '% dodge chance)' : schema.spec.itemType == 'boots' ? 'A ' + schema.spec.rarity + ' boots (+' + string(schema.spec.stat) + '% status resist)' : schema.spec.itemType == 'ring' ? 'A ' + schema.spec.rarity + ' ring (+' + string(schema.spec.stat) + ' HP regen per round)' : 'A ' + schema.spec.rarity + ' amulet (+' + string(schema.spec.stat) + '% damage boost)'}"
+
     - id: lootSecret
       template:
         apiVersion: v1

--- a/manifests/rgds/test/gamecel-test.yaml
+++ b/manifests/rgds/test/gamecel-test.yaml
@@ -1,0 +1,43 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: gamecel-test
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: GameCelTest
+    group: game.k8s.example
+    spec:
+      seed: string | default="test-seed"
+      inventory: string | default=""
+      monsterHP: "[]integer"
+    status:
+      roll20: "${gameConfig.data.roll20}"
+      roll100: "${gameConfig.data.roll100}"
+      roll36: "${gameConfig.data.roll36}"
+      arrayResult: "${gameConfig.data.arrayResult}"
+      csvRemoveResult: "${gameConfig.data.csvRemoveResult}"
+      csvAddResult: "${gameConfig.data.csvAddResult}"
+      csvContainsResult: "${gameConfig.data.csvContainsResult}"
+
+  resources:
+    - id: gameConfig
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: "${schema.metadata.name + '-gamecel'}"
+          namespace: default
+        data:
+          # Test random.seededInt — deterministic roll
+          roll20: "${string(random.seededInt(schema.spec.seed, 20))}"
+          roll100: "${string(random.seededInt(schema.spec.seed + '-shield', 100))}"
+          roll36: "${string(random.seededInt(schema.spec.seed + '-rar', 36))}"
+          # Test lists.set — set element at index
+          arrayResult: "${string(lists.set(schema.spec.monsterHP, 1, 0)[0]) + ',' + string(lists.set(schema.spec.monsterHP, 1, 0)[1]) + ',' + string(lists.set(schema.spec.monsterHP, 1, 0)[2])}"
+          # Test csv.remove
+          csvRemoveResult: "${csv.remove('weapon-common,hppotion-rare,armor-epic', 'hppotion-rare')}"
+          # Test csv.add
+          csvAddResult: "${csv.add(schema.spec.inventory, 'sword', 8)}"
+          # Test csv.contains
+          csvContainsResult: "${csv.contains('weapon-common,armor-rare', 'weapon-common') ? 'true' : 'false'}"


### PR DESCRIPTION
## Summary

- **Fixes dungeon-graph Inactive state**: Renames `game.seededRoll` → `random.seededInt`, `game.arraySet` → `lists.set` to match the deployed kro image that uses generic library names
- **Adds combatResolve specPatch**: Full combat math engine in CEL (hero damage, counter-attacks, status effects, mana, weapon durability) — gated by `lastAttackTarget != ''` so it won't fire until backend migration
- **Adds regenRing specPatch**: Ring HP regen per attack turn, class-capped
- **Removes ring regen from Go backend**: Now handled by kro
- **Fixes loot-graph status types**
- **Adds gamecel-test RGD** for CEL function validation

## Safety

The combatResolve specPatch gate condition (`attackSeq > combatProcessedSeq && lastAttackTarget != ''`) ensures it never fires because the Go backend never writes `lastAttackTarget`. This is an incremental deployment — the CEL is compiled and validated by kro but won't execute until the backend is updated in a future PR.

Closes #330 (partial — combat math CEL ready, backend cutover pending)