### PR TITLE
fix: implement http.Hijacker on responseWriter — WebSocket upgrade 500

### DIFF
--- a/backend/internal/handlers/middleware.go
+++ b/backend/internal/handlers/middleware.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"bufio"
 	"context"
 	"log/slog"
+	"net"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -31,6 +33,12 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 	n, err := rw.ResponseWriter.Write(b)
 	rw.bytes += n
 	return n, err
+}
+
+// Hijack implements http.Hijacker so that gorilla/websocket can take over the
+// underlying TCP connection for WebSocket upgrades.
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return rw.ResponseWriter.(http.Hijacker).Hijack()
 }
 
 // pathParamRe matches dynamic path segments (namespace names and dungeon names).


### PR DESCRIPTION
## Problem

The `AccessLog` middleware wraps `http.ResponseWriter` in a `responseWriter` struct that captures status and byte counts. That struct did not implement `http.Hijacker`.

gorilla/websocket calls `Hijack()` on the `ResponseWriter` to take over the TCP connection for the WebSocket upgrade. Since `responseWriter` didn't forward `Hijack()`, the upgrade failed with `websocket: response does not implement http.Hijacker` → `500 Internal Server Error` on every `/api/v1/events` request.

This caused the frontend to permanently show `○ Reconnecting to server...` even though all other endpoints worked fine.

## Fix

Add a `Hijack()` method to `responseWriter` that delegates to the underlying `http.ResponseWriter.(http.Hijacker)`. WebSocket upgrades now succeed.

Also adds `bufio` and `net` imports (required by the `http.Hijacker` interface signature).