### PR TITLE
fix: prevent 'No dungeons yet' text from wrapping to two lines

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -230,7 +230,7 @@ body {
 .victory-banner .loot { font-size: 9px; color: var(--green); }
 
 /* Loading */
-.loading { text-align: center; padding: 40px; font-size: 10px; color: var(--text-dim); }
+.loading { text-align: center; padding: 40px; font-size: 10px; color: var(--text-dim); white-space: nowrap; }
 .loading::after { content: '...'; animation: dots 1.5s infinite; }
 @keyframes dots { 0% { content: '.'; } 33% { content: '..'; } 66% { content: '...'; } }
 


### PR DESCRIPTION
Adds `white-space: nowrap` to the `.loading` CSS class so the empty-state message renders on a single line.