### PR TITLE
feat: move dungeon init logic into kro dungeonInit specPatch (#364)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"math/rand"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -158,97 +157,28 @@ func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hp, _ := defaultHP[req.Difficulty]
-	monsterHP := make([]interface{}, req.Monsters)
-	for i := range monsterHP {
-		monsterHP[i] = hp.monster
-	}
-
 	heroClass := req.HeroClass
 	if heroClass == "" {
 		heroClass = "warrior"
 	}
-	heroHP := int64(100)
-	heroMana := int64(0)
-	switch heroClass {
-	case "warrior":
-		heroHP = 200
-	case "mage":
-		heroHP = 120
-		heroMana = 8
-	case "rogue":
-		heroHP = 150
-	default:
+	if heroClass != "warrior" && heroClass != "mage" && heroClass != "rogue" {
 		writeError(w, "heroClass must be warrior, mage, or rogue", http.StatusBadRequest)
 		return
 	}
 
-	// Pick a random modifier (20% none, 40% curse, 40% blessing)
-	modifiers := []string{"none", "curse-fortitude", "curse-fury", "curse-darkness", "blessing-strength", "blessing-resilience", "blessing-fortune", "blessing-strength", "curse-fury", "blessing-fortune"}
-	modifier := modifiers[rand.Intn(len(modifiers))]
-
-	// Curse of Fortitude: apply +50% monster HP at creation
-	if modifier == "curse-fortitude" {
-		for i := range monsterHP {
-			monsterHP[i] = monsterHP[i].(int64) * 3 / 2
-		}
-	}
-
-	// New Game+ scaling: each completed run multiplies monster HP by 1.25
-	// and adds +10% hero HP per run (compounded). runCount is the number of
-	// prior completed runs (0 = fresh start, 1 = first New Game+, etc.)
 	runCount := req.RunCount
 	if runCount < 0 || runCount > 20 {
 		runCount = 0 // clamp to reasonable range
 	}
-	if runCount > 0 {
-		// Scale monster HP: 1.25^runCount (integer approximation)
-		// 1 run: 125%, 2 runs: 156%, 3 runs: 195%, etc.
-		scale := int64(100)
-		for i := int64(0); i < runCount; i++ {
-			scale = scale * 125 / 100
-		}
-		for i := range monsterHP {
-			monsterHP[i] = monsterHP[i].(int64) * scale / 100
-		}
-		hp.boss = hp.boss * scale / 100
-		// Hero HP +10% per run (compounded)
-		heroHPScale := int64(100)
-		for i := int64(0); i < runCount; i++ {
-			heroHPScale = heroHPScale * 110 / 100
-		}
-		heroHP = heroHP * heroHPScale / 100
-	}
 
-	// Assign monster types for Room 1: goblin(0), skeleton(1), archer(2+even), shaman(3+odd)
-	// Archers (index % 2 == 0, index >= 2): 20% chance to stun instead of poison
-	// Shamans (index % 2 == 1, index >= 3): 30% chance to heal another monster on counter
-	monsterTypes := make([]interface{}, req.Monsters)
-	for i := range monsterTypes {
-		switch {
-		case i == 0:
-			monsterTypes[i] = "goblin"
-		case i == 1:
-			monsterTypes[i] = "skeleton"
-		case i%2 == 0:
-			monsterTypes[i] = "archer"
-		default:
-			monsterTypes[i] = "shaman"
-		}
-	}
-
+	// Backend writes only the player choices. kro dungeonInit specPatch computes
+	// heroHP, heroMana, monsterHP, bossHP, modifier, and monsterTypes from these
+	// fields deterministically via CEL.
 	dungeonSpec := map[string]interface{}{
-		"monsters":       req.Monsters,
-		"difficulty":     req.Difficulty,
-		"monsterHP":      monsterHP,
-		"bossHP":         hp.boss,
-		"heroHP":         heroHP,
-		"heroClass":      heroClass,
-		"heroMana":       heroMana,
-		"modifier":       modifier,
-		"monsterTypes":   monsterTypes,
-		"runCount":       runCount,
-		"room2MonsterHP": []interface{}{},
+		"monsters":   req.Monsters,
+		"difficulty": req.Difficulty,
+		"heroClass":  heroClass,
+		"runCount":   runCount,
 	}
 	// Carry over gear bonuses from prior run (New Game+)
 	if req.WeaponBonus > 0 {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -642,6 +642,8 @@ export default function App() {
         </>
       ) : loading ? (
         <div className="loading">Initializing dungeon</div>
+      ) : detail && (detail.spec.initProcessedSeq ?? 0) === 0 ? (
+        <div className="loading">Initializing dungeon</div>
       ) : detail ? (
         <DungeonView
           cr={detail}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -35,6 +35,7 @@ export interface DungeonCR {
     lastHeroAction?: string; lastEnemyAction?: string; lastCombatLog?: string; lastLootDrop?: string
     attackSeq?: number; actionSeq?: number
     lastAttackTarget?: string; lastAction?: string; lastAbility?: string
+    initProcessedSeq?: number
   }
   status?: {
     livingMonsters: number; bossState: string; victory: boolean; defeated: boolean

--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -61,6 +61,7 @@ spec:
       abilityProcessedSeq: integer | default=0
       runCount: integer | default=0
       monsterTypes: "[]string"
+      initProcessedSeq: integer | default=0
     status:
       livingMonsters: "${size(monsterCRs.filter(m, m.status.?entityState.orValue('alive') == 'alive'))}"
       bossState: "${bossCR.status.?entityState.orValue('pending')}"
@@ -179,6 +180,119 @@ spec:
           diceFormula: "${schema.spec.difficulty == 'easy' ? '1d20+3' : schema.spec.difficulty == 'hard' ? '3d20+8' : '2d12+6'}"
           monsterCounter: "${schema.spec.difficulty == 'easy' ? '1' : schema.spec.difficulty == 'hard' ? '3' : '2'}"
           bossCounter: "${schema.spec.difficulty == 'easy' ? '3' : schema.spec.difficulty == 'hard' ? '8' : '5'}"
+
+    # ===================================================================
+    # dungeonInit: compute all starting game state from player choices.
+    # Gate: initProcessedSeq == 0 (fires exactly once at creation).
+    # Backend writes only: monsters, difficulty, heroClass, runCount,
+    # and optional NG+ gear carry-overs. kro computes everything else.
+    # ===================================================================
+    - id: dungeonInit
+      type: specPatch
+      includeWhen:
+        - "${schema.spec.initProcessedSeq == 0}"
+      patch:
+        # --- Hero HP by class, scaled by New Game+ runCount (+10% per run compounded) ---
+        heroHP: >-
+          ${cel.bind(base,
+            schema.spec.heroClass == 'warrior' ? 200
+            : schema.spec.heroClass == 'mage' ? 120
+            : schema.spec.heroClass == 'rogue' ? 150 : 100,
+          cel.bind(rc, schema.spec.runCount > 20 ? 20 : (schema.spec.runCount < 0 ? 0 : schema.spec.runCount),
+          cel.bind(s1, rc >= 1 ? base * 110 / 100 : base,
+          cel.bind(s2, rc >= 2 ? s1 * 110 / 100 : s1,
+          cel.bind(s3, rc >= 3 ? s2 * 110 / 100 : s2,
+          cel.bind(s4, rc >= 4 ? s3 * 110 / 100 : s3,
+          cel.bind(s5, rc >= 5 ? s4 * 110 / 100 : s4,
+          cel.bind(s6, rc >= 6 ? s5 * 110 / 100 : s5,
+          cel.bind(s7, rc >= 7 ? s6 * 110 / 100 : s6,
+          cel.bind(s8, rc >= 8 ? s7 * 110 / 100 : s7,
+          cel.bind(s9, rc >= 9 ? s8 * 110 / 100 : s8,
+          cel.bind(s10, rc >= 10 ? s9 * 110 / 100 : s9,
+            rc > 10
+              ? s10 * (rc == 11 ? 110 : rc == 12 ? 121 : rc == 13 ? 133 : rc == 14 ? 146 : rc == 15 ? 161 : rc == 16 ? 177 : rc == 17 ? 195 : rc == 18 ? 214 : rc == 19 ? 236 : 259) / 100
+              : s10
+          )))))))))))))
+
+        # --- Hero mana by class ---
+        heroMana: >-
+          ${schema.spec.heroClass == 'mage' ? 8 : 0}
+
+        # --- Monster HP array: base by difficulty, curse-fortitude +50%, NG+ scale ---
+        monsterHP: >-
+          ${cel.bind(diff, schema.spec.difficulty,
+          cel.bind(base, diff == 'easy' ? 30 : diff == 'hard' ? 80 : 50,
+          cel.bind(rc, schema.spec.runCount > 20 ? 20 : (schema.spec.runCount < 0 ? 0 : schema.spec.runCount),
+          cel.bind(alpha, 'abcdefghijklmnopqrstuvwxyz0123456789',
+          cel.bind(name, schema.metadata.name,
+          cel.bind(modIdx, alpha.indexOf(random.seededString(1, name + '-mod')) % 10,
+          cel.bind(mod, modIdx == 0 ? 'none' : modIdx == 1 ? 'curse-fortitude' : modIdx == 2 ? 'curse-fury' : modIdx == 3 ? 'curse-darkness' : modIdx == 4 ? 'blessing-strength' : modIdx == 5 ? 'blessing-resilience' : modIdx == 6 ? 'blessing-fortune' : modIdx == 7 ? 'blessing-strength' : modIdx == 8 ? 'curse-fury' : 'blessing-fortune',
+          cel.bind(fortified, mod == 'curse-fortitude' ? base * 3 / 2 : base,
+          cel.bind(sc1, rc >= 1 ? fortified * 125 / 100 : fortified,
+          cel.bind(sc2, rc >= 2 ? sc1 * 125 / 100 : sc1,
+          cel.bind(sc3, rc >= 3 ? sc2 * 125 / 100 : sc2,
+          cel.bind(sc4, rc >= 4 ? sc3 * 125 / 100 : sc3,
+          cel.bind(sc5, rc >= 5 ? sc4 * 125 / 100 : sc4,
+          cel.bind(sc6, rc >= 6 ? sc5 * 125 / 100 : sc5,
+          cel.bind(sc7, rc >= 7 ? sc6 * 125 / 100 : sc6,
+          cel.bind(sc8, rc >= 8 ? sc7 * 125 / 100 : sc7,
+          cel.bind(sc9, rc >= 9 ? sc8 * 125 / 100 : sc8,
+          cel.bind(sc10, rc >= 10 ? sc9 * 125 / 100 : sc9,
+          cel.bind(mhp,
+            rc > 10
+              ? sc10 * (rc == 11 ? 125 : rc == 12 ? 156 : rc == 13 ? 195 : rc == 14 ? 244 : rc == 15 ? 305 : rc == 16 ? 381 : rc == 17 ? 476 : rc == 18 ? 596 : rc == 19 ? 745 : 931) / 100
+              : sc10,
+            lists.range(schema.spec.monsters).map(i, mhp)
+          ))))))))))))))))))))}
+
+        # --- Boss HP: base by difficulty, NG+ scaled ---
+        bossHP: >-
+          ${cel.bind(diff, schema.spec.difficulty,
+          cel.bind(base, diff == 'easy' ? 200 : diff == 'hard' ? 800 : 400,
+          cel.bind(rc, schema.spec.runCount > 20 ? 20 : (schema.spec.runCount < 0 ? 0 : schema.spec.runCount),
+          cel.bind(sc1, rc >= 1 ? base * 125 / 100 : base,
+          cel.bind(sc2, rc >= 2 ? sc1 * 125 / 100 : sc1,
+          cel.bind(sc3, rc >= 3 ? sc2 * 125 / 100 : sc2,
+          cel.bind(sc4, rc >= 4 ? sc3 * 125 / 100 : sc3,
+          cel.bind(sc5, rc >= 5 ? sc4 * 125 / 100 : sc4,
+          cel.bind(sc6, rc >= 6 ? sc5 * 125 / 100 : sc5,
+          cel.bind(sc7, rc >= 7 ? sc6 * 125 / 100 : sc6,
+          cel.bind(sc8, rc >= 8 ? sc7 * 125 / 100 : sc7,
+          cel.bind(sc9, rc >= 9 ? sc8 * 125 / 100 : sc8,
+          cel.bind(sc10, rc >= 10 ? sc9 * 125 / 100 : sc9,
+            rc > 10
+              ? sc10 * (rc == 11 ? 125 : rc == 12 ? 156 : rc == 13 ? 195 : rc == 14 ? 244 : rc == 15 ? 305 : rc == 16 ? 381 : rc == 17 ? 476 : rc == 18 ? 596 : rc == 19 ? 745 : 931) / 100
+              : sc10
+          ))))))))))))))}
+
+        # --- Modifier: deterministic from dungeon name via seeded random ---
+        modifier: >-
+          ${cel.bind(alpha, 'abcdefghijklmnopqrstuvwxyz0123456789',
+          cel.bind(name, schema.metadata.name,
+          cel.bind(modIdx, alpha.indexOf(random.seededString(1, name + '-mod')) % 10,
+            modIdx == 0 ? 'none'
+            : modIdx == 1 ? 'curse-fortitude'
+            : modIdx == 2 ? 'curse-fury'
+            : modIdx == 3 ? 'curse-darkness'
+            : modIdx == 4 ? 'blessing-strength'
+            : modIdx == 5 ? 'blessing-resilience'
+            : modIdx == 6 ? 'blessing-fortune'
+            : modIdx == 7 ? 'blessing-strength'
+            : modIdx == 8 ? 'curse-fury'
+            : 'blessing-fortune'
+          )))}
+
+        # --- Monster types: goblin(0), skeleton(1), archer(even>=2), shaman(odd>=3) ---
+        monsterTypes: >-
+          ${lists.range(schema.spec.monsters).map(i,
+            i == 0 ? 'goblin'
+            : i == 1 ? 'skeleton'
+            : i % 2 == 0 ? 'archer'
+            : 'shaman'
+          )}
+
+        # --- Sentinel: mark init complete ---
+        initProcessedSeq: "${1}"
 
     # --- Ability resolution: mage heal and warrior taunt ---
     # Gate: attackSeq has advanced past abilityProcessedSeq AND lastAbility is set.

--- a/tests/e2e/journeys/helpers.js
+++ b/tests/e2e/journeys/helpers.js
@@ -14,10 +14,12 @@ async function createDungeonUI(page, name, { monsters = 2, difficulty = 'easy', 
   const monsterInput = page.locator('input[type="number"]');
   if (await monsterInput.count() > 0) await monsterInput.fill(String(monsters));
   await page.click('button:has-text("Create Dungeon")');
-  // Wait for dungeon view to load (not stuck on list or "Initializing")
+  // Wait for dungeon view to load (not stuck on list or "Initializing dungeon")
+  // The frontend shows "Initializing dungeon" until spec.initProcessedSeq == 1,
+  // which kro sets after computing heroHP, monsterHP, bossHP, modifier, monsterTypes.
   for (let i = 0; i < 60; i++) {
     const text = await page.textContent('body');
-    if (text.includes(heroClass.toUpperCase()) && text.includes(name)) return true;
+    if (text.includes(heroClass.toUpperCase()) && text.includes(name) && !text.includes('Initializing dungeon')) return true;
     await page.waitForTimeout(2000);
   }
   return false;


### PR DESCRIPTION
## Summary

- Adds `dungeonInit` specPatch node to `dungeon-graph.yaml` that computes heroHP, heroMana, monsterHP, bossHP, modifier, and monsterTypes deterministically from CEL, triggered once at dungeon creation via `initProcessedSeq == 0` gate
- Strips `heroHP`, `heroMana`, `monsterHP`, `bossHP`, `modifier`, `monsterTypes` computation from `handlers.go` `CreateDungeon` — backend now writes only: `monsters`, `difficulty`, `heroClass`, `runCount`, and optional NG+ gear carry-overs
- Removes `math/rand` import from handlers (no longer needed)
- Adds `initProcessedSeq` field to `DungeonCR` TypeScript type
- Frontend shows "Initializing dungeon" until `spec.initProcessedSeq == 1`
- Journey helper `createDungeonUI` waits for "Initializing dungeon" to clear before returning

## Notes

- `initProcessedSeq` is a new field in the Dungeon CR schema — requires `kubectl delete rgd dungeon-graph` after merge so kro regenerates the CRD schema (Argo CD sync alone does not update CRD field list)
- Integration tests use old cluster ARN (`569190534191`) in `tests/helpers.sh` — pre-existing issue, not caused by this PR; `--no-verify` used per AGENTS.md policy for RGD schema changes requiring deploy-first

Closes #364