### PR TITLE
fix: add test-login endpoint for browser-based e2e journey auth (#406)

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -51,6 +51,9 @@ func main() {
 	mux.HandleFunc("GET /api/v1/auth/callback", handlers.CallbackHandler)
 	mux.HandleFunc("GET /api/v1/auth/me", handlers.MeHandler)
 	mux.HandleFunc("GET /api/v1/auth/logout", handlers.LogoutHandler)
+	// Test-only login: issues a real session cookie when KROMBAT_TEST_USER is set.
+	// Returns 404 when the krombat-test-auth secret is absent (i.e. in environments without the secret).
+	mux.HandleFunc("GET /api/v1/auth/test-login", handlers.TestLoginHandler)
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
 	mux.Handle("GET /metrics", promhttp.Handler())
 

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -349,3 +349,42 @@ func LogoutHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"ok": "logged out"})
 }
+
+// TestLoginHandler issues a real signed session cookie when KROMBAT_TEST_USER is configured.
+// It accepts ?token=<value> as a query param so automated browser tests can
+// call page.goto('/api/v1/auth/test-login?token=...') to obtain a session without
+// going through the full GitHub OAuth flow.
+//
+// Returns 404 when KROMBAT_TEST_USER is not set (disabled in production without the secret).
+func TestLoginHandler(w http.ResponseWriter, r *http.Request) {
+	testUser := os.Getenv("KROMBAT_TEST_USER")
+	if testUser == "" {
+		http.NotFound(w, r)
+		return
+	}
+	token := r.URL.Query().Get("token")
+	if token == "" || token != testUser {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	payload := sessionPayload{
+		Login:     testUser,
+		AvatarURL: "",
+		ExpiresAt: time.Now().Add(sessionTTL).Unix(),
+	}
+	signed, err := signToken(payload)
+	if err != nil {
+		http.Error(w, "session create failed", http.StatusInternalServerError)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    signed,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   int(sessionTTL.Seconds()),
+	})
+	http.Redirect(w, r, "/", http.StatusFound)
+}

--- a/tests/e2e/journeys/01-warrior-easy.js
+++ b/tests/e2e/journeys/01-warrior-easy.js
@@ -1,6 +1,6 @@
 // Journey 1: Warrior Easy — Full UI Playthrough (UI-ONLY, no kubectl, no API)
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, dismissLootPopup, aliveMonsterCount, deadMonsterCount, getBodyText, waitForCombatResult } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, dismissLootPopup, aliveMonsterCount, deadMonsterCount, getBodyText, waitForCombatResult , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 15000;
@@ -34,6 +34,8 @@ async function run() {
   try {
     // === STEP 1: Create dungeon via UI ===
     console.log('=== Step 1: Create Dungeon ===');
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForTimeout(2000);
     const created = await createDungeonUI(page, dName, { monsters: 2, difficulty: 'easy', heroClass: 'warrior' });

--- a/tests/e2e/journeys/02-mage-normal.js
+++ b/tests/e2e/journeys/02-mage-normal.js
@@ -3,7 +3,7 @@
 // Tests: mage creation, initial state, mana consumption per attack, mana regen on kill,
 //        heal enable/disable logic, heal result, zero-mana half-damage, no-counter on heal
 const { chromium } = require('playwright');
-const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 15000;
@@ -65,6 +65,8 @@ async function run() {
   try {
     // === STEP 1: Create mage dungeon via UI ===
     console.log('=== Step 1: Create Mage Dungeon ===');
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForTimeout(2000);
     // 6 monsters, normal — 6×2=12 dmg/round counter-attacks will push HP below 80 in ~4 attacks

--- a/tests/e2e/journeys/03-rogue-hard.js
+++ b/tests/e2e/journeys/03-rogue-hard.js
@@ -4,7 +4,7 @@
 //        cooldown natural decrement over 3 turns, second backstab, dodge mechanic,
 //        hard difficulty dice/boss HP, no mana display
 const { chromium } = require('playwright');
-const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 15000;
@@ -81,6 +81,8 @@ async function run() {
   try {
     // === STEP 1: Create rogue hard dungeon via UI ===
     console.log('=== Step 1: Create Rogue Hard Dungeon ===');
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForTimeout(2000);
     // 5 monsters on hard: gives enough targets for CD decrement + dodge tests

--- a/tests/e2e/journeys/04-items-equipment.js
+++ b/tests/e2e/journeys/04-items-equipment.js
@@ -1,7 +1,7 @@
 // Journey 4: Items & Equipment — Full UI playthrough
 // UI-ONLY: no kubectl, no fetch/api, no execSync
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, dismissLootPopup, useBackpackItem, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, dismissLootPopup, useBackpackItem, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 15000;
@@ -72,6 +72,8 @@ async function run() {
   try {
     // === Setup: Create dungeon and farm loot by killing monsters ===
     console.log('=== Setup: Create Dungeon & Farm Loot ===');
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForTimeout(2000);
     // Use easy + many monsters to maximize loot drops (easy = 60% drop rate)

--- a/tests/e2e/journeys/05-status-effects.js
+++ b/tests/e2e/journeys/05-status-effects.js
@@ -3,7 +3,7 @@
 // Strategy: fight against boss (25% burn, 15% stun) and monsters (20% poison)
 // until effects are naturally inflicted, then verify badge display and tick behaviour.
 const { chromium } = require('playwright');
-const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 15000;
@@ -111,6 +111,8 @@ async function run() {
     // With 6 monsters we expect ~1.2 poison procs before they're all dead.
     // We keep attacking until we observe each effect (warn if not seen within budget).
     console.log('=== Setup: Create Warrior Easy Dungeon ===');
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForTimeout(2000);
     const created = await createDungeonUI(page, dName, { monsters: 6, difficulty: 'easy', heroClass: 'warrior' });

--- a/tests/e2e/journeys/06-dungeon-modifiers.js
+++ b/tests/e2e/journeys/06-dungeon-modifiers.js
@@ -4,7 +4,7 @@
 // We create dungeons and test whatever modifier is assigned — badge type,
 // combat text, and modifier info panel. Two dungeons improve coverage.
 const { chromium } = require('playwright');
-const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 15000;
@@ -81,6 +81,8 @@ async function run() {
   page.on('dialog', dialog => dialog.accept());
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForTimeout(2000);
 

--- a/tests/e2e/journeys/07-dungeon-management.js
+++ b/tests/e2e/journeys/07-dungeon-management.js
@@ -1,7 +1,7 @@
 // Journey 7: Dungeon Management — create, list, navigate, delete
 // UI-ONLY: no kubectl, no fetch/api, no execSync
 const { chromium } = require('playwright');
-const { createDungeonUI, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 15000;
@@ -20,6 +20,8 @@ async function run() {
     // === Create 3 dungeons via UI ===
     console.log('=== Create Dungeons ===');
     for (const name of names) {
+      await testLogin(page, BASE_URL);
+
       await page.goto(BASE_URL, { timeout: TIMEOUT });
       await page.waitForTimeout(2000);
       const created = await createDungeonUI(page, name, { monsters: 1, difficulty: 'easy', heroClass: 'warrior' });

--- a/tests/e2e/journeys/08-edge-cases.js
+++ b/tests/e2e/journeys/08-edge-cases.js
@@ -1,7 +1,7 @@
 // Journey 8: Edge Cases & Error States
 // UI-ONLY: no kubectl, no fetch/api, no execSync
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 15000;
@@ -51,6 +51,8 @@ async function run() {
     // === Test 1: Speed run — 1 monster easy, play to victory ===
     console.log('=== Test 1: Speed Run (1 monster, easy) ===');
     const speedName = `j8sp${ts}`;
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForTimeout(2000);
     await createDungeonUI(page, speedName, { monsters: 1, difficulty: 'easy', heroClass: 'warrior' });

--- a/tests/e2e/journeys/09-k8s-logs.js
+++ b/tests/e2e/journeys/09-k8s-logs.js
@@ -4,7 +4,7 @@
 // Each dungeon creation, attack, and item action should append a log entry
 // showing the simulated `kubectl` command + result.
 const { chromium } = require('playwright');
-const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 15000;
@@ -64,6 +64,8 @@ async function run() {
   page.on('dialog', dialog => dialog.accept());
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForTimeout(2000);
 

--- a/tests/e2e/journeys/10-animations.js
+++ b/tests/e2e/journeys/10-animations.js
@@ -4,7 +4,7 @@
 //        combat modal sprites, hero sprite, post-dismiss state.
 // Room 2 sprite check is omitted — playing all the way through would take ~15 min.
 const { chromium } = require('playwright');
-const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon, attackMonster } = require('./helpers');
+const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon, attackMonster , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 15000;
@@ -49,6 +49,8 @@ async function run() {
   try {
     // === Setup: Create dungeon with 2 monsters ===
     console.log('=== Setup: Create Dungeon ===');
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForTimeout(2000);
     // Easy warrior: 200 hero HP, avg 12.5 damage/attack.

--- a/tests/e2e/journeys/11-room2-victory.js
+++ b/tests/e2e/journeys/11-room2-victory.js
@@ -6,7 +6,7 @@ const {
   createDungeonUI, attackMonster, attackBoss, waitForCombatResult,
   dismissLootPopup, aliveMonsterCount, deadMonsterCount,
   getBodyText, navigateHome, deleteDungeon,
-} = require('./helpers');
+, testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 15000;
@@ -41,6 +41,8 @@ async function run() {
     // === STEP 1: Create dungeon ===
     // 1 monster, easy — minimises RNG variance so the hero reliably survives two rooms.
     console.log('=== Step 1: Create Dungeon ===');
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForTimeout(2000);
     const created = await createDungeonUI(page, dName, { monsters: 1, difficulty: 'easy', heroClass: 'warrior' });

--- a/tests/e2e/journeys/12-kro-teaching.js
+++ b/tests/e2e/journeys/12-kro-teaching.js
@@ -3,7 +3,7 @@
 // Tests: InsightCards, kro glossary tab, annotated K8s log, resource graph panel,
 //        status bar kro tooltips, CelTrace in combat modal.
 const { chromium } = require('playwright');
-const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -30,6 +30,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/13-defeat-and-mana.js
+++ b/tests/e2e/journeys/13-defeat-and-mana.js
@@ -7,7 +7,7 @@
 //   - Heal ability spends mana
 'use strict';
 const { chromium } = require('playwright');
-const { createDungeonUI, waitForCombatResult, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, waitForCombatResult, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -23,6 +23,8 @@ async function run() {
   // ── PART 1: Defeat banner CSS classes are defined ─────────────────────────
   console.log('=== Part 1: Defeat banner CSS class verification ===');
   const dNameD = `j13d-${Date.now()}`;
+  await testLogin(page, BASE_URL);
+
   await page.goto(BASE_URL, { timeout: TIMEOUT });
   await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/14-kro-inspector.js
+++ b/tests/e2e/journeys/14-kro-inspector.js
@@ -3,7 +3,7 @@
 // Tests: KroGraph node click → Inspector panel; kubectl command; YAML content;
 //        close button; switching between nodes updates inspector.
 const { chromium } = require('playwright');
-const { createDungeonUI, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -47,6 +47,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/15-ownerref-and-glossary.js
+++ b/tests/e2e/journeys/15-ownerref-and-glossary.js
@@ -6,7 +6,7 @@
 //   3. Search bar filters concepts, clear button restores all, empty state for nonsense query
 //   4. Glossary header shows total of /23 concepts
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 30000;
@@ -36,6 +36,8 @@ async function run() {
 
   try {
     // Ensure onboarding is already done so it doesn't block the test
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.evaluate(() => localStorage.setItem('kroOnboardingDone', '1'));
     await page.reload({ waitUntil: 'networkidle', timeout: TIMEOUT });

--- a/tests/e2e/journeys/16-ring-amulet-loot.js
+++ b/tests/e2e/journeys/16-ring-amulet-loot.js
@@ -9,7 +9,7 @@
 //   5. Optionally verify combat still works after equipping passives.
 
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 15000;
@@ -131,6 +131,8 @@ async function run() {
   try {
     // === Setup ===
     console.log('=== Setup: Create Easy Warrior Dungeon (1 monster) ===');
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForTimeout(2000);
     const created = await createDungeonUI(page, dName, { monsters: 1, difficulty: 'easy', heroClass: 'warrior' });

--- a/tests/e2e/journeys/17-cel-playground.js
+++ b/tests/e2e/journeys/17-cel-playground.js
@@ -4,7 +4,7 @@
 //        error expressions show error; history is populated; examples load into editor;
 //        close button works; 'Learn concept' button works.
 const { chromium } = require('playwright');
-const { createDungeonUI, deleteDungeon } = require('./helpers');
+const { createDungeonUI, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -31,6 +31,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/18-achievements.js
+++ b/tests/e2e/journeys/18-achievements.js
@@ -3,7 +3,7 @@
 // Tests: Achievement badges structure, absence during active game, correct aria-labels,
 //        badge count = 8, earned badges have title attr with desc text.
 const { chromium } = require('playwright');
-const { createDungeonUI, deleteDungeon } = require('./helpers');
+const { createDungeonUI, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -22,6 +22,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/19-enemy-variety.js
+++ b/tests/e2e/journeys/19-enemy-variety.js
@@ -4,7 +4,7 @@
 //        combat works against named monsters; stun/shaman-heal are RNG-based so we warn
 //        if not triggered by chance; Room 2 shows Troll/Ghoul display names.
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -23,6 +23,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/20-leaderboard.js
+++ b/tests/e2e/journeys/20-leaderboard.js
@@ -3,7 +3,7 @@
 // Tests: Leaderboard button visible on dungeon list; panel opens; shows correct columns;
 //        after deleting a dungeon, its record appears in the leaderboard.
 const { chromium } = require('playwright');
-const { createDungeonUI, deleteDungeon } = require('./helpers');
+const { createDungeonUI, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -35,6 +35,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/21-new-game-plus.js
+++ b/tests/e2e/journeys/21-new-game-plus.js
@@ -9,7 +9,7 @@
 // very RNG-dependent in CI. This journey tests the UI wiring via a quick path:
 // we verify the button/badge exist and the feature is wired, using warns for RNG-dependent paths.
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -29,6 +29,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/22-minimap.js
+++ b/tests/e2e/journeys/22-minimap.js
@@ -4,7 +4,7 @@
 //        states (R1 current → boss-active → cleared), connector updates, treasure
 //        icon appears when treasure available.
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -23,6 +23,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/23-taunt-and-boss-phases.js
+++ b/tests/e2e/journeys/23-taunt-and-boss-phases.js
@@ -5,7 +5,7 @@
 //        boss phase transitions (ENRAGED at 50% HP, BERSERK at 25% HP),
 //        phase badges and flash overlay visible.
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -24,6 +24,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/24-potions-inventory-cap-helmet-pants.js
+++ b/tests/e2e/journeys/24-potions-inventory-cap-helmet-pants.js
@@ -4,7 +4,7 @@
 //        inventory cap shows N/8 badge, FULL at 8; helmet equip shows crit %;
 //        pants equip shows dodge %; backpack tooltips present.
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -23,6 +23,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/25-mage-room2-mana-restore-room2-scaling.js
+++ b/tests/e2e/journeys/25-mage-room2-mana-restore-room2-scaling.js
@@ -5,7 +5,7 @@
 //        Room 2 monster HP > Room 1 monster HP (1.5x scaling);
 //        Room 2 boss HP > Room 1 boss HP (1.3x scaling).
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -24,6 +24,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/26-kro-certificate-and-mid-game-insights.js
+++ b/tests/e2e/journeys/26-kro-certificate-and-mid-game-insights.js
@@ -4,7 +4,7 @@
 //        boss-ready (cel-ternary), boss-killed (cel-filter); kro Expert Certificate
 //        appears on Room 2 victory; certificate has concept grid and kubectl copy button.
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -23,6 +23,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/27-regression-loot-drop-item-clear-boss-name.js
+++ b/tests/e2e/journeys/27-regression-loot-drop-item-clear-boss-name.js
@@ -12,7 +12,7 @@
 // 3. Stale Room 1 attack guard — inRoomTransition logic prevents spurious victory
 //    from stale Room 1 attack results in Room 2.
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -33,6 +33,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/28-resume-prompt-validation-room1-cleared-last-played.js
+++ b/tests/e2e/journeys/28-resume-prompt-validation-room1-cleared-last-played.js
@@ -5,7 +5,7 @@
 //        Room 1 CLEARED! overlay appears for 3s after boss kill in Room 1;
 //        LAST PLAYED badge on most recently visited dungeon tile.
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -24,6 +24,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/29-ring-regen-amulet-combat.js
+++ b/tests/e2e/journeys/29-ring-regen-amulet-combat.js
@@ -7,7 +7,7 @@
 // 3. Both effects stack correctly with class bonuses
 // Uses cheat modal to equip ring/amulet, then real combat for verification.
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -43,6 +43,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/30-room2-boss-phases.js
+++ b/tests/e2e/journeys/30-room2-boss-phases.js
@@ -6,7 +6,7 @@
 // Room 1 dragon boss (handlers.go lines 944–950) but for the second dungeon.
 // Also verifies that Room 2 entities (Troll/Ghoul names) appear correctly.
 const { chromium } = require('playwright');
-const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon } = require('./helpers');
+const { createDungeonUI, attackMonster, attackBoss, waitForCombatResult, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -25,6 +25,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/31-kro-inspector-combat-modifier-cm.js
+++ b/tests/e2e/journeys/31-kro-inspector-combat-modifier-cm.js
@@ -13,7 +13,7 @@
 // persistent K8s resource — the Inspector skips them by design. gameConfig is
 // the closest real ConfigMap that shows kro CEL output for every dungeon.
 const { chromium } = require('playwright');
-const { createDungeonUI, navigateHome, deleteDungeon } = require('./helpers');
+const { createDungeonUI, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -92,6 +92,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/32-cel-playground-live-eval.js
+++ b/tests/e2e/journeys/32-cel-playground-live-eval.js
@@ -13,7 +13,7 @@
 // The frontend sends this request when the user clicks "Run" in the
 // CEL Playground modal. We verify the whole round-trip through the browser.
 const { chromium } = require('playwright');
-const { createDungeonUI, deleteDungeon } = require('./helpers');
+const { createDungeonUI, deleteDungeon , testLogin} = require('./helpers');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 20000;
@@ -78,6 +78,8 @@ async function run() {
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
 
   try {
+    await testLogin(page, BASE_URL);
+
     await page.goto(BASE_URL, { timeout: TIMEOUT });
     await page.waitForSelector('input[placeholder="my-dungeon"]', { timeout: TIMEOUT });
 

--- a/tests/e2e/journeys/helpers.js
+++ b/tests/e2e/journeys/helpers.js
@@ -190,8 +190,34 @@ async function deleteDungeon(page, name) {
   return true;
 }
 
+// testLogin — navigates to the backend test-login endpoint to obtain a session
+// cookie without going through the full GitHub OAuth flow.
+// Requires KROMBAT_TEST_TOKEN env var (read from cluster secret by run-journeys.js).
+// If the endpoint returns 404 (no KROMBAT_TEST_USER configured) the test will
+// fail naturally when the login screen blocks the dungeon creation input.
+async function testLogin(page, baseUrl) {
+  const token = process.env.KROMBAT_TEST_TOKEN || '';
+  if (!token) {
+    // No token available — skip; test will fail if login screen is shown
+    return;
+  }
+  const loginUrl = `${baseUrl}/api/v1/auth/test-login?token=${encodeURIComponent(token)}`;
+  await page.goto(loginUrl, { timeout: 15000 });
+  // The endpoint redirects to '/' — wait for the main app to load
+  await page.waitForTimeout(1000);
+}
+
+// gotoApp — convenience wrapper: performs test-login first, then navigates to
+// the given URL (defaults to BASE_URL).  Replaces direct page.goto(BASE_URL)
+// in journey tests so auth is handled transparently.
+async function gotoApp(page, url) {
+  await testLogin(page, url.replace(/\/[^/]*$/, '') || url); // extract origin
+  await page.goto(url, { timeout: 15000 });
+  await page.waitForTimeout(500);
+}
+
 module.exports = {
   createDungeonUI, attackMonster, attackBoss, useAbility, useBackpackItem,
   waitForCombatResult, dismissLootPopup, aliveMonsterCount, deadMonsterCount,
-  getBodyText, navigateHome, deleteDungeon
+  getBodyText, navigateHome, deleteDungeon, testLogin, gotoApp
 };

--- a/tests/e2e/run-journeys.js
+++ b/tests/e2e/run-journeys.js
@@ -3,9 +3,30 @@
 // Runs all journey test files concurrently and reports aggregated results.
 // Usage: node tests/e2e/run-journeys.js [--filter 01,07]
 
-const { spawn } = require('child_process');
+const { spawn, execSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const FILTER = process.env.FILTER || (process.argv[2] ? process.argv[2].replace('--filter=', '') : null);
+
+// Read KROMBAT_TEST_TOKEN from cluster secret if not already set in env.
+// Allows journey tests to authenticate via the test-login bypass endpoint.
+let KROMBAT_TEST_TOKEN = process.env.KROMBAT_TEST_TOKEN || '';
+if (!KROMBAT_TEST_TOKEN) {
+  try {
+    const ctx = process.env.KUBECTL_CONTEXT || 'arn:aws:eks:us-west-2:319279230668:cluster/krombat';
+    const raw = execSync(
+      `kubectl --context "${ctx}" get secret krombat-test-auth -n rpg-system -o jsonpath='{.data.KROMBAT_TEST_USER}'`,
+      { stdio: ['ignore', 'pipe', 'ignore'] }
+    ).toString().trim();
+    if (raw) {
+      KROMBAT_TEST_TOKEN = Buffer.from(raw, 'base64').toString('utf8').trim();
+    }
+  } catch (_) {
+    // Secret not available — test bypass will be skipped; tests may fail if login screen is shown
+  }
+}
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const FILTER = process.env.FILTER || (process.argv[2] ? process.argv[2].replace('--filter=', '') : null);
@@ -37,7 +58,7 @@ const runs = files.map(file => {
 
   return new Promise(resolve => {
     const proc = spawn(process.execPath, [fullPath], {
-      env: { ...process.env, BASE_URL },
+      env: { ...process.env, BASE_URL, KROMBAT_TEST_TOKEN },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 

--- a/tests/e2e/smoke-test.js
+++ b/tests/e2e/smoke-test.js
@@ -1,7 +1,28 @@
 const { chromium } = require('playwright');
+const { execSync } = require('child_process');
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const TIMEOUT = 15000;
+
+// Read KROMBAT_TEST_TOKEN for the test-login bypass
+let KROMBAT_TEST_TOKEN = process.env.KROMBAT_TEST_TOKEN || '';
+if (!KROMBAT_TEST_TOKEN) {
+  try {
+    const ctx = process.env.KUBECTL_CONTEXT || 'arn:aws:eks:us-west-2:319279230668:cluster/krombat';
+    const raw = execSync(
+      `kubectl --context "${ctx}" get secret krombat-test-auth -n rpg-system -o jsonpath='{.data.KROMBAT_TEST_USER}'`,
+      { stdio: ['ignore', 'pipe', 'ignore'] }
+    ).toString().trim();
+    if (raw) KROMBAT_TEST_TOKEN = Buffer.from(raw, 'base64').toString('utf8').trim();
+  } catch (_) {}
+}
+
+async function testLogin(page) {
+  if (!KROMBAT_TEST_TOKEN) return;
+  const loginUrl = `${BASE_URL}/api/v1/auth/test-login?token=${encodeURIComponent(KROMBAT_TEST_TOKEN)}`;
+  await page.goto(loginUrl, { timeout: TIMEOUT });
+  await page.waitForTimeout(500);
+}
 
 let passed = 0;
 let failed = 0;
@@ -19,6 +40,9 @@ async function runTests() {
   });
 
   try {
+    // Authenticate via test bypass before any UI interaction
+    await testLogin(page);
+
     // === SECTION 1: Page Load ===
     console.log('=== Page Load ===');
     await page.goto(BASE_URL, { timeout: TIMEOUT });


### PR DESCRIPTION
## Summary

After #432 added GitHub SSO, e2e journey tests couldn't authenticate because they can't perform the GitHub OAuth flow in headless Playwright. This PR adds a secure test-login endpoint that issues a real session cookie using the test bypass token.

## Changes

**`backend/internal/handlers/auth.go`** — `TestLoginHandler`: accepts `?token=<KROMBAT_TEST_USER>` query param, issues a real signed session cookie, redirects to `/`. Returns 404 when `KROMBAT_TEST_USER` is not set.

**`backend/cmd/main.go`** — register `GET /api/v1/auth/test-login` route.

**`tests/e2e/journeys/helpers.js`** — `testLogin(page, baseUrl)`: navigates to the test-login endpoint before any UI interaction. `gotoApp` convenience wrapper.

**`tests/e2e/run-journeys.js`** — reads `KROMBAT_TEST_TOKEN` from cluster secret and passes it to child processes.

**`tests/e2e/smoke-test.js`** — adds `testLogin()` before first page.goto.

**`tests/e2e/journeys/01-32-*.js`** — all 32 journey files updated to call `await testLogin(page, BASE_URL)` before first `page.goto`.