### PR TITLE
fix: security P0 — remove hardcoded test-user bypass, fix WebSocket CSWSH (#406 #407)

### DIFF
--- a/backend/internal/ws/hub.go
+++ b/backend/internal/ws/hub.go
@@ -3,6 +3,8 @@ package ws
 import (
 	"log/slog"
 	"net/http"
+	"os"
+	"strings"
 	"sync"
 
 	"github.com/gorilla/websocket"
@@ -23,8 +25,33 @@ type Event struct {
 	Payload   interface{} `json:"payload,omitempty"`
 }
 
+// allowedOrigins returns the set of origins permitted for WebSocket upgrades.
+// Configured via ALLOWED_ORIGINS env var (comma-separated).  Defaults to the
+// prod ALB hostname so the pod starts safely without explicit configuration.
+func allowedOrigins() map[string]bool {
+	raw := os.Getenv("ALLOWED_ORIGINS")
+	if raw == "" {
+		raw = "https://learn-kro.eks.aws.dev"
+	}
+	m := make(map[string]bool)
+	for _, o := range strings.Split(raw, ",") {
+		o = strings.TrimSpace(o)
+		if o != "" {
+			m[o] = true
+		}
+	}
+	return m
+}
+
 var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
+	CheckOrigin: func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		// Allow requests with no Origin header (same-origin curl / health checks)
+		if origin == "" {
+			return true
+		}
+		return allowedOrigins()[origin]
+	},
 }
 
 type connFilter struct {

--- a/manifests/system/backend.yaml
+++ b/manifests/system/backend.yaml
@@ -29,12 +29,15 @@ spec:
           env:
             - name: GITHUB_CALLBACK_URL
               value: "https://learn-kro.eks.aws.dev/api/v1/auth/callback"
-            - name: KROMBAT_TEST_USER
-              value: "test-player"
+            - name: ALLOWED_ORIGINS
+              value: "https://learn-kro.eks.aws.dev"
           envFrom:
             - secretRef:
                 name: krombat-github-oauth
                 optional: true   # pod still starts without the secret; OAuth simply returns 503
+            - secretRef:
+                name: krombat-test-auth
+                optional: true   # pod still starts without the secret; test bypass disabled if absent
           readinessProbe:
             httpGet:
               path: /healthz

--- a/manifests/system/test-auth-secret.md
+++ b/manifests/system/test-auth-secret.md
@@ -1,0 +1,22 @@
+# krombat-test-auth Secret — NOT committed with real values.
+#
+# This Secret supplies KROMBAT_TEST_USER to the backend pod, enabling the
+# integration-test auth bypass.  The value must be a cryptographically random
+# hex string — NEVER a static value like "test-player".
+#
+# Create/rotate via the helper script (requires kubectl cluster access):
+#
+#   bash tests/create-test-secret.sh           # create
+#   bash tests/create-test-secret.sh --rotate  # rotate
+#
+# After rotating, restart the backend to pick up the new value:
+#
+#   kubectl --context arn:aws:eks:us-west-2:319279230668:cluster/krombat \
+#     rollout restart deployment/rpg-backend -n rpg-system
+#
+# Test scripts (helpers.sh, backend-api.sh, guardrails.sh) read this secret
+# at runtime via kubectl — the token value is never hardcoded in source files.
+#
+# This file is intentionally empty of real secrets.
+# Argo CD will NOT apply this file — it has no actual K8s resource.
+# The secret must be created out-of-band using the helper script above.

--- a/tests/backend-api.sh
+++ b/tests/backend-api.sh
@@ -13,7 +13,13 @@ FAIL=0
 TESTS=()
 
 # Auth bypass header — backend accepts X-Test-User when KROMBAT_TEST_USER env var matches.
-AUTH_H=(-H "X-Test-User: test-player")
+# Value is read from the krombat-test-auth K8s Secret (never committed to git).
+_TEST_USER="$(kubectl --context "$KUBECTL_CONTEXT" get secret krombat-test-auth \
+  -n rpg-system -o jsonpath='{.data.KROMBAT_TEST_USER}' 2>/dev/null | base64 -d 2>/dev/null || echo "")"
+if [ -z "$_TEST_USER" ]; then
+  echo "⚠️  krombat-test-auth secret not found — test bypass unavailable" >&2
+fi
+AUTH_H=(-H "X-Test-User: ${_TEST_USER}")
 
 log()  { echo "=== $1"; }
 pass() { echo "  ✅ $1"; PASS=$((PASS+1)); TESTS+=("PASS: $1"); }

--- a/tests/create-test-secret.sh
+++ b/tests/create-test-secret.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Creates (or rotates) the krombat-test-auth Kubernetes Secret used by test scripts
+# to authenticate against the backend API test bypass.
+#
+# The KROMBAT_TEST_USER value is a cryptographically random hex string — never
+# committed to git.  Only users with kubectl access to the cluster can read it.
+#
+# Run once before running any test suite:
+#   bash tests/create-test-secret.sh
+#
+# To rotate the token:
+#   bash tests/create-test-secret.sh --rotate
+set -euo pipefail
+
+KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-arn:aws:eks:us-west-2:319279230668:cluster/krombat}"
+kctl() { kubectl --context "$KUBECTL_CONTEXT" "$@"; }
+
+ROTATE="${1:-}"
+EXISTING=$(kctl get secret krombat-test-auth -n rpg-system --ignore-not-found 2>/dev/null || true)
+
+if [ -n "$EXISTING" ] && [ "$ROTATE" != "--rotate" ]; then
+  echo "krombat-test-auth already exists (pass --rotate to regenerate)"
+  exit 0
+fi
+
+TOKEN="$(openssl rand -hex 32)"
+
+kctl create secret generic krombat-test-auth \
+  --namespace rpg-system \
+  --from-literal=KROMBAT_TEST_USER="$TOKEN" \
+  --dry-run=client -o yaml | kctl apply -f -
+
+echo "krombat-test-auth secret created/updated with a random token."
+echo "Restart backend pods so the new value takes effect:"
+echo "  kubectl --context $KUBECTL_CONTEXT rollout restart deployment/rpg-backend -n rpg-system"

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -6,8 +6,14 @@ set -euo pipefail
 KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-arn:aws:eks:us-west-2:319279230668:cluster/krombat}"
 kctl() { kubectl --context "$KUBECTL_CONTEXT" "$@"; }
 
-# Auth bypass header — backend accepts X-Test-User when KROMBAT_TEST_USER env matches
-AUTH_H=(-H "X-Test-User: test-player")
+# Auth bypass header — backend accepts X-Test-User when KROMBAT_TEST_USER env matches.
+# Value is read from the krombat-test-auth K8s Secret (never committed to git).
+_TEST_USER="$(kubectl --context "$KUBECTL_CONTEXT" get secret krombat-test-auth \
+  -n rpg-system -o jsonpath='{.data.KROMBAT_TEST_USER}' 2>/dev/null | base64 -d 2>/dev/null || echo "")"
+if [ -z "$_TEST_USER" ]; then
+  echo "⚠️  krombat-test-auth secret not found — live API guardrail checks will skip auth" >&2
+fi
+AUTH_H=(-H "X-Test-User: ${_TEST_USER}")
 
 PASS=0
 FAIL=0

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -40,9 +40,19 @@ wait_dungeon_ready() {
 # BACKEND_URL is set by each test or defaults to port-forwarded backend.
 BACKEND_URL="${BACKEND_URL:-http://localhost:8089}"
 
-# Auth bypass header for integration tests.  The backend accepts X-Test-User when
-# KROMBAT_TEST_USER env var matches the header value (set to "test-player" in prod).
-TEST_USER_HEADER=(-H "X-Test-User: test-player")
+# Auth bypass header for integration tests.
+# The backend reads KROMBAT_TEST_USER from the krombat-test-auth K8s Secret.
+# Test scripts fetch the value at runtime so the token is never committed to git.
+_test_user_val() {
+  kubectl --context "$KUBECTL_CONTEXT" get secret krombat-test-auth \
+    -n rpg-system -o jsonpath='{.data.KROMBAT_TEST_USER}' 2>/dev/null \
+    | base64 -d 2>/dev/null || echo ""
+}
+_TEST_USER="${_TEST_USER:-$(_test_user_val)}"
+if [ -z "$_TEST_USER" ]; then
+  echo "⚠️  krombat-test-auth secret not found — test bypass unavailable (run tests/create-test-secret.sh)" >&2
+fi
+TEST_USER_HEADER=(-H "X-Test-User: ${_TEST_USER}")
 
 # Setup port-forward for backend if not already running on BACKEND_URL port
 # Call once per test group; stores PF_PID for cleanup


### PR DESCRIPTION
## Summary

- **#406** CRITICAL: removes hardcoded `KROMBAT_TEST_USER=test-player` from production Deployment manifest. Value is now a cryptographically random hex string stored in a K8s Secret (`krombat-test-auth`), never committed to git.
- **#407** CRITICAL: fixes WebSocket upgrader `CheckOrigin` that unconditionally returned `true`. Origin is now validated against an allowlist (configurable via `ALLOWED_ORIGINS` env var, defaults to `https://learn-kro.eks.aws.dev`).

## Changes

**`backend/internal/ws/hub.go`** — Replace `CheckOrigin: func(...) bool { return true }` with an origin allowlist read from `ALLOWED_ORIGINS` env var. Empty/absent Origin header (curl, health checks) is still allowed.

**`manifests/system/backend.yaml`** — Remove plaintext `KROMBAT_TEST_USER=test-player` env. Add `envFrom: secretRef: krombat-test-auth optional:true` so the backend reads the token from the secret. Add `ALLOWED_ORIGINS` env for WebSocket allowlist.

**`tests/helpers.sh` / `tests/backend-api.sh` / `tests/guardrails.sh`** — Read `KROMBAT_TEST_USER` at runtime from the `krombat-test-auth` K8s Secret via `kubectl get secret`. No static token in source files.

**`tests/create-test-secret.sh`** — Helper script to create/rotate the secret with `openssl rand -hex 32`. Run once before tests; pass `--rotate` to regenerate.

**`manifests/system/test-auth-secret.md`** — Instructions (matching the pattern of `github-oauth-secret.md`).

## Pre-deploy step

The `krombat-test-auth` secret has already been created on the cluster with a random token before this PR was opened.

Closes #406
Closes #407