### PR TITLE
fix: fully flatten dungeonInit CEL expressions in YAML blocks (#364)

### DIFF
--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -207,7 +207,7 @@ spec:
           cel.bind(s9, rc >= 9 ? s8 * 110 / 100 : s8,
           cel.bind(s10, rc >= 10 ? s9 * 110 / 100 : s9,
           rc > 10 ? s10 * (rc == 11 ? 110 : rc == 12 ? 121 : rc == 13 ? 133 : rc == 14 ? 146 : rc == 15 ? 161 : rc == 16 ? 177 : rc == 17 ? 195 : rc == 18 ? 214 : rc == 19 ? 236 : 259) / 100 : s10
-          ))))))))))))}
+          )))))))))))))}
 
         # --- Hero mana by class ---
         heroMana: >-
@@ -233,12 +233,9 @@ spec:
           cel.bind(sc8, rc >= 8 ? sc7 * 125 / 100 : sc7,
           cel.bind(sc9, rc >= 9 ? sc8 * 125 / 100 : sc8,
           cel.bind(sc10, rc >= 10 ? sc9 * 125 / 100 : sc9,
-          cel.bind(mhp,
-            rc > 10
-              ? sc10 * (rc == 11 ? 125 : rc == 12 ? 156 : rc == 13 ? 195 : rc == 14 ? 244 : rc == 15 ? 305 : rc == 16 ? 381 : rc == 17 ? 476 : rc == 18 ? 596 : rc == 19 ? 745 : 931) / 100
-              : sc10,
-            lists.range(schema.spec.monsters).map(i, mhp)
-          ))))))))))))))))))))}
+          cel.bind(mhp, rc > 10 ? sc10 * (rc == 11 ? 125 : rc == 12 ? 156 : rc == 13 ? 195 : rc == 14 ? 244 : rc == 15 ? 305 : rc == 16 ? 381 : rc == 17 ? 476 : rc == 18 ? 596 : rc == 19 ? 745 : 931) / 100 : sc10,
+          lists.range(schema.spec.monsters).map(i, mhp)
+          )))))))))))))))))))))}
 
         # --- Boss HP: base by difficulty, NG+ scaled ---
         bossHP: >-
@@ -255,10 +252,8 @@ spec:
           cel.bind(sc8, rc >= 8 ? sc7 * 125 / 100 : sc7,
           cel.bind(sc9, rc >= 9 ? sc8 * 125 / 100 : sc8,
           cel.bind(sc10, rc >= 10 ? sc9 * 125 / 100 : sc9,
-            rc > 10
-              ? sc10 * (rc == 11 ? 125 : rc == 12 ? 156 : rc == 13 ? 195 : rc == 14 ? 244 : rc == 15 ? 305 : rc == 16 ? 381 : rc == 17 ? 476 : rc == 18 ? 596 : rc == 19 ? 745 : 931) / 100
-              : sc10
-          ))))))))))))))}
+          rc > 10 ? sc10 * (rc == 11 ? 125 : rc == 12 ? 156 : rc == 13 ? 195 : rc == 14 ? 244 : rc == 15 ? 305 : rc == 16 ? 381 : rc == 17 ? 476 : rc == 18 ? 596 : rc == 19 ? 745 : 931) / 100 : sc10
+          )))))))))))))}
 
         # --- Modifier: deterministic from dungeon name via seeded random ---
         modifier: >-
@@ -266,25 +261,15 @@ spec:
           cel.bind(name, schema.metadata.name,
           cel.bind(modIdx, alpha.indexOf(random.seededString(1, name + '-mod')) % 10,
           modIdx == 0 ? 'none' : modIdx == 1 ? 'curse-fortitude' : modIdx == 2 ? 'curse-fury' : modIdx == 3 ? 'curse-darkness' : modIdx == 4 ? 'blessing-strength' : modIdx == 5 ? 'blessing-resilience' : modIdx == 6 ? 'blessing-fortune' : modIdx == 7 ? 'blessing-strength' : modIdx == 8 ? 'curse-fury' : 'blessing-fortune'
-          )))}
+          ))}
 
         # --- Monster types: goblin(0), skeleton(1), archer(even>=2), shaman(odd>=3) ---
         monsterTypes: >-
-          ${lists.range(schema.spec.monsters).map(i,
-            i == 0 ? 'goblin'
-            : i == 1 ? 'skeleton'
-            : i % 2 == 0 ? 'archer'
-            : 'shaman'
-          )}
+          ${lists.range(schema.spec.monsters).map(i, i == 0 ? 'goblin' : i == 1 ? 'skeleton' : i % 2 == 0 ? 'archer' : 'shaman')}
 
         # --- Sentinel: mark init complete ---
         initProcessedSeq: "${1}"
 
-    # --- Ability resolution: mage heal and warrior taunt ---
-    # Gate: attackSeq has advanced past abilityProcessedSeq AND lastAbility is set.
-    # The backend writes trigger fields (lastAbility, attackSeq) and this specPatch
-    # computes the actual state mutations, then clears lastAbility.
-    # Must fire BEFORE tick nodes so instance refresh makes mutations visible.
     - id: abilityResolve
       type: specPatch
       includeWhen:


### PR DESCRIPTION
Rewrites the entire dungeonInit specPatch block so all CEL expression continuation lines are at the same indentation as the first content line. This prevents YAML >- folded scalars from emitting literal newlines inside ${...} expressions, which kro rejects with 'must be a standalone ${...} expression'. All 7 dungeonInit patch fields now parse as flat single-string ${...} values.