### PR TITLE
feat: leaderboard winners-only filter and cleaner table (#353 phase 1)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -416,6 +416,11 @@ func (h *Handler) recordLeaderboard(spec map[string]interface{}, kroStatus map[s
 		"current_room", currentRoom,
 		"run_count", runCount,
 	)
+	// Only persist victories to the leaderboard — defeats, room1-cleared and
+	// in-progress deletions are noise that would clutter the top-runs list.
+	if outcome != "victory" {
+		return
+	}
 	entry := LeaderboardEntry{
 		DungeonName: dungeonName,
 		HeroClass:   heroClass,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -808,18 +808,6 @@ function DungeonList({ dungeons, onSelect, onDelete, deleting, lastDungeon }: {
   )
 }
 
-const OUTCOME_ICON: Record<string, string> = {
-  victory: 'VICTORY',
-  defeat: 'DEFEAT',
-  'room1-cleared': 'ROOM 1',
-  'in-progress': '...',
-}
-const OUTCOME_COLOR: Record<string, string> = {
-  victory: '#f5c518',
-  defeat: '#e94560',
-  'room1-cleared': '#00ff41',
-  'in-progress': '#888',
-}
 const CLASS_ICON: Record<string, string> = { warrior: 'sword', mage: 'mana', rogue: 'dagger' }
 
 function LeaderboardPanel({ entries, loading, onClose }: {
@@ -843,33 +831,27 @@ function LeaderboardPanel({ entries, loading, onClose }: {
             <thead>
               <tr>
                 <th>#</th>
-                <th>Dungeon</th>
+                <th>Player</th>
                 <th>Class</th>
                 <th>Difficulty</th>
-                <th>Outcome</th>
                 <th>Turns</th>
-                <th>Room</th>
               </tr>
             </thead>
             <tbody>
               {entries.map((e, i) => (
-                <tr key={`${e.timestamp}-${e.dungeonName}`} className={`lb-row lb-${e.outcome}`}>
+                <tr key={`${e.timestamp}-${e.dungeonName}`} className="lb-row lb-victory">
                   <td className="lb-rank">{i + 1}</td>
                   <td className="lb-name">{e.dungeonName}</td>
                   <td><PixelIcon name={CLASS_ICON[e.heroClass] ?? 'sword'} size={10} /></td>
                   <td><span className={`tag tag-${e.difficulty}`}>{e.difficulty}</span></td>
-                  <td style={{ color: OUTCOME_COLOR[e.outcome] ?? '#888', fontWeight: 'bold' }}>
-                    {OUTCOME_ICON[e.outcome] ?? e.outcome}
-                  </td>
                   <td className="lb-turns">{e.totalTurns}</td>
-                  <td>{e.currentRoom ?? 1}</td>
                 </tr>
               ))}
             </tbody>
           </table>
         )}
         <div style={{ fontSize: '7px', color: 'var(--text-dim)', marginTop: 8, textAlign: 'center' }}>
-          Sorted by fewest turns. Stored in the <code>krombat-leaderboard</code> ConfigMap in <code>rpg-system</code>.
+          Victory runs only, sorted by fewest turns. Stored in the <code>krombat-leaderboard</code> ConfigMap in <code>rpg-system</code>.
         </div>
       </div>
     </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -35,7 +35,8 @@ export interface DungeonCR {
     lastHeroAction?: string; lastEnemyAction?: string; lastCombatLog?: string; lastLootDrop?: string
     attackSeq?: number; actionSeq?: number
     lastAttackTarget?: string; lastAction?: string; lastAbility?: string
-    initProcessedSeq?: number
+    initProcessedSeq?: number; room2ProcessedSeq?: number
+    combatProcessedSeq?: number
   }
   status?: {
     livingMonsters: number; bossState: string; victory: boolean; defeated: boolean


### PR DESCRIPTION
## Summary

- Backend: `recordLeaderboard` now early-returns for non-victory outcomes — only full-dungeon victories (both rooms cleared) are recorded in the ConfigMap. Defeats, room1-cleared partial runs, and in-progress deletions are silently dropped.
- Frontend: Leaderboard table simplified to `# | Player | Class | Difficulty | Turns` — removed redundant Outcome and Room columns (all rows are now victories by construction). Footer updated to say "Victory runs only".
- Frontend: Added missing `room2ProcessedSeq` and `combatProcessedSeq` fields to `DungeonSpec` TypeScript type to fix pre-existing TS error.

Closes #353