### PR TITLE
fix: force HTTP/1.1 on ALB backend — WebSocket upgrade fails over HTTP/2

### DIFF
--- a/manifests/system/ingress.yaml
+++ b/manifests/system/ingress.yaml
@@ -34,6 +34,10 @@ metadata:
     external-dns.alpha.kubernetes.io/hostname: "learn-kro.eks.aws.dev"
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/target-type: ip
+    # Force HTTP/1.1 on backend connections — required for WebSocket upgrade.
+    # HTTP/2 does not support the Upgrade header, so WS connections fail with 400
+    # when the ALB negotiates HTTP/2 with the backend.
+    alb.ingress.kubernetes.io/backend-protocol-version: HTTP1
 spec:
   ingressClassName: krombat
   rules:


### PR DESCRIPTION
## Problem

The ALB was negotiating HTTP/2 between itself and the backend pods. WebSocket requires the `Upgrade` header which HTTP/2 does not support — the ALB returned `400` on every WebSocket handshake (`/api/v1/events`), causing the frontend to permanently show `○ Reconnecting to server...` even though REST requests worked fine.

## Fix

Add `alb.ingress.kubernetes.io/backend-protocol-version: HTTP1` to the Ingress annotation. This forces the ALB to use HTTP/1.1 on the backend connection, allowing WebSocket upgrades to succeed.

The ALB still terminates TLS and presents HTTP/2 to clients — only the ALB→pod leg is forced to HTTP/1.1.