### PR TITLE
fix: boss phase damage multipliers 1.3x/1.6x — read from kro bossDamageMultiplier (#398)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -1054,9 +1054,12 @@ func (h *Handler) processCombat(ctx context.Context, r *http.Request, ns, name, 
 	// Step 5: Derive log text from pre→post spec diff (no math — kro is authoritative).
 	diceFormula := getString(postStatus, "diceFormula", getString(dungeonStatus, "diceFormula", ""))
 	bossPhaseStr := getString(postStatus, "bossPhase", getString(dungeonStatus, "bossPhase", "phase1"))
+	// bossDamageMultiplier is stored ×10 as a string in dungeon status (from boss-graph CEL).
+	// e.g. '10'=1.0×, '13'=1.3×, '16'=1.6×. Default '10' when not yet set.
+	bossDmgMultStr := getString(postStatus, "bossDamageMultiplier", getString(dungeonStatus, "bossDamageMultiplier", "10"))
 	heroAction, enemyAction := deriveCombatLog(
 		spec, postSpec, realTarget, isBossTarget, idxInt, isBackstab, stunTurns > 0,
-		heroClass, diceFormula, bossPhaseStr,
+		heroClass, diceFormula, bossPhaseStr, bossDmgMultStr,
 	)
 
 	// Step 6: Write log text and return final dungeon state.
@@ -1098,7 +1101,7 @@ func deriveCombatLog(
 	pre, post map[string]interface{},
 	realTarget string, isBossTarget bool, idxInt int,
 	isBackstab bool, wasStunned bool,
-	heroClass, diceFormula, bossPhaseStr string,
+	heroClass, diceFormula, bossPhaseStr, bossDmgMultStr string,
 ) (heroAction, enemyAction string) {
 	preHeroHP := getInt(pre, "heroHP")
 	postHeroHP := getInt(post, "heroHP")
@@ -1244,10 +1247,18 @@ func deriveCombatLog(
 	}
 
 	phaseNote := ""
-	if bossPhaseStr == "phase2" {
-		phaseNote = " [ENRAGED ×1.5]"
-	} else if bossPhaseStr == "phase3" {
-		phaseNote = " [BERSERK ×2.0]"
+	if bossPhaseStr == "phase2" || bossPhaseStr == "phase3" {
+		// bossDmgMultStr is stored ×10 (e.g. '13' = 1.3×, '16' = 1.6×). Convert for display.
+		multInt, _ := strconv.ParseInt(bossDmgMultStr, 10, 64)
+		if multInt > 10 {
+			whole := multInt / 10
+			frac := multInt % 10
+			label := "ENRAGED"
+			if bossPhaseStr == "phase3" {
+				label = "BERSERK"
+			}
+			phaseNote = fmt.Sprintf(" [%s ×%d.%d]", label, whole, frac)
+		}
 	}
 
 	allEffects := append(healNotes, effectNotes...)

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -1174,9 +1174,9 @@ export function CelTrace({ data, onLearnMore }: { data: CelTraceData; onLearnMor
   if ((data.bossHP ?? 0) > 0 && (data.maxBossHP ?? 0) > 0) {
     const pct = Math.round(((data.bossHP!) / (data.maxBossHP!)) * 100)
     // #446: actual boss-graph uses integer arithmetic (×100 / maxHP), outputs 'phase1'/'phase2'/'phase3'
-    // damageMultiplier stored as integer ×10: phase1=10 (1.0×), phase2=15 (1.5×), phase3=20 (2.0×)
+    // damageMultiplier stored as integer ×10: phase1=10 (1.0×), phase2=13 (1.3×), phase3=16 (1.6×)
     const phase = pct <= 25 ? 'phase3' : pct <= 50 ? 'phase2' : 'phase1'
-    const phaseResult = phase === 'phase3' ? '"phase3" (2.0× dmg)' : phase === 'phase2' ? '"phase2" (1.5× dmg)' : '"phase1" (1.0× dmg)'
+    const phaseResult = phase === 'phase3' ? '"phase3" (1.6× dmg)' : phase === 'phase2' ? '"phase2" (1.3× dmg)' : '"phase1" (1.0× dmg)'
     celLines.push({
       expr: `hp * 100 / maxHP > 50 ? 'phase1' : hp * 100 / maxHP > 25 ? 'phase2' : 'phase3'`,
       result: phaseResult,

--- a/manifests/rgds/boss-graph.yaml
+++ b/manifests/rgds/boss-graph.yaml
@@ -56,13 +56,13 @@ spec:
               schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 25 ? 'phase2' :
               'phase3'
             }
-          # Damage multiplier per phase: 1.0x / 1.5x / 2.0x (stored as integer *10)
+          # Damage multiplier per phase: 1.0x / 1.3x / 1.6x (stored as integer *10)
           damageMultiplier: >-
             ${
               schema.spec.hp <= 0 ? '10' :
               schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 50 ? '10' :
-              schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 25 ? '15' :
-              '20'
+              schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 25 ? '13' :
+              '16'
             }
           # Special attack chance per phase: 20% / 40% / 60%
           specialAttackChance: >-

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -659,6 +659,14 @@ grep -q "'kro Creates 7 Resources\|two ConfigMaps\|id: combatResult" frontend/sr
 grep -q "kubectl patch dungeon\|backend runs a kubectl patch\|'Every Action is a kubectl" frontend/src/KroTeach.tsx && fail "#451: intro modal still says 'backend runs kubectl patch'" || pass "#451: intro modal kubectl patch reference removed"
 grep -q "15 core kro concepts\|and 9 more" frontend/src/KroTeach.tsx && fail "#451: intro modal still says '15 concepts' or '9 more'" || pass "#451: intro modal concept count updated to 23"
 
+# --- Backend audit cleanup guardrails ---
+echo "=== Backend audit cleanup guardrails"
+
+# #398: boss phase multipliers must not be hardcoded ×1.5/×2.0 in combat log
+grep -q 'ENRAGED ×1\.5\|BERSERK ×2\.0\|phaseNote.*1\.5\|phaseNote.*2\.0' backend/internal/handlers/handlers.go && fail "#398: hardcoded boss phase multipliers 1.5/2.0 still in deriveCombatLog" || pass "#398: boss phase multipliers read from kro bossDamageMultiplier"
+# boss-graph damageMultiplier must use 13/16 (not 15/20) — check only the damageMultiplier CEL block
+grep -A6 "damageMultiplier:" manifests/rgds/boss-graph.yaml | grep -q "'15'\|'20'" && fail "#398: boss-graph damageMultiplier still uses 15/20 (should be 13/16)" || pass "#398: boss-graph damageMultiplier uses correct 13/16"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

- **boss-graph.yaml**: Change `damageMultiplier` CEL from `'15'`/`'20'` to `'13'`/`'16'` (phase2=1.3×, phase3=1.6×)
- **handlers.go**: `deriveCombatLog` now reads `bossDamageMultiplier` from `postStatus` (written by dungeon-graph from boss-graph CEL) and formats `[ENRAGED ×1.3]`/`[BERSERK ×1.6]` dynamically — no more hardcoded strings
- **KroTeach.tsx**: Update CelTrace boss phase display to show correct 1.3×/1.6× labels
- **guardrails.sh**: Add #398 checks — no hardcoded 1.5/2.0 in backend, boss-graph uses 13/16

## RGD Note

`boss-graph` schema changed. After merge, run:
```
kubectl --context arn:aws:eks:us-west-2:319279230668:cluster/krombat delete rgd boss-graph
```
Argo CD will recreate it within ~6s.

Closes #398