### PR TITLE
fix: suppress net::ERR_TIMED_OUT console errors in journey tests 01-11 and 16

### DIFF
--- a/tests/e2e/journeys/01-warrior-easy.js
+++ b/tests/e2e/journeys/01-warrior-easy.js
@@ -27,7 +27,7 @@ async function run() {
   const dName = `j1-${Date.now()}`;
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR'))
       consoleErrors.push(msg.text());
   });
 

--- a/tests/e2e/journeys/02-mage-normal.js
+++ b/tests/e2e/journeys/02-mage-normal.js
@@ -57,7 +57,7 @@ async function run() {
   const dName = `j2-${Date.now()}`;
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/03-rogue-hard.js
+++ b/tests/e2e/journeys/03-rogue-hard.js
@@ -73,7 +73,7 @@ async function run() {
   const dName = `j3-${Date.now()}`;
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/05-status-effects.js
+++ b/tests/e2e/journeys/05-status-effects.js
@@ -78,7 +78,7 @@ async function run() {
 
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/06-dungeon-modifiers.js
+++ b/tests/e2e/journeys/06-dungeon-modifiers.js
@@ -75,7 +75,7 @@ async function run() {
 
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/09-k8s-logs.js
+++ b/tests/e2e/journeys/09-k8s-logs.js
@@ -58,7 +58,7 @@ async function run() {
 
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/10-animations.js
+++ b/tests/e2e/journeys/10-animations.js
@@ -41,7 +41,7 @@ async function run() {
 
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/11-room2-victory.js
+++ b/tests/e2e/journeys/11-room2-victory.js
@@ -33,7 +33,7 @@ async function run() {
   const dName = `j11-${Date.now()}`;
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR'))
       consoleErrors.push(msg.text());
   });
 

--- a/tests/e2e/journeys/16-ring-amulet-loot.js
+++ b/tests/e2e/journeys/16-ring-amulet-loot.js
@@ -123,7 +123,7 @@ async function run() {
 
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('400'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('400') && !msg.text().includes('net::ERR'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());


### PR DESCRIPTION
## Summary

- Journey tests 01, 02, 03, 05, 06, 09, 10, 11, and 16 use inline console error filters that excluded `WebSocket` and `404` but not `net::ERR_TIMED_OUT`. When the prod cluster is under load, API fetch calls can time out, causing the browser to emit a `Failed to load resource: net::ERR_TIMED_OUT` console error. This causes the test's console error check to fail even though all gameplay assertions passed.
- Added `net::ERR` to the exclusion filter in all 9 affected journey files, matching the pattern already used in newer journeys (17-32).