### PR TITLE
feat: migrate action logic to kro CEL specPatch (#330)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -1285,7 +1285,6 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, cl
 	heroMana := getInt(spec, "heroMana")
 	heroClass := getString(spec, "heroClass", "warrior")
 	inventory := getString(spec, "inventory", "")
-	difficulty := getString(spec, "difficulty", "normal")
 	bossHP := getInt(spec, "bossHP")
 	actionSeq := getInt(spec, "actionSeq")
 
@@ -1331,9 +1330,14 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, cl
 	}
 
 	patchSpec := map[string]interface{}{
-		"lastLootDrop": "",
-		"actionSeq":    newSeq,
+		"actionSeq":  newSeq,
+		"lastAction": action, // trigger field for kro's actionResolve specPatch
 	}
+
+	// MIGRATION: state mutations (inventory, heroHP, heroMana, equipment bonuses,
+	// treasureOpened, doorUnlocked, room transition fields) are now computed by
+	// kro's actionResolve specPatch. Backend writes only trigger + log text.
+	// Validation stays here (returns 400 errors before setting trigger).
 
 	switch {
 	case strings.HasPrefix(action, "use-"):
@@ -1342,26 +1346,21 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, cl
 			writeError(w, "item not in inventory: "+item, http.StatusBadRequest)
 			return fmt.Errorf("item not in inventory")
 		}
-		newInv := inventoryRemove(inventory, item)
-		patchSpec["inventory"] = newInv
 
 		switch item {
 		case "hppotion-common":
 			maxHP := classMaxHP(heroClass)
 			newHP := min64(heroHP+20, maxHP)
-			patchSpec["heroHP"] = newHP
 			patchSpec["lastHeroAction"] = fmt.Sprintf("Used %s! HP: %d -> %d", item, heroHP, newHP)
 			patchSpec["lastEnemyAction"] = "Item used"
 		case "hppotion-rare":
 			maxHP := classMaxHP(heroClass)
 			newHP := min64(heroHP+40, maxHP)
-			patchSpec["heroHP"] = newHP
 			patchSpec["lastHeroAction"] = fmt.Sprintf("Used %s! HP: %d -> %d", item, heroHP, newHP)
 			patchSpec["lastEnemyAction"] = "Item used"
 		case "hppotion-epic":
 			maxHP := classMaxHP(heroClass)
 			newHP := min64(heroHP+999, maxHP)
-			patchSpec["heroHP"] = newHP
 			patchSpec["lastHeroAction"] = fmt.Sprintf("Used %s! HP: %d -> %d", item, heroHP, newHP)
 			patchSpec["lastEnemyAction"] = "Item used"
 		case "manapotion-common":
@@ -1370,7 +1369,6 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, cl
 				return fmt.Errorf("mana potion non-mage")
 			}
 			newMana := min64(heroMana+2, classMaxMana(heroClass))
-			patchSpec["heroMana"] = newMana
 			patchSpec["lastHeroAction"] = fmt.Sprintf("Used %s! Mana: %d -> %d", item, heroMana, newMana)
 			patchSpec["lastEnemyAction"] = "Item used"
 		case "manapotion-rare":
@@ -1379,7 +1377,6 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, cl
 				return fmt.Errorf("mana potion non-mage")
 			}
 			newMana := min64(heroMana+3, classMaxMana(heroClass))
-			patchSpec["heroMana"] = newMana
 			patchSpec["lastHeroAction"] = fmt.Sprintf("Used %s! Mana: %d -> %d", item, heroMana, newMana)
 			patchSpec["lastEnemyAction"] = "Item used"
 		case "manapotion-epic":
@@ -1388,7 +1385,6 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, cl
 				return fmt.Errorf("mana potion non-mage")
 			}
 			newMana := min64(heroMana+8, classMaxMana(heroClass))
-			patchSpec["heroMana"] = newMana
 			patchSpec["lastHeroAction"] = fmt.Sprintf("Used %s! Mana: %d -> %d", item, heroMana, newMana)
 			patchSpec["lastEnemyAction"] = "Item used"
 		default:
@@ -1402,84 +1398,55 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, cl
 			writeError(w, "item not in inventory: "+item, http.StatusBadRequest)
 			return fmt.Errorf("item not in inventory")
 		}
-		newInv := inventoryRemove(inventory, item)
-		patchSpec["inventory"] = newInv
 
 		switch item {
 		case "weapon-common":
-			patchSpec["weaponBonus"] = int64(5)
-			patchSpec["weaponUses"] = int64(3)
 			patchSpec["lastHeroAction"] = "Equipped weapon-common! +5 damage for 3 attacks"
 		case "weapon-rare":
-			patchSpec["weaponBonus"] = int64(10)
-			patchSpec["weaponUses"] = int64(3)
 			patchSpec["lastHeroAction"] = "Equipped weapon-rare! +10 damage for 3 attacks"
 		case "weapon-epic":
-			patchSpec["weaponBonus"] = int64(20)
-			patchSpec["weaponUses"] = int64(3)
 			patchSpec["lastHeroAction"] = "Equipped weapon-epic! +20 damage for 3 attacks"
 		case "armor-common":
-			patchSpec["armorBonus"] = int64(10)
 			patchSpec["lastHeroAction"] = "Equipped armor-common! +10% defense"
 		case "armor-rare":
-			patchSpec["armorBonus"] = int64(20)
 			patchSpec["lastHeroAction"] = "Equipped armor-rare! +20% defense"
 		case "armor-epic":
-			patchSpec["armorBonus"] = int64(30)
 			patchSpec["lastHeroAction"] = "Equipped armor-epic! +30% defense"
 		case "shield-common":
-			patchSpec["shieldBonus"] = int64(10)
 			patchSpec["lastHeroAction"] = "Equipped shield-common! +10% block chance"
 		case "shield-rare":
-			patchSpec["shieldBonus"] = int64(15)
 			patchSpec["lastHeroAction"] = "Equipped shield-rare! +15% block chance"
 		case "shield-epic":
-			patchSpec["shieldBonus"] = int64(25)
 			patchSpec["lastHeroAction"] = "Equipped shield-epic! +25% block chance"
 		case "helmet-common":
-			patchSpec["helmetBonus"] = int64(5)
 			patchSpec["lastHeroAction"] = "Equipped helmet-common! +5% crit chance"
 		case "helmet-rare":
-			patchSpec["helmetBonus"] = int64(10)
 			patchSpec["lastHeroAction"] = "Equipped helmet-rare! +10% crit chance"
 		case "helmet-epic":
-			patchSpec["helmetBonus"] = int64(15)
 			patchSpec["lastHeroAction"] = "Equipped helmet-epic! +15% crit chance"
 		case "pants-common":
-			patchSpec["pantsBonus"] = int64(5)
 			patchSpec["lastHeroAction"] = "Equipped pants-common! +5% dodge chance"
 		case "pants-rare":
-			patchSpec["pantsBonus"] = int64(10)
 			patchSpec["lastHeroAction"] = "Equipped pants-rare! +10% dodge chance"
 		case "pants-epic":
-			patchSpec["pantsBonus"] = int64(15)
 			patchSpec["lastHeroAction"] = "Equipped pants-epic! +15% dodge chance"
 		case "boots-common":
-			patchSpec["bootsBonus"] = int64(20)
 			patchSpec["lastHeroAction"] = "Equipped boots-common! +20% status resist"
 		case "boots-rare":
-			patchSpec["bootsBonus"] = int64(40)
 			patchSpec["lastHeroAction"] = "Equipped boots-rare! +40% status resist"
 		case "boots-epic":
-			patchSpec["bootsBonus"] = int64(60)
 			patchSpec["lastHeroAction"] = "Equipped boots-epic! +60% status resist"
 		case "ring-common":
-			patchSpec["ringBonus"] = int64(5)
 			patchSpec["lastHeroAction"] = "Equipped ring-common! +5 HP regen per round"
 		case "ring-rare":
-			patchSpec["ringBonus"] = int64(8)
 			patchSpec["lastHeroAction"] = "Equipped ring-rare! +8 HP regen per round"
 		case "ring-epic":
-			patchSpec["ringBonus"] = int64(12)
 			patchSpec["lastHeroAction"] = "Equipped ring-epic! +12 HP regen per round"
 		case "amulet-common":
-			patchSpec["amuletBonus"] = int64(10)
 			patchSpec["lastHeroAction"] = "Equipped amulet-common! +10% damage boost"
 		case "amulet-rare":
-			patchSpec["amuletBonus"] = int64(20)
 			patchSpec["lastHeroAction"] = "Equipped amulet-rare! +20% damage boost"
 		case "amulet-epic":
-			patchSpec["amuletBonus"] = int64(30)
 			patchSpec["lastHeroAction"] = "Equipped amulet-epic! +30% damage boost"
 		default:
 			writeError(w, "cannot equip: "+item, http.StatusBadRequest)
@@ -1499,7 +1466,6 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, cl
 			writeError(w, "cannot open treasure: boss not defeated", http.StatusBadRequest)
 			return fmt.Errorf("cannot open treasure")
 		}
-		patchSpec["treasureOpened"] = int64(1)
 		patchSpec["lastHeroAction"] = "Opened the treasure chest!"
 		patchSpec["lastEnemyAction"] = ""
 
@@ -1509,7 +1475,6 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, cl
 			writeError(w, "open the treasure first", http.StatusBadRequest)
 			return fmt.Errorf("open treasure first")
 		}
-		patchSpec["doorUnlocked"] = int64(1)
 		patchSpec["lastHeroAction"] = "Door unlocked! A new room awaits..."
 		patchSpec["lastEnemyAction"] = ""
 
@@ -1519,51 +1484,8 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, cl
 			writeError(w, "unlock the door first", http.StatusBadRequest)
 			return fmt.Errorf("unlock door first")
 		}
-		modifier := getString(spec, "modifier", "none")
-
-		// Scale Room 2 HP from Room 1 base values:
-		//   monsters: Room1Base × 1.5  (×3/2)
-		//   boss:     Room1Base × 1.3  (×13/10)
-		// Then apply modifier adjustment:
-		//   blessing: ×0.9 (×9/10) — dungeon feels more forgiving
-		//   curse:    ×1.1 (×11/10) — dungeon feels more punishing
-		r1 := defaultHP[difficulty]
-		r2MonsterHP := r1.monster * 3 / 2
-		r2BossHP := r1.boss * 13 / 10
-		if strings.Contains(modifier, "blessing") {
-			r2MonsterHP = r2MonsterHP * 9 / 10
-			r2BossHP = r2BossHP * 9 / 10
-		} else if strings.Contains(modifier, "curse") {
-			r2MonsterHP = r2MonsterHP * 11 / 10
-			r2BossHP = r2BossHP * 11 / 10
-		}
-		newMonsterHP := make([]interface{}, len(monsterHPRaw))
-		for i := range newMonsterHP {
-			newMonsterHP[i] = r2MonsterHP
-		}
-		// Room 2 monster types: troll(even), ghoul(odd) — no special classes in room 2
-		r2MonsterTypes := make([]interface{}, len(monsterHPRaw))
-		for i := range r2MonsterTypes {
-			if i%2 == 0 {
-				r2MonsterTypes[i] = "troll"
-			} else {
-				r2MonsterTypes[i] = "ghoul"
-			}
-		}
-		patchSpec["currentRoom"] = int64(2)
-		patchSpec["monsterHP"] = newMonsterHP
-		patchSpec["bossHP"] = r2BossHP
-		patchSpec["room2MonsterHP"] = newMonsterHP
-		patchSpec["room2BossHP"] = r2BossHP
-		patchSpec["monsterTypes"] = r2MonsterTypes
-		patchSpec["treasureOpened"] = int64(0)
-		patchSpec["doorUnlocked"] = int64(0)
 		patchSpec["lastHeroAction"] = "Entered Room 2! Stronger enemies await..."
 		patchSpec["lastEnemyAction"] = ""
-		// Restore mana to class maximum when entering Room 2
-		if heroClass == "mage" {
-			patchSpec["heroMana"] = int64(8)
-		}
 
 	default:
 		writeError(w, "unknown action: "+action, http.StatusBadRequest)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -315,27 +315,15 @@ export default function App() {
       let updated = detail!
 
       if (isItem) {
-        // Items: poll until the specific field changes
-        const checkField = (d: any) => {
-          if (target === 'open-treasure') return d.spec.treasureOpened
-          if (target === 'unlock-door') return d.spec.doorUnlocked
-          if (target === 'enter-room-2') return d.spec.currentRoom
-          if (target.startsWith('equip-weapon')) return d.spec.weaponBonus
-          if (target.startsWith('equip-armor')) return d.spec.armorBonus
-          if (target.startsWith('equip-shield')) return d.spec.shieldBonus
-          if (target.startsWith('equip-helmet')) return d.spec.helmetBonus
-          if (target.startsWith('equip-pants')) return d.spec.pantsBonus
-          if (target.startsWith('equip-boots')) return d.spec.bootsBonus
-          if (target.startsWith('equip-ring')) return d.spec.ringBonus
-          if (target.startsWith('equip-amulet')) return d.spec.amuletBonus
-          return d.spec.lastHeroAction
-        }
-        const prevVal = checkField(detail)
+        // Poll until actionSeq > prevSeq AND lastAction is cleared (kro finished processing).
+        // The backend writes trigger fields (lastAction, actionSeq, etc.) and kro's
+        // actionResolve specPatch computes the actual state mutations, then clears lastAction.
+        const prevSeq = detail?.spec.actionSeq ?? 0
         if (target === 'enter-room-2') setRoomLoading(true)
         for (let attempt = 0; attempt < 20; attempt++) {
           await new Promise(r => setTimeout(r, 1500))
           const current = await getDungeon(selected.ns, selected.name)
-          if (checkField(current) !== prevVal) {
+          if ((current.spec.actionSeq || 0) > prevSeq && !current.spec.lastAction) {
             updated = current
             break
           }

--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -54,6 +54,8 @@ spec:
       lastAttackIsBoss: boolean | default=false
       lastAttackIsBackstab: boolean | default=false
       combatProcessedSeq: integer | default=0
+      lastAction: string | default=""
+      actionProcessedSeq: integer | default=0
       runCount: integer | default=0
       monsterTypes: "[]string"
     status:
@@ -635,4 +637,203 @@ spec:
 
         # --- Clear attack context so specPatch doesn't re-fire ---
         lastAttackTarget: "${''}"
+
+    # ===================================================================
+    # actionResolve: handles use/equip/treasure/door/room2 state mutations
+    # Backend writes: lastAction, actionSeq, lastHeroAction, lastEnemyAction
+    # kro computes: inventory, heroHP, heroMana, equipment bonuses, room transition
+    # ===================================================================
+    - id: actionResolve
+      type: specPatch
+      includeWhen:
+        - "${schema.spec.actionSeq > schema.spec.actionProcessedSeq && schema.spec.lastAction != ''}"
+      patch:
+        # --- Inventory: remove item on use/equip ---
+        inventory: >-
+          ${cel.bind(a, schema.spec.lastAction,
+          cel.bind(inv, schema.spec.inventory,
+            a.startsWith('use-') || a.startsWith('equip-') ?
+              csv.remove(inv, a.startsWith('use-') ? a.substring(4) : a.substring(6))
+            : inv
+          ))}
+
+        # --- heroHP: HP potion healing ---
+        heroHP: >-
+          ${cel.bind(a, schema.spec.lastAction,
+          cel.bind(hp, schema.spec.heroHP,
+          cel.bind(maxHP,
+            schema.spec.heroClass == 'warrior' ? 200
+            : schema.spec.heroClass == 'mage' ? 120
+            : schema.spec.heroClass == 'rogue' ? 150 : 100,
+            a == 'use-hppotion-common' ? (hp + 20 > maxHP ? maxHP : hp + 20)
+            : a == 'use-hppotion-rare' ? (hp + 40 > maxHP ? maxHP : hp + 40)
+            : a == 'use-hppotion-epic' ? maxHP
+            : hp
+          )))}
+
+        # --- heroMana: mana potion restore + room 2 mana refill ---
+        heroMana: >-
+          ${cel.bind(a, schema.spec.lastAction,
+          cel.bind(mana, schema.spec.heroMana,
+            a == 'use-manapotion-common' ? (mana + 2 > 8 ? 8 : mana + 2)
+            : a == 'use-manapotion-rare' ? (mana + 3 > 8 ? 8 : mana + 3)
+            : a == 'use-manapotion-epic' ? 8
+            : a == 'enter-room-2' && schema.spec.heroClass == 'mage' ? 8
+            : mana
+          ))}
+
+        # --- Equipment bonus fields (overwrite on equip) ---
+        weaponBonus: >-
+          ${cel.bind(a, schema.spec.lastAction,
+            a == 'equip-weapon-common' ? 5
+            : a == 'equip-weapon-rare' ? 10
+            : a == 'equip-weapon-epic' ? 20
+            : schema.spec.weaponBonus
+          )}
+        weaponUses: >-
+          ${cel.bind(a, schema.spec.lastAction,
+            a == 'equip-weapon-common' || a == 'equip-weapon-rare' || a == 'equip-weapon-epic' ? 3
+            : schema.spec.weaponUses
+          )}
+        armorBonus: >-
+          ${cel.bind(a, schema.spec.lastAction,
+            a == 'equip-armor-common' ? 10
+            : a == 'equip-armor-rare' ? 20
+            : a == 'equip-armor-epic' ? 30
+            : schema.spec.armorBonus
+          )}
+        shieldBonus: >-
+          ${cel.bind(a, schema.spec.lastAction,
+            a == 'equip-shield-common' ? 10
+            : a == 'equip-shield-rare' ? 15
+            : a == 'equip-shield-epic' ? 25
+            : schema.spec.shieldBonus
+          )}
+        helmetBonus: >-
+          ${cel.bind(a, schema.spec.lastAction,
+            a == 'equip-helmet-common' ? 5
+            : a == 'equip-helmet-rare' ? 10
+            : a == 'equip-helmet-epic' ? 15
+            : schema.spec.helmetBonus
+          )}
+        pantsBonus: >-
+          ${cel.bind(a, schema.spec.lastAction,
+            a == 'equip-pants-common' ? 5
+            : a == 'equip-pants-rare' ? 10
+            : a == 'equip-pants-epic' ? 15
+            : schema.spec.pantsBonus
+          )}
+        bootsBonus: >-
+          ${cel.bind(a, schema.spec.lastAction,
+            a == 'equip-boots-common' ? 20
+            : a == 'equip-boots-rare' ? 40
+            : a == 'equip-boots-epic' ? 60
+            : schema.spec.bootsBonus
+          )}
+        ringBonus: >-
+          ${cel.bind(a, schema.spec.lastAction,
+            a == 'equip-ring-common' ? 5
+            : a == 'equip-ring-rare' ? 8
+            : a == 'equip-ring-epic' ? 12
+            : schema.spec.ringBonus
+          )}
+        amuletBonus: >-
+          ${cel.bind(a, schema.spec.lastAction,
+            a == 'equip-amulet-common' ? 10
+            : a == 'equip-amulet-rare' ? 20
+            : a == 'equip-amulet-epic' ? 30
+            : schema.spec.amuletBonus
+          )}
+
+        # --- Treasure and door ---
+        treasureOpened: >-
+          ${cel.bind(a, schema.spec.lastAction,
+            a == 'open-treasure' ? 1
+            : a == 'enter-room-2' ? 0
+            : schema.spec.treasureOpened
+          )}
+        doorUnlocked: >-
+          ${cel.bind(a, schema.spec.lastAction,
+            a == 'unlock-door' ? 1
+            : a == 'enter-room-2' ? 0
+            : schema.spec.doorUnlocked
+          )}
+
+        # --- Room 2 transition fields ---
+        currentRoom: >-
+          ${schema.spec.lastAction == 'enter-room-2' ? 2 : schema.spec.currentRoom}
+
+        monsterHP: >-
+          ${cel.bind(a, schema.spec.lastAction,
+          cel.bind(diff, schema.spec.difficulty,
+          cel.bind(mod, schema.spec.modifier,
+            a == 'enter-room-2' ?
+              cel.bind(r1m, diff == 'easy' ? 30 : diff == 'hard' ? 80 : 50,
+              cel.bind(r2m, r1m * 3 / 2,
+              cel.bind(adj,
+                mod.startsWith('blessing') ? r2m * 9 / 10
+                : mod.startsWith('curse') ? r2m * 11 / 10
+                : r2m,
+                schema.spec.monsterHP.map(x, adj)
+              )))
+            : schema.spec.monsterHP
+          )))}
+
+        bossHP: >-
+          ${cel.bind(a, schema.spec.lastAction,
+          cel.bind(diff, schema.spec.difficulty,
+          cel.bind(mod, schema.spec.modifier,
+            a == 'enter-room-2' ?
+              cel.bind(r1b, diff == 'easy' ? 200 : diff == 'hard' ? 800 : 400,
+              cel.bind(r2b, r1b * 13 / 10,
+                mod.startsWith('blessing') ? r2b * 9 / 10
+                : mod.startsWith('curse') ? r2b * 11 / 10
+                : r2b
+              ))
+            : schema.spec.bossHP
+          )))}
+
+        room2MonsterHP: >-
+          ${cel.bind(a, schema.spec.lastAction,
+          cel.bind(diff, schema.spec.difficulty,
+          cel.bind(mod, schema.spec.modifier,
+            a == 'enter-room-2' ?
+              cel.bind(r1m, diff == 'easy' ? 30 : diff == 'hard' ? 80 : 50,
+              cel.bind(r2m, r1m * 3 / 2,
+              cel.bind(adj,
+                mod.startsWith('blessing') ? r2m * 9 / 10
+                : mod.startsWith('curse') ? r2m * 11 / 10
+                : r2m,
+                schema.spec.monsterHP.map(x, adj)
+              )))
+            : schema.spec.room2MonsterHP
+          )))}
+
+        room2BossHP: >-
+          ${cel.bind(a, schema.spec.lastAction,
+          cel.bind(diff, schema.spec.difficulty,
+          cel.bind(mod, schema.spec.modifier,
+            a == 'enter-room-2' ?
+              cel.bind(r1b, diff == 'easy' ? 200 : diff == 'hard' ? 800 : 400,
+              cel.bind(r2b, r1b * 13 / 10,
+                mod.startsWith('blessing') ? r2b * 9 / 10
+                : mod.startsWith('curse') ? r2b * 11 / 10
+                : r2b
+              ))
+            : schema.spec.room2BossHP
+          )))}
+
+        monsterTypes: >-
+          ${schema.spec.lastAction == 'enter-room-2' ?
+            lists.range(size(schema.spec.monsterHP)).map(i, i % 2 == 0 ? 'troll' : 'ghoul')
+            : schema.spec.monsterTypes}
+
+        # --- Loot cleared on every action ---
+        lastLootDrop: "${''}"
+
+        # --- Action processed sentinel ---
+        actionProcessedSeq: "${schema.spec.actionSeq}"
+
+        # --- Clear action trigger so specPatch doesn't re-fire ---
+        lastAction: "${''}"
 

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -77,16 +77,18 @@ submit_attack() {
     "[ -z \"\$(kctl get dungeon ${dname} -o jsonpath='{.spec.lastAttackTarget}' 2>/dev/null)\" ]" 30
 }
 
-# Submit an action (non-combat) via the backend REST API and wait for lastHeroAction to change.
+# Submit an action (non-combat) via the backend REST API and wait for kro to finish.
+# The backend writes trigger fields (lastAction, actionSeq) and kro's actionResolve
+# specPatch computes the actual state mutations, then clears lastAction.
 # Usage: submit_action <dungeon-name> <action>
 submit_action() {
   local dname="$1" action="$2"
-  local prev_action prev_seq
-  prev_action=$(kctl get dungeon "$dname" -o jsonpath='{.spec.lastHeroAction}' 2>/dev/null || echo "")
+  local prev_seq
   prev_seq=$(kctl get dungeon "$dname" -o jsonpath='{.spec.actionSeq}' 2>/dev/null || echo "0")
   curl -s -X POST "${BACKEND_URL}/api/v1/dungeons/default/${dname}/attacks" \
     -H "Content-Type: application/json" \
     -d "{\"target\":\"${action}\",\"damage\":0,\"seq\":${prev_seq}}" -o /dev/null
-  wait_for "${dname} action changed" \
-    "[ \"\$(kctl get dungeon ${dname} -o jsonpath='{.spec.lastHeroAction}' 2>/dev/null)\" != \"${prev_action}\" ]" 30
+  # Wait for actionSeq > prevSeq (backend wrote triggers) AND lastAction == '' (kro finished)
+  wait_for "${dname} action processed" \
+    "[ \"\$(kctl get dungeon ${dname} -o jsonpath='{.spec.actionSeq}' 2>/dev/null)\" -gt \"${prev_seq}\" ] && [ -z \"\$(kctl get dungeon ${dname} -o jsonpath='{.spec.lastAction}' 2>/dev/null)\" ]" 30
 }


### PR DESCRIPTION
## Summary
- Add `actionResolve` specPatch node to dungeon-graph RGD
- Handles all action types: use (6 potions), equip (27 items), open-treasure, unlock-door, enter-room-2
- New schema fields: `lastAction` (trigger), `actionProcessedSeq` (sentinel)
- Backend `processAction` now writes only trigger + log text; all state mutations removed
- Frontend polls `lastAction == ''` for kro completion (replaces field-specific polling)
- Test helper `submit_action` waits for `lastAction` cleared + `actionSeq` bumped
- Room 2 transition: HP scaling, modifier adjustment, monster type reassignment, mana restore — all in CEL

Closes part of #330