### PR TITLE
ops: scale to 3 replicas with topology spread, beef up kro, fix PDBs (#354 #355)

### DIFF
--- a/manifests/system/backend-pdb.yaml
+++ b/manifests/system/backend-pdb.yaml
@@ -4,7 +4,18 @@ metadata:
   name: rpg-backend-pdb
   namespace: rpg-system
 spec:
-  minAvailable: 0
+  minAvailable: 2
   selector:
     matchLabels:
       app: rpg-backend
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: rpg-frontend-pdb
+  namespace: rpg-system
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: rpg-frontend

--- a/manifests/system/backend.yaml
+++ b/manifests/system/backend.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rpg-backend
   namespace: rpg-system
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: rpg-backend
@@ -14,6 +14,13 @@ spec:
         app: rpg-backend
     spec:
       serviceAccountName: rpg-backend-sa
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: rpg-backend
       containers:
         - name: backend
           image: 319279230668.dkr.ecr.us-west-2.amazonaws.com/krombat/backend:latest

--- a/manifests/system/frontend.yaml
+++ b/manifests/system/frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rpg-frontend
   namespace: rpg-system
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: rpg-frontend
@@ -13,6 +13,13 @@ spec:
       labels:
         app: rpg-frontend
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: rpg-frontend
       containers:
         - name: frontend
           image: 319279230668.dkr.ecr.us-west-2.amazonaws.com/krombat/frontend:latest
@@ -24,6 +31,13 @@ spec:
               port: 3000
             initialDelaySeconds: 2
             periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            failureThreshold: 3
           resources:
             requests:
               memory: "128Mi"

--- a/manifests/system/kro-resources.yaml
+++ b/manifests/system/kro-resources.yaml
@@ -1,0 +1,30 @@
+# kro resource and concurrency override — applied by ArgoCD on top of the
+# Helm-managed kro Deployment. Terraform EKS capability module owns the Helm
+# release (image tag, initial install); this manifest owns resource limits and
+# concurrency env vars so they are tracked in Git and survive helm upgrades.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kro
+  namespace: kro
+spec:
+  template:
+    spec:
+      containers:
+        - name: kro
+          resources:
+            requests:
+              cpu: "1"
+              memory: "1Gi"
+            limits:
+              cpu: "4"
+              memory: "8Gi"
+          env:
+            - name: KRO_RESOURCE_GROUP_CONCURRENT_RECONCILES
+              value: "16"
+            - name: KRO_DYNAMIC_CONTROLLER_CONCURRENT_RECONCILES
+              value: "16"
+            - name: KRO_CLIENT_QPS
+              value: "200"
+            - name: KRO_CLIENT_BURST
+              value: "400"


### PR DESCRIPTION
## Summary

Addresses #354 and #355.

### #354 — Beef up kro (4 CPU / 8 Gi / 16 concurrent reconciles)

Adds `manifests/system/kro-resources.yaml` — a Deployment patch applied by ArgoCD via SSA on top of the Terraform/Helm-managed kro Deployment. ArgoCD owns only the resource and env fields; Helm retains ownership of everything else (image, volumes, etc.).

Changes:
- CPU: `256m` request / `1` limit → `1` request / `4` limit
- Memory: `128Mi` request / `1Gi` limit → `1Gi` request / `8Gi` limit
- `KRO_RESOURCE_GROUP_CONCURRENT_RECONCILES`: `1` → `16`
- `KRO_DYNAMIC_CONTROLLER_CONCURRENT_RECONCILES`: `1` → `16`
- `KRO_CLIENT_QPS`: `100` → `200`
- `KRO_CLIENT_BURST`: `150` → `400`

### #355 — 3 replicas + topology spread + frontend liveness probe + real PDBs

**backend.yaml**: replicas 1→3, add `topologySpreadConstraints` (zone spread, ScheduleAnyway)

**frontend.yaml**: replicas 1→3, add `topologySpreadConstraints`, add liveness probe (`GET /`, 10s initial delay, 15s period, 3 failures)

**backend-pdb.yaml**: `minAvailable: 0` → `minAvailable: 2` for backend; add frontend PDB with `minAvailable: 2`

Closes #354
Closes #355