### PR TITLE
fix: Phase 0b bugs — dice RNG, combat log, loot timing, DoT duration (#383-387)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -680,7 +680,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 		},
 	}}
 	attackData, _ := json.Marshal(attackObj.Object)
-	attackResult, err := h.client.Dynamic.Resource(k8s.AttackGVR).Namespace("default").Patch(
+	_, err = h.client.Dynamic.Resource(k8s.AttackGVR).Namespace("default").Patch(
 		ctx, attackCRName, types.ApplyPatchType, attackData,
 		metav1.PatchOptions{FieldManager: "rpg-backend", Force: boolPtr(true)})
 	if err != nil {
@@ -692,8 +692,11 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 
 	// Step 3: Compute combat math here in the backend (Go replaces the bash Job).
 	// All game logic is deterministic given the inputs from dungeon spec.
-	// Random rolls use the Attack CR's UID as seed (written by API server, truly random).
-	attackUID := string(attackResult.GetUID())
+	// Per-turn seed: unique per (dungeon, turn) — produces real dice variance.
+	// NOTE: The fixed-name Attack CR reuses the same UID every turn via SSA, so
+	// attackResult.GetUID() is constant and MUST NOT be used as a random seed.
+	// We use dungeon name + sequence number instead.
+	turnSeed := name + "-seq-" + strconv.FormatInt(newSeq, 10)
 
 	// NOTE: DoT ticks (poison/burn/stun), backstab cooldown decrement, and taunt
 	// advancement are now handled by kro specPatch nodes (tickDoT, advanceTaunt,
@@ -771,9 +774,9 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 		return h.patchAndRespond(ctx, ns, name, patch, w)
 	}
 
-	// Dice roll (seeded by attack UID)
+	// Dice roll (seeded by turn seed — changes every turn for real variance)
 	isBossTarget := strings.HasSuffix(realTarget, "-boss")
-	baseDamage := rollDice(difficulty, isBossTarget, attackUID)
+	baseDamage, diceFormula := rollDiceDetailed(difficulty, isBossTarget, turnSeed)
 
 	// Class modifier
 	effectiveDamage := baseDamage
@@ -803,7 +806,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 		effectiveDamage = effectiveDamage * 3 / 2
 		classNote += " [Blessing: +50% dmg]"
 	} else if modifier == "blessing-fortune" {
-		critRoll := seededRoll(attackUID+"-crit", 100)
+		critRoll := seededRoll(turnSeed+"-crit", 100)
 		if critRoll < 20 {
 			effectiveDamage *= 2
 			classNote += " [CRIT! 2x dmg]"
@@ -824,7 +827,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 
 	// Helmet bonus: crit chance (double damage)
 	if helmetBonus > 0 {
-		if seededRoll(attackUID+"-helmet-crit", 100) < helmetBonus {
+		if seededRoll(turnSeed+"-helmet-crit", 100) < helmetBonus {
 			effectiveDamage *= 2
 			classNote += fmt.Sprintf(" [CRIT! helmet +%d%% crit]", helmetBonus)
 		}
@@ -858,7 +861,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 	patchSpec := map[string]interface{}{
 		"attackSeq":            newSeq,
 		"lastAttackTarget":     realTarget,
-		"lastAttackSeed":       attackUID,
+		"lastAttackSeed":       turnSeed,
 		"lastAttackIndex":      int64(-1), // will be set below for monster targets
 		"lastAttackIsBoss":     isBossTarget,
 		"lastAttackIsBackstab": isBackstab,
@@ -911,7 +914,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			}
 			// Shield block is independent of armor — works even with no armor equipped
 			if shieldBonus > 0 && counter > 0 {
-				if seededRoll(attackUID+"-shield", 100) < shieldBonus {
+				if seededRoll(turnSeed+"-shield", 100) < shieldBonus {
 					counter = 0
 					classNote += " Shield blocked!"
 				}
@@ -919,14 +922,14 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			if heroClass == "warrior" {
 				counter = counter * 3 / 4
 			} else if heroClass == "rogue" {
-				if seededRoll(attackUID+"-dodge-boss", 100) < 25 {
+				if seededRoll(turnSeed+"-dodge-boss", 100) < 25 {
 					counter = 0
 					classNote += " Rogue dodged!"
 				}
 			}
 			// Pants: bonus dodge chance (any class)
 			if pantsBonus > 0 && counter > 0 {
-				if seededRoll(attackUID+"-pants-dodge", 100) < pantsBonus {
+				if seededRoll(turnSeed+"-pants-dodge", 100) < pantsBonus {
 					counter = 0
 					classNote += fmt.Sprintf(" [DODGED! pants +%d%% dodge]", pantsBonus)
 				}
@@ -942,8 +945,8 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			enemyAction = fmt.Sprintf("Boss strikes back for %d damage!%s (Hero HP: %d)", counter, phaseNote, heroHP)
 
 			// Status effects from boss — boots provide status resist
-			effectRoll := seededRoll(attackUID+"-fx", 100)
-			resistRoll := seededRoll(attackUID+"-boots-resist", 100)
+			effectRoll := seededRoll(turnSeed+"-fx", 100)
+			resistRoll := seededRoll(turnSeed+"-boots-resist", 100)
 			resisted := bootsBonus > 0 && resistRoll < bootsBonus
 			if currentRoom == 2 {
 				// Bat-boss: poison 30%, stun 15%
@@ -982,19 +985,14 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			}
 		} else {
 			enemyAction = "Boss defeated!"
-			// Boss loot — always drops, added to inventory if under cap
-			// (Loot CR is created by boss-graph via includeWhen: hp==0)
-			// We compute the item name from the same CEL seed so frontend shows it
+			// Boss loot computed by kro combatResolve; no loot text in Go log to avoid RNG mismatch.
 			bossLootItem := computeBossLoot(name)
-			if updated, added := inventoryAdd(inventory2, bossLootItem); added {
-				inventory2 = updated
-				classNote += " Boss dropped " + bossLootItem + "!"
-			} else {
-				classNote += " Boss dropped " + bossLootItem + " (inventory full!)"
+			if _, added := inventoryAdd(inventory2, bossLootItem); !added {
+				classNote += " (inventory full)"
 			}
 		}
 
-		heroAction := fmt.Sprintf("Hero (%s) deals %d damage to %s (HP: %d -> %d)%s", heroClass, effectiveDamage, realTarget, bossHP, newBossHP, classNote)
+		heroAction := fmt.Sprintf("[%s] Hero (%s) deals %d damage to %s (HP: %d -> %d)%s", diceFormula, heroClass, effectiveDamage, realTarget, bossHP, newBossHP, classNote)
 		// MIGRATION: game state (heroHP, bossHP, poisonTurns, etc.) is computed by kro.
 		// Backend writes only log text and loot/inventory.
 		patchSpec["lastHeroAction"] = heroAction
@@ -1040,14 +1038,15 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			classNote += " +1 mana!"
 		}
 
-		// Loot drop on kill transition
+		// Loot drop is computed by kro combatResolve and written to lastLootDrop.
+		// Backend no longer adds "Dropped X!" to classNote to avoid Go vs kro RNG mismatch.
+		// inventory2 is still updated to guard the "inventory full" message correctly.
 		if oldHP > 0 && newHP == 0 {
 			if dropped, item := computeMonsterLoot(name, idxInt, difficulty); dropped {
-				if updated, added := inventoryAdd(inventory2, item); added {
-					inventory2 = updated
-					classNote += " Dropped " + item + "!"
+				if _, added := inventoryAdd(inventory2, item); added {
+					// item added — kro handles the actual drop log; no note here
 				} else {
-					classNote += " " + item + " dropped but inventory full!"
+					classNote += " (inventory full)"
 				}
 			}
 		}
@@ -1080,7 +1079,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 		}
 		// Shield block is independent of armor — works even with no armor equipped
 		if shieldBonus > 0 && totalCounter > 0 {
-			if seededRoll(attackUID+"-shield-m", 100) < shieldBonus {
+			if seededRoll(turnSeed+"-shield-m", 100) < shieldBonus {
 				totalCounter = 0
 				classNote += " Shield blocked!"
 			}
@@ -1090,14 +1089,14 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			if heroClass == "warrior" {
 				totalCounter = totalCounter * 3 / 4 // 25% reduction (consistent with boss path)
 			} else if heroClass == "rogue" {
-				if seededRoll(attackUID+"-dodge-monster", 100) < 25 {
+				if seededRoll(turnSeed+"-dodge-monster", 100) < 25 {
 					totalCounter = 0
 					classNote += " Rogue dodged!"
 				}
 			}
 			// Pants: bonus dodge chance (any class)
 			if pantsBonus > 0 && totalCounter > 0 {
-				if seededRoll(attackUID+"-pants-dodge", 100) < pantsBonus {
+				if seededRoll(turnSeed+"-pants-dodge", 100) < pantsBonus {
 					totalCounter = 0
 					classNote += fmt.Sprintf(" [DODGED! pants +%d%% dodge]", pantsBonus)
 				}
@@ -1120,8 +1119,8 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 		// Status effects from monster counter — boots provide status resist
 		effectNote := ""
 		if aliveCount > 0 && poisonTurns == 0 {
-			resistRoll := seededRoll(attackUID+"-boots-resist", 100)
-			if seededRoll(attackUID+"-fx", 100) < 20 {
+			resistRoll := seededRoll(turnSeed+"-boots-resist", 100)
+			if seededRoll(turnSeed+"-fx", 100) < 20 {
 				if bootsBonus > 0 && resistRoll < bootsBonus {
 					effectNote = fmt.Sprintf(" [RESISTED poison! boots +%d%% resist]", bootsBonus)
 				} else {
@@ -1141,8 +1140,8 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 					mtype, _ = monsterTypesRaw[i].(string)
 				}
 				if hp > 0 && mtype == "archer" {
-					if seededRoll(attackUID+fmt.Sprintf("-archer%d-stun", i), 100) < 20 {
-						resistRoll := seededRoll(attackUID+"-boots-resist-archer", 100)
+					if seededRoll(turnSeed+fmt.Sprintf("-archer%d-stun", i), 100) < 20 {
+						resistRoll := seededRoll(turnSeed+"-boots-resist-archer", 100)
 						if bootsBonus > 0 && resistRoll < bootsBonus {
 							effectNote += fmt.Sprintf(" [RESISTED archer stun! boots +%d%% resist]", bootsBonus)
 						} else {
@@ -1165,7 +1164,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 					mtype, _ = monsterTypesRaw[i].(string)
 				}
 				if hp > 0 && mtype == "shaman" {
-					if seededRoll(attackUID+fmt.Sprintf("-shaman%d-heal", i), 100) < 30 {
+					if seededRoll(turnSeed+fmt.Sprintf("-shaman%d-heal", i), 100) < 30 {
 						// Find the first alive non-shaman monster to heal
 						for j, vj := range newMonsterHP {
 							hpj := sliceInt(vj)
@@ -1193,7 +1192,7 @@ func (h *Handler) processCombat(ctx context.Context, ns, name, target string, cl
 			}
 		}
 
-		heroAction := fmt.Sprintf("Hero (%s) deals %d damage to %s (HP: %d -> %d)%s", heroClass, effectiveDamage, realTarget, oldHP, newHP, classNote)
+		heroAction := fmt.Sprintf("[%s] Hero (%s) deals %d damage to %s (HP: %d -> %d)%s", diceFormula, heroClass, effectiveDamage, realTarget, oldHP, newHP, classNote)
 		// MIGRATION: game state (heroHP, monsterHP, poisonTurns, etc.) is computed by kro.
 		// Backend writes only log text. lastLootDrop and inventory computed by kro combatResolve.
 		patchSpec["lastHeroAction"] = heroAction
@@ -1555,19 +1554,39 @@ func sanitizeK8sError(err error) string {
 
 // rollDice rolls dice based on difficulty using seeded randomness.
 func rollDice(difficulty string, isBoss bool, uid string) int64 {
+	result, _ := rollDiceDetailed(difficulty, isBoss, uid)
+	return result
+}
+
+// rollDiceDetailed returns both the numeric result and a human-readable formula string
+// e.g. "1d20+3: rolled 14 (11+3)" or "2d12+6: rolled 19 (7+6+6)".
+func rollDiceDetailed(difficulty string, isBoss bool, uid string) (int64, string) {
 	var result int64
+	var formula string
 	switch difficulty {
 	case "easy":
-		result = seededRoll(uid+"-d1", 20) + 3
+		d1 := seededRoll(uid+"-d1", 20) // [0,19]
+		result = d1 + 3
+		formula = fmt.Sprintf("1d20+3: rolled %d (%d+3)", result, d1)
 	case "hard":
-		result = seededRoll(uid+"-d1", 20) + seededRoll(uid+"-d2", 20) + seededRoll(uid+"-d3", 20) + 8
-	default:
-		result = seededRoll(uid+"-d1", 12) + seededRoll(uid+"-d2", 12) + 6
+		d1 := seededRoll(uid+"-d1", 20)
+		d2 := seededRoll(uid+"-d2", 20)
+		d3 := seededRoll(uid+"-d3", 20)
+		result = d1 + d2 + d3 + 8
+		formula = fmt.Sprintf("3d20+8: rolled %d (%d+%d+%d+8)", result, d1, d2, d3)
+	default: // normal
+		d1 := seededRoll(uid+"-d1", 12)
+		d2 := seededRoll(uid+"-d2", 12)
+		result = d1 + d2 + 6
+		formula = fmt.Sprintf("2d12+6: rolled %d (%d+%d+6)", result, d1, d2)
 	}
 	if isBoss {
-		result += seededRoll(uid+"-dboss", 20) + 3
+		db := seededRoll(uid+"-dboss", 20)
+		base := result
+		result += db + 3
+		formula = fmt.Sprintf("%s + boss[%d+3]=%d", formula, db, result-base)
 	}
-	return result
+	return result, formula
 }
 
 // seededRoll returns a deterministic value in [0, max) using the uid seed.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -419,11 +419,19 @@ export default function App() {
         } else {
           addEvent(icon, heroAction)
         }
-        if (heroAction.includes('Dropped')) addEvent('chest', heroAction.split('Dropped')[1]?.trim() || 'Loot dropped!')
-        // Kill
-        if (heroAction.includes('-> 0)')) {
-          const target = heroAction.match(/damage to (\S+)/)?.[1] || 'enemy'
-          addEvent('skull', `${target} slain!`)
+        // Loot: use lastLootDrop from spec (kro-authoritative), not Go log text
+        if (pollSucceeded && updated.spec.lastLootDrop && updated.spec.lastLootDrop !== detail?.spec.lastLootDrop) {
+          addEvent('chest', `Loot dropped: ${updated.spec.lastLootDrop}`)
+        }
+        // Kill detection: use actual monsterHP spec change, not Go log text
+        if (pollSucceeded) {
+          const prevMonHP: number[] = detail?.spec.monsterHP || []
+          const newMonHP: number[] = updated.spec.monsterHP || []
+          newMonHP.forEach((hp, idx) => {
+            if (hp <= 0 && (prevMonHP[idx] ?? 1) > 0) {
+              addEvent('skull', `monster-${idx} slain!`)
+            }
+          })
         }
       }
       if (pollSucceeded && enemyAction) {
@@ -1590,7 +1598,6 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
           difficulty={spec.difficulty || 'normal'}
           turns={spec.attackSeq || 0}
           unlocked={kroUnlocked}
-          k8sLog={k8sLog}
           onClose={() => setShowCertificate(false)}
         />
       )}
@@ -2033,9 +2040,11 @@ function CombatBreakdown({ heroAction, enemyAction, spec, oldHP }: { heroAction:
   // Weapon bonus
   if (heroAction.includes('+') && heroAction.includes('wpn')) lines.push({ icon: 'dagger', text: 'Weapon bonus applied' })
 
-  // Loot
-  if (heroAction.includes('Dropped')) { const m = heroAction.match(/Dropped (.+?)!/); if (m) lines.push({ icon: 'chest', text: `Loot: ${m[1]}`, color: '#f5c518' }) }
-  if (heroAction.includes('mana!')) lines.push({ icon: 'mana', text: '+1 mana (monster kill)', color: '#9b59b6' })
+  // Mana regen on kill (from Go log text — reliable)
+  if (heroAction.includes('+1 mana')) lines.push({ icon: 'mana', text: '+1 mana (monster kill)', color: '#9b59b6' })
+
+  // Loot — show from spec.lastLootDrop (kro-authoritative), not from Go log text
+  if (spec?.lastLootDrop) lines.push({ icon: 'chest', text: `Loot: ${spec.lastLootDrop}`, color: '#f5c518' })
 
   // Enemy action
   if (enemyAction) {
@@ -2054,8 +2063,10 @@ function CombatBreakdown({ heroAction, enemyAction, spec, oldHP }: { heroAction:
   if (enemyAction.includes('BURN')) lines.push({ icon: 'fire', text: 'Burning! -8 HP/turn for 2 turns', color: '#e74c3c' })
   if (enemyAction.includes('STUN')) lines.push({ icon: 'lightning', text: 'Stunned! Skip next attack', color: '#f1c40f' })
 
-  // Kill / victory
-  if (dmgMatch && dmgMatch[3] === '0') lines.push({ icon: 'skull', text: 'Target slain!', color: '#f5c518' })
+  // Kill / victory — derive from spec (kro-authoritative), not Go log text
+  const monsterKilled = Array.isArray(spec?.monsterHP) && spec.monsterHP.some((hp: number) => hp <= 0)
+  const bossKilled = (spec?.bossHP ?? 1) <= 0
+  if ((monsterKilled || bossKilled) && (dmgMatch || heroAction.includes('defeated'))) lines.push({ icon: 'skull', text: 'Target slain!', color: '#f5c518' })
   if (enemyAction.includes('defeated')) lines.push({ icon: 'crown', text: 'BOSS DEFEATED!', color: '#f5c518' })
 
   return (

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -1205,24 +1205,14 @@ export interface KroExpertCertificateProps {
   difficulty: string
   turns: number
   unlocked: Set<KroConceptId>
-  k8sLog: { ts: string; cmd: string; res: string }[]
   onClose: () => void
 }
 
-export function KroExpertCertificate({ dungeonName, heroClass, difficulty, turns, unlocked, k8sLog, onClose }: KroExpertCertificateProps) {
+export function KroExpertCertificate({ dungeonName, heroClass, difficulty, turns, unlocked, onClose }: KroExpertCertificateProps) {
   const total = CONCEPT_ORDER.length
   const count = unlocked.size
   const isMaster = count === total
   const title = isMaster ? 'kro Master' : count >= 9 ? 'kro Expert' : count >= 4 ? 'kro Practitioner' : 'kro Apprentice'
-
-  const handleCopyKubectl = () => {
-    const cmds = k8sLog
-      .filter(e => e.cmd.startsWith('kubectl'))
-      .map(e => `# ${e.res}\n${e.cmd}`)
-      .join('\n\n')
-    navigator.clipboard.writeText(cmds).catch(() => {/* ignore */})
-  }
-
   return (
     <div className="kro-cert-overlay" onClick={onClose}>
       <div className="kro-cert-modal" onClick={e => e.stopPropagation()}>
@@ -1262,10 +1252,7 @@ export function KroExpertCertificate({ dungeonName, heroClass, difficulty, turns
         )}
 
         <div className="kro-cert-actions">
-          <button className="btn btn-primary" onClick={handleCopyKubectl} style={{ fontSize: 8 }}>
-            <PixelIcon name="scroll" size={10} /> Copy kubectl commands
-          </button>
-          <button className="btn" onClick={onClose} style={{ fontSize: 8 }}>
+          <button className="btn btn-primary" onClick={onClose} style={{ fontSize: 8 }}>
             Close
           </button>
         </div>

--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -300,14 +300,17 @@ spec:
         abilityProcessedSeq: "${schema.spec.attackSeq}"
         lastAbility: "${''}"
 
-    # --- DoT tick: decrement poison/burn/stun and apply HP damage, once per attack turn ---
-    # Gate: attackSeq has advanced past dotProcessedSeq AND at least one DoT is active
-    # AND lastAttackTarget is empty (meaning combatResolve isn't handling this turn)
-    # AND lastAbility is empty (meaning abilityResolve already ran or this isn't an ability turn).
+     # --- DoT tick: decrement poison/burn/stun and apply HP damage, once per attack turn ---
+     # Gate: attackSeq has advanced past dotProcessedSeq AND combatResolve has fired first
+     # (dotProcessedSeq < combatProcessedSeq prevents firing the same reconcile cycle that
+     # applied the DoT via counter-attack, which would give an extra tick)
+     # AND at least one DoT is active
+     # AND lastAttackTarget is empty (combatResolve already ran and cleared the target)
+     # AND lastAbility is empty.
     - id: tickDoT
       type: specPatch
       includeWhen:
-        - "${schema.spec.attackSeq > schema.spec.dotProcessedSeq && (schema.spec.poisonTurns > 0 || schema.spec.burnTurns > 0 || schema.spec.stunTurns > 0) && schema.spec.lastAttackTarget == '' && schema.spec.lastAbility == ''}"
+        - "${schema.spec.attackSeq > schema.spec.dotProcessedSeq && schema.spec.dotProcessedSeq < schema.spec.combatProcessedSeq && (schema.spec.poisonTurns > 0 || schema.spec.burnTurns > 0 || schema.spec.stunTurns > 0) && schema.spec.lastAttackTarget == '' && schema.spec.lastAbility == ''}"
       patch:
         heroHP: "${schema.spec.heroHP - (schema.spec.poisonTurns > 0 ? 5 : 0) - (schema.spec.burnTurns > 0 ? 8 : 0) < 0 ? 0 : schema.spec.heroHP - (schema.spec.poisonTurns > 0 ? 5 : 0) - (schema.spec.burnTurns > 0 ? 8 : 0)}"
         poisonTurns: "${schema.spec.poisonTurns > 0 ? schema.spec.poisonTurns - 1 : 0}"


### PR DESCRIPTION
## Summary

Fixes 6 bugs from Phase 0b of the master plan (#368).

### #383 — Dice results almost always the same
- Root cause: fixed-name Attack CR (`name + "-latest-attack"`) is upserted via SSA every turn, keeping the same UID. `lastAttackSeed` was set to this constant UID, so every turn used identical RNG.
- Fix: `turnSeed = dungeonName + "-seq-" + attackSeq`. Per-turn unique seed. Both Go log text and kro CEL `lastAttackSeed` now change every turn.

### #382 — Dice results not shown in combat log
- Added `rollDiceDetailed()` that returns both the numeric result and a formula string (e.g. `2d12+6: rolled 19 (7+6+6)`)
- Prepended to `lastHeroAction`: `[2d12+6: rolled 19 (7+6+6)] Hero (warrior) deals 19 damage...`

### #385 — Loot visible before kill / #386 — "Monster slain" shown at wrong time
- Root cause: Go (FNV-1a hash) and kro CEL (SHA-256 hash) produce different damage values for the same seed string. Go log text said "Dropped X!" or `HP -> 0` when kro's actual state differed.
- Fix backend: removed `"Dropped X!"` and kill-indicating text from Go `classNote`; kro CEL is authoritative.
- Fix frontend `CombatBreakdown`: loot shown from `spec.lastLootDrop` (kro), kill from actual `spec.monsterHP`/`spec.bossHP` state.
- Fix frontend event log: loot event from `lastLootDrop` change; kill event from actual `monsterHP` transition.

### #387 — Poison/burn last longer than stated
- Root cause: after `combatResolve` sets `poisonTurns=3` and clears `lastAttackTarget`, kro triggers another reconcile, `tickDoT` fires the same turn poison was applied → 4 ticks instead of 3.
- Fix: added `schema.spec.dotProcessedSeq < schema.spec.combatProcessedSeq` gate to `tickDoT` — ensures it only fires once combat is already processed, never on the same reconcile cycle that set the DoT.

### #384 — Remove copy kubectl commands button from cert modal
- Removed button + `handleCopyKubectl` function + `k8sLog` prop from `KroExpertCertificate`.

Closes #383, #382, #385, #386, #387, #384