### PR TITLE
fix: balance CEL parentheses in loot specPatch expressions (#330)

### DIFF
--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -575,7 +575,7 @@ spec:
                 : ''
               )))
             : ''
-          )))))))))))))))))))}
+          )))))))))))))))))}
 
         # --- Inventory: add loot item if dropped and under cap ---
         inventory: >-
@@ -631,7 +631,7 @@ spec:
               )))
             : '',
             lootItem != '' ? csv.add(schema.spec.inventory, lootItem, 8) : schema.spec.inventory
-          ))))))))))))))))))))}
+          ))))))))))))))))))}
 
         # --- Clear attack context so specPatch doesn't re-fire ---
         lastAttackTarget: "${''}"


### PR DESCRIPTION
## Summary
- Fix 2 extra closing parens in `lastLootDrop` CEL expression
- Fix 3 extra closing parens in `inventory` CEL expression
- Both expressions now parse correctly; RGD is Ready
- Manually verified: loot drops compute correctly via kro CEL (tested `loottest3b` → `manapotion-common`)

Closes part of #330