### PR TITLE
fix: initialize room2MonsterHP to empty array on dungeon creation (#330)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -238,16 +238,17 @@ func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
 	}
 
 	dungeonSpec := map[string]interface{}{
-		"monsters":     req.Monsters,
-		"difficulty":   req.Difficulty,
-		"monsterHP":    monsterHP,
-		"bossHP":       hp.boss,
-		"heroHP":       heroHP,
-		"heroClass":    heroClass,
-		"heroMana":     heroMana,
-		"modifier":     modifier,
-		"monsterTypes": monsterTypes,
-		"runCount":     runCount,
+		"monsters":       req.Monsters,
+		"difficulty":     req.Difficulty,
+		"monsterHP":      monsterHP,
+		"bossHP":         hp.boss,
+		"heroHP":         heroHP,
+		"heroClass":      heroClass,
+		"heroMana":       heroMana,
+		"modifier":       modifier,
+		"monsterTypes":   monsterTypes,
+		"runCount":       runCount,
+		"room2MonsterHP": []interface{}{},
 	}
 	// Carry over gear bonuses from prior run (New Game+)
 	if req.WeaponBonus > 0 {


### PR DESCRIPTION
## Summary
- Initializes `room2MonsterHP` to `[]` during dungeon creation in the backend
- Without this, kro's `actionResolve` specPatch gets a "data pending" error on the `room2MonsterHP` field because it's a `[]integer` type with no default value
- This caused all action processing (use potion, equip item, open treasure, etc.) to hang indefinitely in a requeue loop

Closes #330 (partial — fixes action processing)