### PR TITLE
fix: KROMBAT_TEST_USER must be ≤63 chars — K8s label limit crashes ListDungeons (#406)

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -14,6 +14,13 @@ import (
 func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
 
+	// Validate KROMBAT_TEST_USER early: Kubernetes label values must be ≤63 chars.
+	// The value is used as krombat.io/owner label — a 64-char value causes 500 on list.
+	if tv := os.Getenv("KROMBAT_TEST_USER"); len(tv) > 63 {
+		slog.Error("KROMBAT_TEST_USER exceeds 63 characters — Kubernetes label value limit; rotate the krombat-test-auth secret with: bash tests/create-test-secret.sh --rotate")
+		os.Exit(1)
+	}
+
 	client, err := k8s.NewClient()
 	if err != nil {
 		slog.Error("failed to create k8s client", "error", err)

--- a/tests/create-test-secret.sh
+++ b/tests/create-test-secret.sh
@@ -23,7 +23,7 @@ if [ -n "$EXISTING" ] && [ "$ROTATE" != "--rotate" ]; then
   exit 0
 fi
 
-TOKEN="$(openssl rand -hex 32)"
+TOKEN="$(openssl rand -hex 31)"  # 62 chars — Kubernetes label values must be ≤63 characters
 
 kctl create secret generic krombat-test-auth \
   --namespace rpg-system \


### PR DESCRIPTION
## Summary

Follow-up to #432: the random token generated by `tests/create-test-secret.sh` was 64 hex chars, exceeding the Kubernetes label value limit of 63 characters. The `KROMBAT_TEST_USER` is used as `krombat.io/owner` label, so a 64-char value caused a 500 on `GET /api/v1/dungeons`.

## Changes

- `tests/create-test-secret.sh` — use `openssl rand -hex 31` (62 chars) instead of 32 bytes
- `backend/cmd/main.go` — fail-fast at startup if `KROMBAT_TEST_USER` exceeds 63 chars with a clear error message

The secret on the cluster has already been rotated to a valid 62-char value.