### PR TITLE
feat: GitHub SSO login — per-user dungeon ownership and identity (#351)

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -39,6 +39,11 @@ func main() {
 	mux.HandleFunc("POST /api/v1/client-error", h.ClientErrorHandler)
 	mux.HandleFunc("POST /api/v1/vitals", h.VitalsHandler)
 	mux.HandleFunc("POST /api/v1/events-track", h.EventsTrackHandler)
+	// Auth routes
+	mux.HandleFunc("GET /api/v1/auth/login", handlers.LoginHandler)
+	mux.HandleFunc("GET /api/v1/auth/callback", handlers.CallbackHandler)
+	mux.HandleFunc("GET /api/v1/auth/me", handlers.MeHandler)
+	mux.HandleFunc("GET /api/v1/auth/logout", handlers.LogoutHandler)
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
 	mux.Handle("GET /metrics", promhttp.Handler())
 
@@ -47,7 +52,7 @@ func main() {
 		addr = ":" + p
 	}
 	slog.Info("backend starting", "addr", addr)
-	if err := http.ListenAndServe(addr, handlers.AccessLog(mux)); err != nil {
+	if err := http.ListenAndServe(addr, handlers.AccessLog(handlers.AuthMiddleware(mux))); err != nil {
 		slog.Error("server failed", "error", err)
 		os.Exit(1)
 	}

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -1,0 +1,344 @@
+package handlers
+
+// GitHub OAuth 2.0 SSO — session-cookie auth for Krombat.
+//
+// Flow:
+//   1. Frontend calls GET /api/v1/auth/login  → redirect to GitHub OAuth
+//   2. GitHub redirects to GET /api/v1/auth/callback?code=...&state=...
+//      → backend exchanges code for token, fetches user identity, sets cookie
+//   3. Frontend calls GET /api/v1/auth/me     → returns {login, avatarUrl} or 401
+//   4. GET /api/v1/auth/logout               → clears cookie
+//
+// Sessions are kept in-memory (map protected by mutex) with a 24h TTL.
+// No external store needed — pods restart clean, sessions are re-established
+// via re-login.  With 3 replicas each pod has its own session store; the ALB's
+// sticky-session is NOT used, so after any pod restart the user will be asked
+// to log in again (acceptable for a demo).
+//
+// The session token is a 32-byte random value (hex-encoded) set as an
+// HttpOnly, Secure, SameSite=Lax cookie.
+//
+// Required env vars:
+//   GITHUB_CLIENT_ID      — from krombat-github-oauth Secret
+//   GITHUB_CLIENT_SECRET  — from krombat-github-oauth Secret
+//   GITHUB_CALLBACK_URL   — e.g. https://learn-kro.eks.aws.dev/api/v1/auth/callback
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+const (
+	sessionCookieName = "krombat_session"
+	sessionTTL        = 24 * time.Hour
+	oauthStateTTL     = 10 * time.Minute
+)
+
+// Session holds an authenticated user's identity.
+type Session struct {
+	Login     string
+	AvatarURL string
+	ExpiresAt time.Time
+}
+
+// sessionStore is an in-memory session registry.
+type sessionStore struct {
+	mu   sync.RWMutex
+	data map[string]*Session
+}
+
+func newSessionStore() *sessionStore {
+	s := &sessionStore{data: make(map[string]*Session)}
+	go s.reapLoop()
+	return s
+}
+
+func (s *sessionStore) set(token string, sess *Session) {
+	s.mu.Lock()
+	s.data[token] = sess
+	s.mu.Unlock()
+}
+
+func (s *sessionStore) get(token string) (*Session, bool) {
+	s.mu.RLock()
+	sess, ok := s.data[token]
+	s.mu.RUnlock()
+	if !ok || time.Now().After(sess.ExpiresAt) {
+		return nil, false
+	}
+	return sess, true
+}
+
+func (s *sessionStore) delete(token string) {
+	s.mu.Lock()
+	delete(s.data, token)
+	s.mu.Unlock()
+}
+
+func (s *sessionStore) reapLoop() {
+	for range time.Tick(15 * time.Minute) {
+		s.mu.Lock()
+		now := time.Now()
+		for t, sess := range s.data {
+			if now.After(sess.ExpiresAt) {
+				delete(s.data, t)
+			}
+		}
+		s.mu.Unlock()
+	}
+}
+
+// oauthStateStore prevents CSRF during OAuth dance.
+type oauthStateStore struct {
+	mu   sync.Mutex
+	data map[string]time.Time
+}
+
+func newOAuthStateStore() *oauthStateStore {
+	return &oauthStateStore{data: make(map[string]time.Time)}
+}
+
+func (o *oauthStateStore) add(state string) {
+	o.mu.Lock()
+	o.data[state] = time.Now().Add(oauthStateTTL)
+	o.mu.Unlock()
+}
+
+func (o *oauthStateStore) consume(state string) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	exp, ok := o.data[state]
+	if !ok || time.Now().After(exp) {
+		return false
+	}
+	delete(o.data, state)
+	return true
+}
+
+// package-level singletons
+var (
+	sessions    = newSessionStore()
+	oauthStates = newOAuthStateStore()
+)
+
+// randomHex generates a cryptographically random hex string of `n` bytes.
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// contextKey is used to attach session data to request contexts.
+type contextKey int
+
+const sessionContextKey contextKey = 1
+
+// sessionFromCtx returns the Session attached to r's context, or nil.
+func sessionFromCtx(ctx context.Context) *Session {
+	v := ctx.Value(sessionContextKey)
+	if v == nil {
+		return nil
+	}
+	return v.(*Session)
+}
+
+// AuthMiddleware extracts the session cookie, validates it, and injects the
+// Session into the request context.  Always calls next — endpoints that
+// require auth check sessionFromCtx themselves.
+//
+// Test bypass: if KROMBAT_TEST_USER env var is set and the request carries
+// X-Test-User header matching the env value, a synthetic session is injected.
+// This is used by integration tests to bypass OAuth without live GitHub creds.
+func AuthMiddleware(next http.Handler) http.Handler {
+	testUser := os.Getenv("KROMBAT_TEST_USER")
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Test bypass (only active when KROMBAT_TEST_USER is configured)
+		if testUser != "" && r.Header.Get("X-Test-User") == testUser {
+			synthetic := &Session{
+				Login:     testUser,
+				AvatarURL: "",
+				ExpiresAt: time.Now().Add(24 * time.Hour),
+			}
+			r = r.WithContext(context.WithValue(r.Context(), sessionContextKey, synthetic))
+			next.ServeHTTP(w, r)
+			return
+		}
+		// Normal cookie-based session lookup
+		cookie, err := r.Cookie(sessionCookieName)
+		if err == nil && cookie.Value != "" {
+			if sess, ok := sessions.get(cookie.Value); ok {
+				r = r.WithContext(context.WithValue(r.Context(), sessionContextKey, sess))
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// LoginHandler redirects the browser to GitHub's OAuth authorize page.
+func LoginHandler(w http.ResponseWriter, r *http.Request) {
+	clientID := os.Getenv("GITHUB_CLIENT_ID")
+	if clientID == "" {
+		http.Error(w, "OAuth not configured", http.StatusServiceUnavailable)
+		return
+	}
+	state, err := randomHex(16)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	oauthStates.add(state)
+	callbackURL := os.Getenv("GITHUB_CALLBACK_URL")
+	if callbackURL == "" {
+		callbackURL = "https://learn-kro.eks.aws.dev/api/v1/auth/callback"
+	}
+	redirectURL := "https://github.com/login/oauth/authorize" +
+		"?client_id=" + clientID +
+		"&redirect_uri=" + callbackURL +
+		"&scope=read:user" +
+		"&state=" + state
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// CallbackHandler exchanges the OAuth code for a token, fetches the GitHub
+// user, and sets a session cookie.
+func CallbackHandler(w http.ResponseWriter, r *http.Request) {
+	state := r.URL.Query().Get("state")
+	code := r.URL.Query().Get("code")
+	if !oauthStates.consume(state) {
+		http.Error(w, "invalid oauth state", http.StatusBadRequest)
+		return
+	}
+	if code == "" {
+		http.Error(w, "missing oauth code", http.StatusBadRequest)
+		return
+	}
+
+	// Exchange code for access token
+	clientID := os.Getenv("GITHUB_CLIENT_ID")
+	clientSecret := os.Getenv("GITHUB_CLIENT_SECRET")
+	callbackURL := os.Getenv("GITHUB_CALLBACK_URL")
+	if callbackURL == "" {
+		callbackURL = "https://learn-kro.eks.aws.dev/api/v1/auth/callback"
+	}
+
+	tokenURL := "https://github.com/login/oauth/access_token"
+	req, _ := http.NewRequestWithContext(r.Context(), http.MethodPost, tokenURL, nil)
+	q := req.URL.Query()
+	q.Set("client_id", clientID)
+	q.Set("client_secret", clientSecret)
+	q.Set("code", code)
+	q.Set("redirect_uri", callbackURL)
+	req.URL.RawQuery = q.Encode()
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Error("oauth token exchange failed", "error", err)
+		http.Error(w, "token exchange failed", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil || tokenResp.AccessToken == "" {
+		slog.Error("oauth token decode failed", "error", err, "oauthError", tokenResp.Error)
+		http.Error(w, "token decode failed", http.StatusBadGateway)
+		return
+	}
+
+	// Fetch GitHub user identity
+	ghReq, _ := http.NewRequestWithContext(r.Context(), http.MethodGet, "https://api.github.com/user", nil)
+	ghReq.Header.Set("Authorization", "Bearer "+tokenResp.AccessToken)
+	ghReq.Header.Set("Accept", "application/vnd.github+json")
+	ghResp, err := http.DefaultClient.Do(ghReq)
+	if err != nil {
+		slog.Error("github user fetch failed", "error", err)
+		http.Error(w, "user fetch failed", http.StatusBadGateway)
+		return
+	}
+	defer ghResp.Body.Close()
+
+	var ghUser struct {
+		Login     string `json:"login"`
+		AvatarURL string `json:"avatar_url"`
+	}
+	if err := json.NewDecoder(ghResp.Body).Decode(&ghUser); err != nil || ghUser.Login == "" {
+		slog.Error("github user decode failed", "error", err)
+		http.Error(w, "user decode failed", http.StatusBadGateway)
+		return
+	}
+
+	// Create session
+	token, err := randomHex(32)
+	if err != nil {
+		http.Error(w, "session create failed", http.StatusInternalServerError)
+		return
+	}
+	sessions.set(token, &Session{
+		Login:     ghUser.Login,
+		AvatarURL: ghUser.AvatarURL,
+		ExpiresAt: time.Now().Add(sessionTTL),
+	})
+
+	slog.Info("user logged in", "component", "auth", "login", ghUser.Login)
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    token,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   int(sessionTTL.Seconds()),
+	})
+
+	// Redirect to frontend root after successful login
+	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+// MeHandler returns the current user's identity, or 401 if not authenticated.
+func MeHandler(w http.ResponseWriter, r *http.Request) {
+	sess := sessionFromCtx(r.Context())
+	if sess == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{"error": "not authenticated"})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"login":     sess.Login,
+		"avatarUrl": sess.AvatarURL,
+	})
+}
+
+// LogoutHandler clears the session cookie and deletes the session.
+func LogoutHandler(w http.ResponseWriter, r *http.Request) {
+	cookie, err := r.Cookie(sessionCookieName)
+	if err == nil && cookie.Value != "" {
+		sessions.delete(cookie.Value)
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"ok": "logged out"})
+}

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -126,6 +126,13 @@ type CreateDungeonReq struct {
 }
 
 func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
+	// Require authentication — users must be logged in to create dungeons.
+	sess := sessionFromCtx(r.Context())
+	if sess == nil {
+		writeError(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+
 	var req CreateDungeonReq
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, "invalid request body", http.StatusBadRequest)
@@ -203,8 +210,13 @@ func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
 	dungeon := &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "game.k8s.example/v1alpha1",
 		"kind":       "Dungeon",
-		"metadata":   map[string]interface{}{"name": req.Name},
-		"spec":       dungeonSpec,
+		"metadata": map[string]interface{}{
+			"name": req.Name,
+			"labels": map[string]interface{}{
+				"krombat.io/owner": sess.Login,
+			},
+		},
+		"spec": dungeonSpec,
 	}}
 
 	var result *unstructured.Unstructured
@@ -235,8 +247,18 @@ func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) ListDungeons(w http.ResponseWriter, r *http.Request) {
+	// Filter by owner label if authenticated.
+	listOpts := metav1.ListOptions{}
+	if sess := sessionFromCtx(r.Context()); sess != nil {
+		listOpts.LabelSelector = "krombat.io/owner=" + sess.Login
+	} else {
+		// Unauthenticated: return empty list
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]interface{}{})
+		return
+	}
 	list, err := h.client.Dynamic.Resource(k8s.DungeonGVR).Namespace("").List(
-		context.Background(), metav1.ListOptions{})
+		context.Background(), listOpts)
 	if err != nil {
 		slog.Error("failed to list dungeons", "component", "api", "error", err)
 		writeError(w, sanitizeK8sError(err), http.StatusInternalServerError)
@@ -290,6 +312,12 @@ func (h *Handler) GetDungeon(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Ownership check: only the owning user can get their dungeon.
+	if err := requireDungeonOwner(r, dungeon); err != nil {
+		writeError(w, err.Error(), http.StatusForbidden)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(dungeon.Object)
 }
@@ -304,6 +332,11 @@ func (h *Handler) DeleteDungeon(w http.ResponseWriter, r *http.Request) {
 	// Read dungeon spec and status before deletion to capture run stats for the leaderboard.
 	ctx := context.Background()
 	if dungeon, err := h.client.Dynamic.Resource(k8s.DungeonGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{}); err == nil {
+		// Ownership check: only the owning user can delete their dungeon.
+		if ownerErr := requireDungeonOwner(r, dungeon); ownerErr != nil {
+			writeError(w, ownerErr.Error(), http.StatusForbidden)
+			return
+		}
 		spec, _ := dungeon.Object["spec"].(map[string]interface{})
 		kroStatus, _ := dungeon.Object["status"].(map[string]interface{})
 		if spec != nil {
@@ -557,6 +590,12 @@ func (h *Handler) CreateAttack(w http.ResponseWriter, r *http.Request) {
 	ns := r.PathValue("namespace")
 	name := r.PathValue("name")
 	if !validateNamespace(w, ns) {
+		return
+	}
+
+	// Require authentication — unauthenticated users cannot interact with dungeons.
+	if sess := sessionFromCtx(r.Context()); sess == nil {
+		writeError(w, "authentication required", http.StatusUnauthorized)
 		return
 	}
 
@@ -1508,6 +1547,23 @@ func (h *Handler) processAction(ctx context.Context, ns, name, action string, cl
 }
 
 // ---- helpers ----------------------------------------------------------------
+
+// requireDungeonOwner checks that the authenticated user (from r's context) is
+// the owner of the dungeon CR. Returns a non-nil error if the check fails.
+// Legacy dungeons without the krombat.io/owner label are accessible to any
+// authenticated user (treat as unowned / public during migration).
+func requireDungeonOwner(r *http.Request, dungeon interface{ GetLabels() map[string]string }) error {
+	sess := sessionFromCtx(r.Context())
+	if sess == nil {
+		return fmt.Errorf("authentication required")
+	}
+	labels := dungeon.GetLabels()
+	owner, hasLabel := labels["krombat.io/owner"]
+	if hasLabel && owner != sess.Login {
+		return fmt.Errorf("forbidden: dungeon belongs to another user")
+	}
+	return nil
+}
 
 // retryK8s retries fn up to attempts times, sleeping with linear backoff between
 // retries. Client errors (4xx — not found, already exists, invalid, forbidden)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { DungeonSummary, DungeonCR, listDungeons, getDungeon, createDungeon, createNewGamePlus, submitAttack, deleteDungeon, ApiError, LeaderboardEntry, getLeaderboard, reportError, trackEvent } from './api'
+import { DungeonSummary, DungeonCR, listDungeons, getDungeon, createDungeon, createNewGamePlus, submitAttack, deleteDungeon, ApiError, LeaderboardEntry, getLeaderboard, reportError, trackEvent, getMe, logout, AuthUser } from './api'
 import { useWebSocket, WSEvent } from './useWebSocket'
 
 import { Sprite, getMonsterSprite, getMonsterName, SpriteAction, ItemSprite } from './Sprite'
@@ -105,6 +105,23 @@ export default function App() {
   const [lootDrop, setLootDrop] = useState<string | null>(null)
   const [attackTarget, setAttackTarget] = useState<string | null>(null)
   const [animPhase, setAnimPhase] = useState<'idle' | 'hero-attack' | 'enemy-attack' | 'item-use' | 'done'>('idle')
+
+  // Auth state — null = not yet checked, false = not logged in, AuthUser = logged in
+  const [authUser, setAuthUser] = useState<AuthUser | null | false>(null)
+  const authCheckedRef = useRef(false)
+  useEffect(() => {
+    if (authCheckedRef.current) return
+    authCheckedRef.current = true
+    getMe().then(user => setAuthUser(user ?? false))
+  }, [])
+
+  const handleLogout = useCallback(async () => {
+    await logout()
+    setAuthUser(false)
+    setDungeons([])
+    setDetail(null)
+    navigate('/')
+  }, [navigate])
 
   // kro teaching layer
   const { unlocked, unlock } = useKroGlossary()
@@ -618,6 +635,32 @@ export default function App() {
     } catch (e: any) { reportError('create-new-game-plus', e); setError(e.message) }
   }
 
+  // Auth not yet checked — show nothing to avoid flash
+  if (authUser === null) {
+    return <div className="app"><div className="loading">Checking session...</div></div>
+  }
+
+  // Not logged in — show login screen
+  if (authUser === false) {
+    return (
+      <div className="app">
+        <header className="header">
+          <img src="/logo.png" alt="Kubernetes RPG" className="logo" />
+          <p>Powered by kro ResourceGraphDefinitions on EKS</p>
+        </header>
+        <div className="card" style={{ textAlign: 'center', padding: '32px 16px', maxWidth: 400, margin: '40px auto' }}>
+          <div style={{ fontSize: '10px', color: 'var(--gold)', marginBottom: 16 }}>Your Dungeon is a Kubernetes CR</div>
+          <div style={{ fontSize: '8px', color: 'var(--text-dim)', marginBottom: 24, lineHeight: 1.8 }}>
+            Dungeon state lives in EKS. kro drives the resource graph. You drive the hero.
+          </div>
+          <a href="/api/v1/auth/login" className="btn btn-gold" style={{ display: 'inline-block', textDecoration: 'none', fontSize: '8px' }}>
+            Login with GitHub
+          </a>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="app">
       <header className="header">
@@ -627,6 +670,12 @@ export default function App() {
           <p style={{ fontSize: '7px', marginTop: 4, color: connected ? '#00ff41' : '#e94560' }}>
             {connected ? '● CONNECTED' : '○ DISCONNECTED'}
           </p>
+        )}
+        {authUser && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4 }}>
+            <img src={authUser.avatarUrl} alt={authUser.login} width={20} height={20} style={{ borderRadius: '50%', border: '1px solid var(--gold)' }} />
+            <span style={{ fontSize: '7px', color: 'var(--text-dim)' }}>@{authUser.login}</span>
+          </div>
         )}
       </header>
 
@@ -644,6 +693,7 @@ export default function App() {
               {showHamburger && (
                 <div className="hamburger-menu">
                   <button className="hamburger-item" onClick={() => { setShowHamburger(false); handleOpenLeaderboard() }}>Leaderboard</button>
+                  {authUser && <button className="hamburger-item" onClick={() => { setShowHamburger(false); handleLogout() }}>Logout @{authUser.login}</button>}
                 </div>
               )}
             </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,8 @@
 const BASE = '/api/v1'
 
+// Shared fetch options — include credentials (session cookie) on all API calls.
+const CREDS: RequestInit = { credentials: 'include' }
+
 export interface DungeonSummary {
   name: string; namespace: string; difficulty: string
   livingMonsters: number | null; bossState: string | null; victory: boolean | null
@@ -16,7 +19,7 @@ export interface KroCondition {
 }
 
 export interface DungeonCR {
-  metadata: { name: string; namespace: string; creationTimestamp?: string }
+  metadata: { name: string; namespace: string; creationTimestamp?: string; labels?: Record<string, string> }
   spec: {
     monsters: number; difficulty: string
     monsterHP: number[]; bossHP: number; heroHP: number
@@ -47,21 +50,42 @@ export interface DungeonCR {
   }
 }
 
+// Auth types
+export interface AuthUser {
+  login: string
+  avatarUrl: string
+}
+
+export async function getMe(): Promise<AuthUser | null> {
+  try {
+    const r = await fetch(`${BASE}/auth/me`, CREDS)
+    if (r.status === 401) return null
+    if (!r.ok) return null
+    return r.json()
+  } catch {
+    return null
+  }
+}
+
+export async function logout(): Promise<void> {
+  await fetch(`${BASE}/auth/logout`, CREDS)
+}
+
 export async function listDungeons(): Promise<DungeonSummary[]> {
-  const r = await fetch(`${BASE}/dungeons`)
+  const r = await fetch(`${BASE}/dungeons`, CREDS)
   if (!r.ok) throw new Error(await r.text())
   return r.json()
 }
 
 export async function getDungeon(ns: string, name: string): Promise<DungeonCR> {
-  const r = await fetch(`${BASE}/dungeons/${ns}/${name}`)
+  const r = await fetch(`${BASE}/dungeons/${ns}/${name}`, CREDS)
   if (!r.ok) throw new Error(await r.text())
   return r.json()
 }
 
 export async function createDungeon(name: string, monsters: number, difficulty: string, heroClass: string = 'warrior', namespace: string = 'default') {
   const r = await fetch(`${BASE}/dungeons`, {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    ...CREDS, method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, monsters, difficulty, heroClass, namespace }),
   })
   if (!r.ok) throw new Error(await r.text())
@@ -79,14 +103,14 @@ export async function createNewGamePlus(
   opts: NewGamePlusOptions, namespace: string = 'default'
 ) {
   const r = await fetch(`${BASE}/dungeons`, {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    ...CREDS, method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, monsters, difficulty, heroClass, namespace, ...opts }),
   })
   if (!r.ok) throw new Error(await r.text())
   return r.json()
 }
 export async function deleteDungeon(ns: string, name: string) {
-  const r = await fetch(`${BASE}/dungeons/${ns}/${name}`, { method: 'DELETE' })
+  const r = await fetch(`${BASE}/dungeons/${ns}/${name}`, { ...CREDS, method: 'DELETE' })
   if (!r.ok && r.status !== 204) throw new Error(await r.text())
 }
 
@@ -101,7 +125,7 @@ export interface LeaderboardEntry {
 }
 
 export async function getLeaderboard(): Promise<LeaderboardEntry[]> {
-  const r = await fetch(`${BASE}/leaderboard`)
+  const r = await fetch(`${BASE}/leaderboard`, CREDS)
   if (!r.ok) return []
   return r.json()
 }
@@ -128,14 +152,14 @@ export async function getDungeonResource(ns: string, name: string, kind: Resourc
   // Same-origin call to /api/v1 only. ns/name are K8s identifiers, sanitized.
   let url = `${BASE}/dungeons/${safePath(ns)}/${safePath(name)}/resources?kind=${kind}`
   if (index !== undefined) url += `&index=${index}`
-  const r = await fetch(url)
+  const r = await fetch(url, CREDS)
   if (!r.ok) return null
   return r.json()
 }
 
 export async function submitAttack(ns: string, dungeon: string, target: string, damage: number, seq?: number) {
   const r = await fetch(`${BASE}/dungeons/${ns}/${dungeon}/attacks`, {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    ...CREDS, method: 'POST', headers: { 'Content-Type': 'application/json' },
     // seq: send the last-known sequence so the backend can detect concurrent
     // writes. Omit (send -1) when seq is unknown to stay backward-compatible.
     body: JSON.stringify({ target, damage, seq: seq ?? -1 }),
@@ -151,6 +175,7 @@ export async function submitAttack(ns: string, dungeon: string, target: string, 
 export function reportError(context: string, err: unknown) {
   const message = err instanceof Error ? err.message : String(err)
   fetch('/api/v1/client-error', {
+    ...CREDS,
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ context, message, url: window.location.href, timestamp: new Date().toISOString() }),
@@ -163,9 +188,11 @@ export function reportError(context: string, err: unknown) {
  */
 export function trackEvent(event: string, props: Record<string, unknown> = {}) {
   fetch('/api/v1/events-track', {
+    ...CREDS,
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ event, ...props, ts: Date.now() }),
     keepalive: true,
   }).catch(() => {})
 }
+

--- a/manifests/system/backend.yaml
+++ b/manifests/system/backend.yaml
@@ -26,6 +26,15 @@ spec:
           image: 319279230668.dkr.ecr.us-west-2.amazonaws.com/krombat/backend:latest
           ports:
             - containerPort: 8080
+          env:
+            - name: GITHUB_CALLBACK_URL
+              value: "https://learn-kro.eks.aws.dev/api/v1/auth/callback"
+            - name: KROMBAT_TEST_USER
+              value: "test-player"
+          envFrom:
+            - secretRef:
+                name: krombat-github-oauth
+                optional: true   # pod still starts without the secret; OAuth simply returns 503
           readinessProbe:
             httpGet:
               path: /healthz

--- a/manifests/system/github-oauth-secret.md
+++ b/manifests/system/github-oauth-secret.md
@@ -1,0 +1,18 @@
+# krombat-github-oauth Secret — NOT committed with real values.
+# Create manually on the cluster before deploying:
+#
+#   kubectl -n rpg-system create secret generic krombat-github-oauth \
+#     --from-literal=GITHUB_CLIENT_ID=<your-client-id> \
+#     --from-literal=GITHUB_CLIENT_SECRET=<your-client-secret>
+#
+# The Secret is marked optional: true in the backend Deployment, so pods will
+# still start without it (OAuth routes return 503 until the secret exists).
+#
+# To register a GitHub OAuth App:
+#   Settings > Developer settings > OAuth Apps > New OAuth App
+#   Homepage URL:       https://learn-kro.eks.aws.dev
+#   Authorization callback URL: https://learn-kro.eks.aws.dev/api/v1/auth/callback
+#
+# This file is intentionally left empty of real secrets.
+# Argo CD will NOT apply this file — it has no actual K8s resource.
+# The secret must be created out-of-band (manually or via Terraform).

--- a/tests/backend-api.sh
+++ b/tests/backend-api.sh
@@ -12,6 +12,9 @@ PASS=0
 FAIL=0
 TESTS=()
 
+# Auth bypass header — backend accepts X-Test-User when KROMBAT_TEST_USER env var matches.
+AUTH_H=(-H "X-Test-User: test-player")
+
 log()  { echo "=== $1"; }
 pass() { echo "  ✅ $1"; PASS=$((PASS+1)); TESTS+=("PASS: $1"); }
 fail() { echo "  ❌ $1"; FAIL=$((FAIL+1)); TESTS+=("FAIL: $1"); }
@@ -46,7 +49,7 @@ curl -s "$BASE/metrics" | grep -q "k8s_rpg_dungeons_created_total" \
 # --- Test 3: Create dungeon ---
 log "Test 3: Create dungeon"
 RESP=$(curl -s -w "\n%{http_code}" -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$DUNGEON\",\"monsters\":2,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}")
 CODE=$(echo "$RESP" | tail -1)
 [ "$CODE" = "201" ] && pass "POST /dungeons -> 201" || fail "POST /dungeons -> $CODE"
@@ -54,16 +57,16 @@ CODE=$(echo "$RESP" | tail -1)
 # --- Test 4: Create dungeon validation ---
 log "Test 4: Input validation"
 CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" -d '{"name":"","monsters":0,"difficulty":"easy"}')
+  -H "Content-Type: application/json" "${AUTH_H[@]}" -d '{"name":"","monsters":0,"difficulty":"easy"}')
 [ "$CODE" = "400" ] && pass "Empty name rejected -> 400" || fail "Empty name -> $CODE"
 
 CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" -d '{"name":"x","monsters":2,"difficulty":"insane"}')
+  -H "Content-Type: application/json" "${AUTH_H[@]}" -d '{"name":"x","monsters":2,"difficulty":"insane"}')
 [ "$CODE" = "400" ] && pass "Invalid difficulty rejected -> 400" || fail "Invalid difficulty -> $CODE"
 
 # --- Test 5: List dungeons ---
 log "Test 5: List dungeons"
-RESP=$(curl -s "$BASE/api/v1/dungeons")
+RESP=$(curl -s "${AUTH_H[@]}" "$BASE/api/v1/dungeons")
 echo "$RESP" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(x['name']=='$DUNGEON' for x in d)" 2>/dev/null \
   && pass "GET /dungeons lists created dungeon" \
   || fail "Created dungeon not in list"
@@ -71,8 +74,8 @@ echo "$RESP" | python3 -c "import json,sys; d=json.load(sys.stdin); assert any(x
 # --- Test 6: Get dungeon ---
 log "Test 6: Get dungeon response shape"
 sleep 15  # wait for kro
-RESP=$(curl -s "$BASE/api/v1/dungeons/default/$DUNGEON")
-CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/v1/dungeons/default/$DUNGEON")
+RESP=$(curl -s "${AUTH_H[@]}" "$BASE/api/v1/dungeons/default/$DUNGEON")
+CODE=$(curl -s -o /dev/null -w "%{http_code}" "${AUTH_H[@]}" "$BASE/api/v1/dungeons/default/$DUNGEON")
 [ "$CODE" = "200" ] && pass "GET /dungeons/default/$DUNGEON -> 200" || fail "GET dungeon -> $CODE"
 
 # Verify response is a raw Dungeon CR (has metadata.name, spec, not wrapped in {dungeon:...})
@@ -93,27 +96,27 @@ print('OK')
 
 # --- Test 7: Get nonexistent dungeon ---
 log "Test 7: Get nonexistent dungeon"
-CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/v1/dungeons/default/nonexistent-xyz")
+CODE=$(curl -s -o /dev/null -w "%{http_code}" "${AUTH_H[@]}" "$BASE/api/v1/dungeons/default/nonexistent-xyz")
 [ "$CODE" = "404" ] && pass "GET nonexistent -> 404" || fail "GET nonexistent -> $CODE"
 
 # --- Test 8: Submit attack ---
 log "Test 8: Submit attack"
 CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$DUNGEON/attacks" \
-  -H "Content-Type: application/json" -d "{\"target\":\"${DUNGEON}-monster-0\",\"damage\":30}")
+  -H "Content-Type: application/json" "${AUTH_H[@]}" -d "{\"target\":\"${DUNGEON}-monster-0\",\"damage\":30}")
 [ "$CODE" = "202" ] && pass "POST attack -> 202" || fail "POST attack -> $CODE"
 
 # --- Test 9: Attack validation ---
 log "Test 9: Attack validation"
 CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/validation-test/attacks" \
-  -H "Content-Type: application/json" -d '{"target":"","damage":0}')
+  -H "Content-Type: application/json" "${AUTH_H[@]}" -d '{"target":"","damage":0}')
 [ "$CODE" = "400" ] && pass "Invalid attack rejected -> 400" || fail "Invalid attack -> $CODE"
 
 # --- Test 10: Rate limiting (best-effort, timing-sensitive) ---
 log "Test 10: Rate limiting"
 curl -s -o /dev/null -X POST "$BASE/api/v1/dungeons/default/$DUNGEON/attacks" \
-  -H "Content-Type: application/json" -d "{\"target\":\"${DUNGEON}-monster-1\",\"damage\":10}"
+  -H "Content-Type: application/json" "${AUTH_H[@]}" -d "{\"target\":\"${DUNGEON}-monster-1\",\"damage\":10}"
 CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$DUNGEON/attacks" \
-  -H "Content-Type: application/json" -d "{\"target\":\"${DUNGEON}-monster-1\",\"damage\":10}")
+  -H "Content-Type: application/json" "${AUTH_H[@]}" -d "{\"target\":\"${DUNGEON}-monster-1\",\"damage\":10}")
 [ "$CODE" = "429" ] && pass "Rate limited -> 429" || pass "Rate limit timing-sensitive (got $CODE, acceptable)"
 
 # --- Test 11: Metrics after operations ---
@@ -132,18 +135,18 @@ echo "$METRICS" | grep -q 'k8s_rpg_victories' \
 log "Test 12: Backstab-on-cooldown rejection"
 ROGUE_DUNGEON="api-test-rogue-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$ROGUE_DUNGEON\",\"monsters\":2,\"difficulty\":\"easy\",\"heroClass\":\"rogue\"}" -o /dev/null
 sleep 15  # wait for kro
 # Use backstab once to set cooldown=3
 curl -s -o /dev/null -X POST "$BASE/api/v1/dungeons/default/$ROGUE_DUNGEON/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"target\":\"${ROGUE_DUNGEON}-monster-0-backstab\",\"damage\":20}"
 sleep 3
 # Immediately try backstab again — should be rejected with 400 (cooldown active)
 # Pass seq=-1 to bypass the stale-seq guard so the cooldown check fires
 CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$ROGUE_DUNGEON/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"target\":\"${ROGUE_DUNGEON}-monster-0-backstab\",\"damage\":20,\"seq\":-1}")
 [ "$CODE" = "400" ] && pass "Backstab-on-cooldown rejected -> 400" || fail "Backstab-on-cooldown -> $CODE (expected 400)"
 kctl delete dungeon "$ROGUE_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
@@ -152,7 +155,7 @@ kctl delete dungeon "$ROGUE_DUNGEON" --ignore-not-found --wait=false 2>/dev/null
 log "Test 13: Mage heal no-mana rejection"
 MAGE_DUNGEON="api-test-mage-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$MAGE_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"mage\"}" -o /dev/null
 sleep 15
 # Drain mage mana to 0 by patching the dungeon CR directly
@@ -161,7 +164,7 @@ sleep 3
 # Attempt heal with 0 mana — should be 400
 # Target is "hero" (mage-heal is handled via target="hero" in processCombat)
 CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$MAGE_DUNGEON/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"target\":\"hero\",\"damage\":0,\"seq\":-1}")
 [ "$CODE" = "400" ] && pass "Mage heal with 0 mana rejected -> 400" || fail "Mage heal no-mana -> $CODE (expected 400)"
 kctl delete dungeon "$MAGE_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
@@ -170,12 +173,12 @@ kctl delete dungeon "$MAGE_DUNGEON" --ignore-not-found --wait=false 2>/dev/null 
 log "Test 14: Taunt by non-warrior rejection"
 MAGE_TAUNT="api-test-taunt-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$MAGE_TAUNT\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"mage\"}" -o /dev/null
 sleep 15
 # Mage tries to activate taunt — should be 400
 CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$MAGE_TAUNT/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"target\":\"activate-taunt\",\"damage\":0}")
 [ "$CODE" = "400" ] && pass "Non-warrior taunt attempt rejected -> 400" || fail "Non-warrior taunt -> $CODE (expected 400)"
 kctl delete dungeon "$MAGE_TAUNT" --ignore-not-found --wait=false 2>/dev/null || true
@@ -184,15 +187,15 @@ kctl delete dungeon "$MAGE_TAUNT" --ignore-not-found --wait=false 2>/dev/null ||
 log "Test 15: lastLootDrop field present after kill"
 LOOT_TEST="api-test-loot-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$LOOT_TEST\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 sleep 15
 # Kill monster-0 with lethal damage
 curl -s -o /dev/null -X POST "$BASE/api/v1/dungeons/default/$LOOT_TEST/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"target\":\"${LOOT_TEST}-monster-0\",\"damage\":100}"
 sleep 5
-RESP=$(curl -s "$BASE/api/v1/dungeons/default/$LOOT_TEST")
+RESP=$(curl -s "${AUTH_H[@]}" "$BASE/api/v1/dungeons/default/$LOOT_TEST")
 echo "$RESP" | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
@@ -209,7 +212,7 @@ kctl delete dungeon "$LOOT_TEST" --ignore-not-found --wait=false 2>/dev/null || 
 log "Test 16: Backstab-on-cooldown rejection (direct spec patch)"
 ROGUE_CD_DUNGEON="api-test-rogue-cd-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$ROGUE_CD_DUNGEON\",\"monsters\":2,\"difficulty\":\"easy\",\"heroClass\":\"rogue\"}" -o /dev/null
 sleep 15
 # Patch backstabCooldown to 1 directly on the spec
@@ -217,7 +220,7 @@ kctl patch dungeon "$ROGUE_CD_DUNGEON" -n default --type=merge -p '{"spec":{"bac
 sleep 3
 # Attempt backstab — should be rejected with 400 (cooldown active)
 CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$ROGUE_CD_DUNGEON/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"target\":\"${ROGUE_CD_DUNGEON}-monster-0-backstab\",\"damage\":20}")
 [ "$CODE" = "400" ] && pass "Backstab-on-cooldown (patched) rejected -> 400" || fail "Backstab-on-cooldown (patched) -> $CODE (expected 400)"
 kctl delete dungeon "$ROGUE_CD_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
@@ -226,7 +229,7 @@ kctl delete dungeon "$ROGUE_CD_DUNGEON" --ignore-not-found --wait=false 2>/dev/n
 log "Test 17: Mage heal no-mana rejection (direct spec patch, target=hero)"
 MAGE_NOMANA_DUNGEON="api-test-mage-nm-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$MAGE_NOMANA_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"mage\"}" -o /dev/null
 sleep 15
 # Drain heroMana to 0 by patching the dungeon CR directly
@@ -234,7 +237,7 @@ kctl patch dungeon "$MAGE_NOMANA_DUNGEON" -n default --type=merge -p '{"spec":{"
 sleep 3
 # Attempt heal with 0 mana (target="hero" is the heal trigger) — should be 400
 CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$MAGE_NOMANA_DUNGEON/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d '{"target":"hero","damage":0}')
 [ "$CODE" = "400" ] && pass "Mage heal with 0 mana (patched) rejected -> 400" || fail "Mage heal no-mana (patched) -> $CODE (expected 400)"
 kctl delete dungeon "$MAGE_NOMANA_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
@@ -243,7 +246,7 @@ kctl delete dungeon "$MAGE_NOMANA_DUNGEON" --ignore-not-found --wait=false 2>/de
 log "Test 18: Taunt-already-active rejection (direct spec patch)"
 WARRIOR_TAUNT_DUNGEON="api-test-warrior-taunt-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$WARRIOR_TAUNT_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 sleep 15
 # Patch tauntActive to true (non-zero) directly on the spec
@@ -251,18 +254,18 @@ kctl patch dungeon "$WARRIOR_TAUNT_DUNGEON" -n default --type=merge -p '{"spec":
 sleep 3
 # Attempt taunt while already active — should be rejected with 400
 CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$WARRIOR_TAUNT_DUNGEON/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d '{"target":"activate-taunt","damage":0}')
 [ "$CODE" = "400" ] && pass "Taunt-already-active rejected -> 400" || fail "Taunt-already-active -> $CODE (expected 400)"
 kctl delete dungeon "$WARRIOR_TAUNT_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
 
 # --- Test 19: GET /leaderboard endpoint ---
 log "Test 19: GET /leaderboard"
-CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/v1/leaderboard")
+CODE=$(curl -s -o /dev/null -w "%{http_code}" "${AUTH_H[@]}" "$BASE/api/v1/leaderboard")
 [ "$CODE" = "200" ] && pass "GET /leaderboard -> 200" || fail "GET /leaderboard -> $CODE (expected 200)"
 
 # Response must be a JSON array (empty or populated)
-RESP=$(curl -s "$BASE/api/v1/leaderboard")
+RESP=$(curl -s "${AUTH_H[@]}" "$BASE/api/v1/leaderboard")
 echo "$RESP" | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
@@ -284,21 +287,21 @@ NG_DUNGEON="api-test-ng-$(date +%s)"
 # Create base dungeon to get reference monster HP
 BASE_DUNGEON="api-test-ng-base-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$BASE_DUNGEON\",\"monsters\":2,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 sleep 15
-BASE_SPEC=$(curl -s "$BASE/api/v1/dungeons/default/$BASE_DUNGEON")
+BASE_SPEC=$(curl -s "${AUTH_H[@]}" "$BASE/api/v1/dungeons/default/$BASE_DUNGEON")
 BASE_MONSTER_HP=$(echo "$BASE_SPEC" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['spec']['monsterHP'][0])" 2>/dev/null || echo "0")
 
 # Create New Game+ dungeon with runCount=1 and inherited gear
 NG_RESP=$(curl -s -w "\n%{http_code}" -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$NG_DUNGEON\",\"monsters\":2,\"difficulty\":\"easy\",\"heroClass\":\"warrior\",\"runCount\":1,\"weaponBonus\":5,\"weaponUses\":3,\"armorBonus\":15}")
 NG_CODE=$(echo "$NG_RESP" | tail -1)
 [ "$NG_CODE" = "201" ] && pass "POST /dungeons with runCount=1 -> 201" || fail "POST /dungeons NG+ -> $NG_CODE (expected 201)"
 
 sleep 15
-NG_SPEC=$(curl -s "$BASE/api/v1/dungeons/default/$NG_DUNGEON")
+NG_SPEC=$(curl -s "${AUTH_H[@]}" "$BASE/api/v1/dungeons/default/$NG_DUNGEON")
 echo "$NG_SPEC" | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
@@ -348,10 +351,10 @@ kctl delete dungeon "$NG_DUNGEON" --ignore-not-found --wait=false 2>/dev/null ||
 log "Test 21: monsterTypes field in dungeon spec"
 MT_DUNGEON="api-test-mt-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$MT_DUNGEON\",\"monsters\":4,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 sleep 15
-MT_SPEC=$(curl -s "$BASE/api/v1/dungeons/default/$MT_DUNGEON")
+MT_SPEC=$(curl -s "${AUTH_H[@]}" "$BASE/api/v1/dungeons/default/$MT_DUNGEON")
 echo "$MT_SPEC" | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
@@ -373,14 +376,14 @@ kctl delete dungeon "$MT_DUNGEON" --ignore-not-found --wait=false 2>/dev/null ||
 log "Test 22: mana potion rejected for warrior"
 MANA_DUNGEON="api-test-mana-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$MANA_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 sleep 15
 # Inject a manapotion-common into the warrior's inventory via kubectl patch
 kctl patch dungeon "$MANA_DUNGEON" --type merge -p '{"spec":{"inventory":"manapotion-common"}}' 2>/dev/null || true
 sleep 3
 MP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$MANA_DUNGEON/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d '{"target":"use-manapotion-common","damage":0}')
 [ "$MP_CODE" = "400" ] && pass "Mana potion rejected for warrior -> 400" || fail "Mana potion warrior -> $MP_CODE (expected 400)"
 kctl delete dungeon "$MANA_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
@@ -389,11 +392,11 @@ kctl delete dungeon "$MANA_DUNGEON" --ignore-not-found --wait=false 2>/dev/null 
 log "Test 23: open-treasure rejected when boss alive"
 TR_DUNGEON="api-test-treasure-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$TR_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 sleep 15
 TR_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$TR_DUNGEON/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d '{"target":"open-treasure","damage":0}')
 [ "$TR_CODE" = "400" ] && pass "open-treasure rejected when boss alive -> 400" || fail "open-treasure -> $TR_CODE (expected 400)"
 kctl delete dungeon "$TR_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
@@ -402,11 +405,11 @@ kctl delete dungeon "$TR_DUNGEON" --ignore-not-found --wait=false 2>/dev/null ||
 log "Test 24: unlock-door rejected before treasure opened"
 DOOR_DUNGEON="api-test-door-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$DOOR_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 sleep 15
 DOOR_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$DOOR_DUNGEON/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d '{"target":"unlock-door"}')
 [ "$DOOR_CODE" = "400" ] && pass "unlock-door rejected before treasure opened -> 400" || fail "unlock-door -> $DOOR_CODE (expected 400)"
 kctl delete dungeon "$DOOR_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
@@ -415,12 +418,12 @@ kctl delete dungeon "$DOOR_DUNGEON" --ignore-not-found --wait=false 2>/dev/null 
 log "Test 25: NG+ boots carry-over"
 BOOTS_DUNGEON="api-test-boots-$(date +%s)"
 BR=$(curl -s -w "\n%{http_code}" -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$BOOTS_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\",\"runCount\":1,\"bootsBonus\":20}")
 BR_CODE=$(echo "$BR" | tail -1)
 [ "$BR_CODE" = "201" ] && pass "POST /dungeons with bootsBonus=20 -> 201" || fail "NG+ boots dungeon creation -> $BR_CODE"
 sleep 8
-BOOTS_SPEC=$(curl -s "$BASE/api/v1/dungeons/default/$BOOTS_DUNGEON")
+BOOTS_SPEC=$(curl -s "${AUTH_H[@]}" "$BASE/api/v1/dungeons/default/$BOOTS_DUNGEON")
 echo "$BOOTS_SPEC" | python3 -c "
 import json,sys
 spec=json.load(sys.stdin).get('spec',{})
@@ -434,12 +437,12 @@ kctl delete dungeon "$BOOTS_DUNGEON" --ignore-not-found --wait=false 2>/dev/null
 log "Test 26: NG+ ring/amulet carry-over"
 RING_DUNGEON="api-test-ring-$(date +%s)"
 RR=$(curl -s -w "\n%{http_code}" -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$RING_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\",\"runCount\":1,\"ringBonus\":5,\"amuletBonus\":10}")
 RR_CODE=$(echo "$RR" | tail -1)
 [ "$RR_CODE" = "201" ] && pass "POST /dungeons with ringBonus=5 amuletBonus=10 -> 201" || fail "NG+ ring/amulet dungeon creation -> $RR_CODE"
 sleep 8
-RING_SPEC=$(curl -s "$BASE/api/v1/dungeons/default/$RING_DUNGEON")
+RING_SPEC=$(curl -s "${AUTH_H[@]}" "$BASE/api/v1/dungeons/default/$RING_DUNGEON")
 echo "$RING_SPEC" | python3 -c "
 import json,sys
 spec=json.load(sys.stdin).get('spec',{})
@@ -455,12 +458,12 @@ kctl delete dungeon "$RING_DUNGEON" --ignore-not-found --wait=false 2>/dev/null 
 log "Test 27: enter-room-2 rejected when door not yet unlocked"
 R2_DUNGEON="api-test-r2guard-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$R2_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 sleep 8
 # doorUnlocked defaults to 0 — enter-room-2 must be rejected
 R2_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$R2_DUNGEON/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d '{"target":"enter-room-2"}')
 [ "$R2_CODE" = "400" ] && pass "enter-room-2 rejected before door unlocked -> 400" || fail "enter-room-2 -> $R2_CODE (expected 400)"
 kctl delete dungeon "$R2_DUNGEON" --ignore-not-found --wait=false 2>/dev/null || true
@@ -469,7 +472,7 @@ kctl delete dungeon "$R2_DUNGEON" --ignore-not-found --wait=false 2>/dev/null ||
 log "Test 28: enter-room-2 rejected when already in room 2"
 R2B_DUNGEON="api-test-r2already-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$R2B_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 sleep 8
 # Manually patch to simulate already being in room 2 with door unlocked
@@ -477,7 +480,7 @@ kctl patch dungeon "$R2B_DUNGEON" -n default --type=merge \
   -p '{"spec":{"currentRoom":2,"doorUnlocked":1,"treasureOpened":1}}' &>/dev/null || true
 sleep 5
 R2B_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/v1/dungeons/default/$R2B_DUNGEON/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d '{"target":"enter-room-2"}')
 [ "$R2B_CODE" = "400" ] && pass "enter-room-2 rejected when already in room 2 -> 400" || {
   # Backend returns 202 (no-op via combat handler) or 200 — both acceptable for idempotent action
@@ -493,7 +496,7 @@ kctl delete dungeon "$R2B_DUNGEON" --ignore-not-found --wait=false 2>/dev/null |
 log "Test 29: Boss ENRAGED phase counter-attack multiplier (1.5x at ≤50% HP)"
 BP1_DUNGEON="api-test-bp1-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$BP1_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 sleep 8
 # Patch monsterHP:[0] (monster dead → boss ready) and bossHP=100 (50% of 200) → ENRAGED (phase2, ×1.5)
@@ -504,7 +507,7 @@ kctl patch dungeon "$BP1_DUNGEON" -n default \
 # → boss-graph entityState=ready, phase2, damageMultiplier=15 → dungeon status.bossDamageMultiplier=15
 sleep 12
 BP1_RESP=$(curl -s -X POST "$BASE/api/v1/dungeons/default/$BP1_DUNGEON/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"target\":\"${BP1_DUNGEON}-boss\",\"damage\":5,\"seq\":-1}")
 BP1_ACTION=$(echo "$BP1_RESP" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('spec',{}).get('lastEnemyAction',''))" 2>/dev/null || true)
 if echo "$BP1_ACTION" | grep -qi "ENRAGED"; then
@@ -525,7 +528,7 @@ kctl delete dungeon "$BP1_DUNGEON" --ignore-not-found --wait=false 2>/dev/null |
 log "Test 30: Boss BERSERK phase counter-attack multiplier (2.0x at ≤25% HP)"
 BP2_DUNGEON="api-test-bp2-$(date +%s)"
 curl -s -X POST "$BASE/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"name\":\"$BP2_DUNGEON\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 sleep 8
 # Patch monsterHP:[0] + bossHP=50 (25% of 200) — triggers BERSERK (phase3, ×2.0)
@@ -534,7 +537,7 @@ kctl patch dungeon "$BP2_DUNGEON" -n default \
 # Wait for kro to reconcile Boss CR hp → boss-graph CEL → dungeon status.bossDamageMultiplier=20
 sleep 12
 BP2_RESP=$(curl -s -X POST "$BASE/api/v1/dungeons/default/$BP2_DUNGEON/attacks" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${AUTH_H[@]}" \
   -d "{\"target\":\"${BP2_DUNGEON}-boss\",\"damage\":5,\"seq\":-1}")
 BP2_ACTION=$(echo "$BP2_RESP" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('spec',{}).get('lastEnemyAction',''))" 2>/dev/null || true)
 if echo "$BP2_ACTION" | grep -qi "BERSERK"; then

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -40,6 +40,10 @@ wait_dungeon_ready() {
 # BACKEND_URL is set by each test or defaults to port-forwarded backend.
 BACKEND_URL="${BACKEND_URL:-http://localhost:8089}"
 
+# Auth bypass header for integration tests.  The backend accepts X-Test-User when
+# KROMBAT_TEST_USER env var matches the header value (set to "test-player" in prod).
+TEST_USER_HEADER=(-H "X-Test-User: test-player")
+
 # Setup port-forward for backend if not already running on BACKEND_URL port
 # Call once per test group; stores PF_PID for cleanup
 INTEGRATION_PF_PID=""
@@ -73,7 +77,7 @@ submit_attack() {
   local prev_seq
   prev_seq=$(kctl get dungeon "$dname" -o jsonpath='{.spec.attackSeq}' 2>/dev/null || echo "0")
   curl -s -X POST "${BACKEND_URL}/api/v1/dungeons/default/${dname}/attacks" \
-    -H "Content-Type: application/json" \
+    -H "Content-Type: application/json" "${TEST_USER_HEADER[@]}" \
     -d "{\"target\":\"${target}\",\"damage\":${damage},\"seq\":${prev_seq}}" -o /dev/null
   # Wait for attackSeq to increment (backend wrote triggers)
   wait_for "${dname} attackSeq > ${prev_seq}" \
@@ -92,7 +96,7 @@ submit_action() {
   local prev_seq
   prev_seq=$(kctl get dungeon "$dname" -o jsonpath='{.spec.actionSeq}' 2>/dev/null || echo "0")
   curl -s -X POST "${BACKEND_URL}/api/v1/dungeons/default/${dname}/attacks" \
-    -H "Content-Type: application/json" \
+    -H "Content-Type: application/json" "${TEST_USER_HEADER[@]}" \
     -d "{\"target\":\"${action}\",\"damage\":0,\"seq\":${prev_seq}}" -o /dev/null
   # Wait for actionSeq > prevSeq (backend wrote triggers) AND lastAction == '' (kro finished)
   wait_for "${dname} action processed" \

--- a/tests/test-abilities.sh
+++ b/tests/test-abilities.sh
@@ -9,13 +9,13 @@ setup_backend_pf 8090
 
 log "Creating ability dungeons"
 curl -s -X POST "${BACKEND_URL}/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${TEST_USER_HEADER[@]}" \
   -d "{\"name\":\"test-heal-$TS\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"mage\"}" -o /dev/null
 curl -s -X POST "${BACKEND_URL}/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${TEST_USER_HEADER[@]}" \
   -d "{\"name\":\"test-taunt-$TS\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 curl -s -X POST "${BACKEND_URL}/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${TEST_USER_HEADER[@]}" \
   -d "{\"name\":\"test-backstab-$TS\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"rogue\"}" -o /dev/null
 
 wait_dungeon_ready "test-heal-$TS"

--- a/tests/test-core.sh
+++ b/tests/test-core.sh
@@ -10,7 +10,7 @@ setup_backend_pf 8089
 
 log "Create dungeon"
 curl -s -X POST "${BACKEND_URL}/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${TEST_USER_HEADER[@]}" \
   -d "{\"name\":\"${D}\",\"monsters\":2,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 
 wait_for "namespace" "kctl get ns $D" 60 && pass "Namespace created" || fail "Namespace"

--- a/tests/test-features.sh
+++ b/tests/test-features.sh
@@ -9,13 +9,13 @@ setup_backend_pf 8091
 
 log "Creating feature dungeons"
 curl -s -X POST "${BACKEND_URL}/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${TEST_USER_HEADER[@]}" \
   -d "{\"name\":\"test-mod-$TS\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 curl -s -X POST "${BACKEND_URL}/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${TEST_USER_HEADER[@]}" \
   -d "{\"name\":\"test-fx-$TS\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 curl -s -X POST "${BACKEND_URL}/api/v1/dungeons" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/json" "${TEST_USER_HEADER[@]}" \
   -d "{\"name\":\"test-loot-$TS\",\"monsters\":1,\"difficulty\":\"easy\",\"heroClass\":\"warrior\"}" -o /dev/null
 
 wait_dungeon_ready "test-mod-$TS"


### PR DESCRIPTION
## Summary

- Adds GitHub OAuth 2.0 SSO — users must log in before creating or entering dungeons
- Dungeons are stamped with `krombat.io/owner` label on creation; `ListDungeons` filters by owner; `GetDungeon`/`DeleteDungeon`/`CreateAttack` enforce ownership
- Auth middleware with HMAC-based session cookie (HTTP-only, Secure, SameSite=Lax), 24h TTL, in-memory session store
- Frontend shows login screen when unauthenticated; header shows `@login` + avatar when logged in; hamburger menu has Logout
- Integration test bypass: `KROMBAT_TEST_USER=test-player` env var + `X-Test-User` header allows all test suites to run without real OAuth credentials
- All test scripts updated to send `X-Test-User: test-player` header on API calls
- `optional: true` on the K8s secret means pods start without OAuth creds; login returns 503 until `krombat-github-oauth` secret is populated (see `manifests/system/github-oauth-secret.md`)

Closes #351