### PR TITLE
feat: migrate loot drops to kro CEL specPatch (#330)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -916,7 +916,6 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 	// combat math for log text generation (same FNV-1a RNG → same results as kro).
 	patchSpec := map[string]interface{}{
 		"attackSeq":            newSeq,
-		"lastLootDrop":         "",
 		"lastAttackTarget":     realTarget,
 		"lastAttackSeed":       attackUID,
 		"lastAttackIndex":      int64(-1), // will be set below for monster targets
@@ -934,7 +933,8 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 		patchSpec["cooldownProcessedSeq"] = newSeq + actionSeqForGate
 	}
 
-	lootDrop := ""
+	// MIGRATION: loot state (lastLootDrop, inventory) is now computed by kro's combatResolve.
+	// Backend still needs inventory2 to decide log text ("inventory full!" vs "Dropped X!").
 	inventory2 := inventory
 
 	if isBossTarget {
@@ -1051,7 +1051,6 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			bossLootItem := computeBossLoot(name)
 			if updated, added := inventoryAdd(inventory2, bossLootItem); added {
 				inventory2 = updated
-				lootDrop = bossLootItem
 				classNote += " Boss dropped " + bossLootItem + "!"
 			} else {
 				classNote += " Boss dropped " + bossLootItem + " (inventory full!)"
@@ -1063,8 +1062,8 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 		// Backend writes only log text and loot/inventory.
 		patchSpec["lastHeroAction"] = heroAction
 		patchSpec["lastEnemyAction"] = enemyAction + effectNote
-		patchSpec["lastLootDrop"] = lootDrop
-		patchSpec["inventory"] = inventory2
+		// MIGRATION: lastLootDrop and inventory are now computed by kro's combatResolve specPatch.
+		// Backend keeps computeBossLoot() for log text (classNote) but does not write loot state.
 
 	} else {
 		// Monster target — parse index as native int to avoid int64→int narrowing
@@ -1109,7 +1108,6 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			if dropped, item := computeMonsterLoot(name, idxInt, difficulty); dropped {
 				if updated, added := inventoryAdd(inventory2, item); added {
 					inventory2 = updated
-					lootDrop = item
 					classNote += " Dropped " + item + "!"
 				} else {
 					classNote += " " + item + " dropped but inventory full!"
@@ -1260,11 +1258,9 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 
 		heroAction := fmt.Sprintf("Hero (%s) deals %d damage to %s (HP: %d -> %d)%s", heroClass, effectiveDamage, realTarget, oldHP, newHP, classNote)
 		// MIGRATION: game state (heroHP, monsterHP, poisonTurns, etc.) is computed by kro.
-		// Backend writes only log text and loot/inventory.
+		// Backend writes only log text. lastLootDrop and inventory computed by kro combatResolve.
 		patchSpec["lastHeroAction"] = heroAction
 		patchSpec["lastEnemyAction"] = enemyAction + effectNote
-		patchSpec["lastLootDrop"] = lootDrop
-		patchSpec["inventory"] = inventory2
 	}
 
 	patch := map[string]interface{}{"spec": patchSpec}

--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -523,6 +523,116 @@ spec:
         # --- Combat processed sentinel ---
         combatProcessedSeq: "${schema.spec.attackSeq}"
 
+        # --- Loot drop: compute on kill transition (monster or boss) ---
+        lastLootDrop: >-
+          ${cel.bind(s, schema.spec.lastAttackSeed,
+          cel.bind(isBoss, schema.spec.lastAttackIsBoss,
+          cel.bind(diff, schema.spec.difficulty,
+          cel.bind(idx, schema.spec.lastAttackIndex,
+          cel.bind(alpha, 'abcdefghijklmnopqrstuvwxyz0123456789',
+          cel.bind(name, schema.metadata.name,
+          cel.bind(baseDmg,
+            (diff == 'easy' ? random.seededInt(s + '-d1', 20) + 3
+             : diff == 'hard' ? random.seededInt(s + '-d1', 20) + random.seededInt(s + '-d2', 20) + random.seededInt(s + '-d3', 20) + 8
+             : random.seededInt(s + '-d1', 12) + random.seededInt(s + '-d2', 12) + 6)
+            + (isBoss ? random.seededInt(s + '-dboss', 20) + 3 : 0),
+          cel.bind(classMult,
+            schema.spec.lastAttackIsBackstab ? baseDmg * 3
+            : schema.spec.heroClass == 'mage' ? (schema.spec.heroMana > 0 ? baseDmg * 13 / 10 : baseDmg / 2)
+            : schema.spec.heroClass == 'rogue' ? baseDmg * 11 / 10
+            : baseDmg,
+          cel.bind(modMult,
+            schema.spec.modifier == 'curse-darkness' ? classMult * 3 / 4
+            : schema.spec.modifier == 'blessing-strength' ? classMult * 3 / 2
+            : schema.spec.modifier == 'blessing-fortune' && random.seededInt(s + '-crit', 100) < 20 ? classMult * 2
+            : classMult,
+          cel.bind(wpnDmg, schema.spec.weaponUses > 0 ? modMult + schema.spec.weaponBonus : modMult,
+          cel.bind(helmDmg, schema.spec.helmetBonus > 0 && random.seededInt(s + '-helmet-crit', 100) < schema.spec.helmetBonus ? wpnDmg * 2 : wpnDmg,
+          cel.bind(amuDmg, schema.spec.amuletBonus > 0 ? helmDmg * (100 + schema.spec.amuletBonus) / 100 : helmDmg,
+          cel.bind(finalDmg, schema.spec.stunTurns > 0 ? 0 : amuDmg,
+          cel.bind(monsterKill, !isBoss && idx >= 0 && schema.spec.monsterHP[idx] > 0
+            && schema.spec.monsterHP[idx] - finalDmg <= 0,
+          cel.bind(bossKill, isBoss && schema.spec.bossHP > 0
+            && schema.spec.bossHP - finalDmg <= 0,
+          cel.bind(types8, ['weapon','armor','hppotion','manapotion','shield','helmet','pants','boots'],
+          cel.bind(types7, ['weapon','armor','hppotion','shield','helmet','pants','boots'],
+            bossKill ?
+              cel.bind(bRar, alpha.indexOf(random.seededString(1, name + '-boss-rar')) % 36,
+              cel.bind(bRarity, bRar >= 18 ? 'epic' : 'rare',
+              cel.bind(bTyp, alpha.indexOf(random.seededString(1, name + '-boss-typ')) % 7,
+                types7[bTyp] + '-' + bRarity
+              )))
+            : monsterKill ?
+              cel.bind(mSeed, name + '-m' + string(idx),
+              cel.bind(dropRoll, alpha.indexOf(random.seededString(1, mSeed + '-drop')) % 36,
+              cel.bind(dropThresh, diff == 'easy' ? 22 : diff == 'hard' ? 13 : 16,
+                dropRoll < dropThresh ?
+                  cel.bind(rarRoll, alpha.indexOf(random.seededString(1, mSeed + '-rar')) % 36,
+                  cel.bind(mRarity, rarRoll >= 33 ? 'epic' : rarRoll >= 22 ? 'rare' : 'common',
+                  cel.bind(typRoll, alpha.indexOf(random.seededString(1, mSeed + '-typ')) % 8,
+                    types8[typRoll] + '-' + mRarity
+                  )))
+                : ''
+              )))
+            : ''
+          )))))))))))))))))))}
+
+        # --- Inventory: add loot item if dropped and under cap ---
+        inventory: >-
+          ${cel.bind(s, schema.spec.lastAttackSeed,
+          cel.bind(isBoss, schema.spec.lastAttackIsBoss,
+          cel.bind(diff, schema.spec.difficulty,
+          cel.bind(idx, schema.spec.lastAttackIndex,
+          cel.bind(alpha, 'abcdefghijklmnopqrstuvwxyz0123456789',
+          cel.bind(name, schema.metadata.name,
+          cel.bind(baseDmg,
+            (diff == 'easy' ? random.seededInt(s + '-d1', 20) + 3
+             : diff == 'hard' ? random.seededInt(s + '-d1', 20) + random.seededInt(s + '-d2', 20) + random.seededInt(s + '-d3', 20) + 8
+             : random.seededInt(s + '-d1', 12) + random.seededInt(s + '-d2', 12) + 6)
+            + (isBoss ? random.seededInt(s + '-dboss', 20) + 3 : 0),
+          cel.bind(classMult,
+            schema.spec.lastAttackIsBackstab ? baseDmg * 3
+            : schema.spec.heroClass == 'mage' ? (schema.spec.heroMana > 0 ? baseDmg * 13 / 10 : baseDmg / 2)
+            : schema.spec.heroClass == 'rogue' ? baseDmg * 11 / 10
+            : baseDmg,
+          cel.bind(modMult,
+            schema.spec.modifier == 'curse-darkness' ? classMult * 3 / 4
+            : schema.spec.modifier == 'blessing-strength' ? classMult * 3 / 2
+            : schema.spec.modifier == 'blessing-fortune' && random.seededInt(s + '-crit', 100) < 20 ? classMult * 2
+            : classMult,
+          cel.bind(wpnDmg, schema.spec.weaponUses > 0 ? modMult + schema.spec.weaponBonus : modMult,
+          cel.bind(helmDmg, schema.spec.helmetBonus > 0 && random.seededInt(s + '-helmet-crit', 100) < schema.spec.helmetBonus ? wpnDmg * 2 : wpnDmg,
+          cel.bind(amuDmg, schema.spec.amuletBonus > 0 ? helmDmg * (100 + schema.spec.amuletBonus) / 100 : helmDmg,
+          cel.bind(finalDmg, schema.spec.stunTurns > 0 ? 0 : amuDmg,
+          cel.bind(monsterKill, !isBoss && idx >= 0 && schema.spec.monsterHP[idx] > 0
+            && schema.spec.monsterHP[idx] - finalDmg <= 0,
+          cel.bind(bossKill, isBoss && schema.spec.bossHP > 0
+            && schema.spec.bossHP - finalDmg <= 0,
+          cel.bind(types8, ['weapon','armor','hppotion','manapotion','shield','helmet','pants','boots'],
+          cel.bind(types7, ['weapon','armor','hppotion','shield','helmet','pants','boots'],
+          cel.bind(lootItem,
+            bossKill ?
+              cel.bind(bRar, alpha.indexOf(random.seededString(1, name + '-boss-rar')) % 36,
+              cel.bind(bRarity, bRar >= 18 ? 'epic' : 'rare',
+              cel.bind(bTyp, alpha.indexOf(random.seededString(1, name + '-boss-typ')) % 7,
+                types7[bTyp] + '-' + bRarity
+              )))
+            : monsterKill ?
+              cel.bind(mSeed, name + '-m' + string(idx),
+              cel.bind(dropRoll, alpha.indexOf(random.seededString(1, mSeed + '-drop')) % 36,
+              cel.bind(dropThresh, diff == 'easy' ? 22 : diff == 'hard' ? 13 : 16,
+                dropRoll < dropThresh ?
+                  cel.bind(rarRoll, alpha.indexOf(random.seededString(1, mSeed + '-rar')) % 36,
+                  cel.bind(mRarity, rarRoll >= 33 ? 'epic' : rarRoll >= 22 ? 'rare' : 'common',
+                  cel.bind(typRoll, alpha.indexOf(random.seededString(1, mSeed + '-typ')) % 8,
+                    types8[typRoll] + '-' + mRarity
+                  )))
+                : ''
+              )))
+            : '',
+            lootItem != '' ? csv.add(schema.spec.inventory, lootItem, 8) : schema.spec.inventory
+          ))))))))))))))))))))}
+
         # --- Clear attack context so specPatch doesn't re-fire ---
         lastAttackTarget: "${''}"
 


### PR DESCRIPTION
## Summary
- Add `lastLootDrop` and `inventory` fields to combatResolve specPatch in dungeon-graph RGD
- CEL computes kill detection via full damage chain re-derivation (same FNV-1a + SHA-256 RNG)
- Boss loot: 100% drop rate, rare/epic 50/50, 7 types (no manapotion)
- Monster loot: difficulty-based drop chance (easy 61%, normal 44%, hard 36%), 3 rarity tiers, 8 types
- Inventory cap enforced via `csv.add(inventory, item, 8)`
- Remove `lastLootDrop` and `inventory` writes from Go backend `processCombat`
- Keep `computeMonsterLoot`/`computeBossLoot` for log text generation only

Closes part of #330