### PR TITLE
fix: T2 teaching audit — lootInfo CM nodes, graph edges, spec-patch concept, CEL playground, boss phase table (#437,#439,#440,#444,#449,#450,#452,#453)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -2538,6 +2538,29 @@ func (h *Handler) GetDungeonResource(w http.ResponseWriter, r *http.Request) {
 		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-treasure-state"}
 	case "treasuresecret":
 		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "secrets"}, name + "-treasure-secret"}
+	// #437: Loot CR and its loot-graph children (lootInfo CM + lootSecret Secret)
+	case "loot":
+		if index == "" {
+			index = "0"
+		}
+		def = &resourceDef{schema.GroupVersionResource{Group: grp, Version: ver, Resource: "loots"}, name + "-monster-" + index + "-loot"}
+	case "lootinfo":
+		if index == "" {
+			index = "0"
+		}
+		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-monster-" + index + "-loot-info"}
+	case "lootsecret":
+		if index == "" {
+			index = "0"
+		}
+		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "secrets"}, name + "-monster-" + index + "-loot"}
+	// #437: Boss loot CR and its loot-graph children
+	case "bossloot":
+		def = &resourceDef{schema.GroupVersionResource{Group: grp, Version: ver, Resource: "loots"}, name + "-boss-loot"}
+	case "bosslootinfo":
+		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "configmaps"}, name + "-boss-loot-info"}
+	case "bosslootsecret":
+		def = &resourceDef{schema.GroupVersionResource{Group: coreGrp, Version: coreVer, Resource: "secrets"}, name + "-boss-loot"}
 	default:
 		writeError(w, "unknown kind: "+kind, http.StatusBadRequest)
 		return

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -370,7 +370,17 @@ export default function App() {
         setAttackTarget(null)
         attackingRef.current = false
         // Teach specific item/room events
-        if (target === 'enter-room-2') triggerInsight('enter-room-2')
+        if (target === 'enter-room-2') {
+          triggerInsight('enter-room-2')
+          // #444: K8s log entry for room transition — enterRoom2Resolve specPatch fired
+          const newMonHP = updated.spec.room2MonsterHP?.join(',') ?? '...'
+          const newBossHP = updated.spec.room2BossHP ?? '...'
+          addK8s(
+            `kubectl patch dungeon ${selected.name} --type=merge -p '{"spec":{"currentRoom":2}}'`,
+            `enterRoom2Resolve specPatch fired — monsterHP: [${newMonHP}], bossHP: ${newBossHP}`,
+            `# dungeon-graph.yaml — enterRoom2Resolve specPatch\ntype: specPatch\npatch:\n  currentRoom: "2"\n  monsterHP: "<scaled ×1.5 via CEL>"\n  bossHP: "<scaled ×1.3 via CEL>"`
+          )
+        }
         if (target === 'open-treasure') triggerInsight('treasure-opened')
         if (target.startsWith('equip-boots')) triggerInsight('boots-equipped')
         return // Items done — don't fall through to combat/loot logic
@@ -481,14 +491,26 @@ export default function App() {
         const prevPct = newMaxBossHP > 0 ? (prevBossHP / newMaxBossHP) * 100 : 100
         const newPct = newMaxBossHP > 0 ? (newBossHP / newMaxBossHP) * 100 : 100
         if (prevPct > 50 && newPct <= 50 && newBossHP > 0) {
-          addEvent('fire', 'The boss becomes ENRAGED! (Phase 2: x1.5 damage)')
+          addEvent('fire', 'The boss becomes ENRAGED! (Phase 2: ×1.3 damage)')
           setBossPhaseFlash('enraged')
           setTimeout(() => setBossPhaseFlash(null), 1500)
+          // #444: K8s log entry for boss phase change — boss-graph CEL fired
+          addK8s(
+            `kubectl get cm ${selected?.name ?? '...'}-boss -n ${selected?.ns ?? '...'}`,
+            `bossPhase: phase2, damageMultiplier: 13 (1.3×)`,
+            `# boss-graph.yaml — damageMultiplier specPatch (phase2)\nphase: "\${hp * 100 / maxHP > 50 ? 'phase1' : hp * 100 / maxHP > 25 ? 'phase2' : 'phase3'}"\ndamageMultiplier: "\${... > 50 ? '10' : ... > 25 ? '13' : '16'}"  # ×10 integer`
+          )
         }
         if (prevPct > 25 && newPct <= 25 && newBossHP > 0) {
-          addEvent('skull', 'BERSERK MODE! Boss attacks with fury! (Phase 3: x2.0 damage)')
+          addEvent('skull', 'BERSERK MODE! Boss attacks with fury! (Phase 3: ×1.6 damage)')
           setBossPhaseFlash('berserk')
           setTimeout(() => setBossPhaseFlash(null), 1500)
+          // #444: K8s log entry for boss phase change — boss-graph CEL fired
+          addK8s(
+            `kubectl get cm ${selected?.name ?? '...'}-boss -n ${selected?.ns ?? '...'}`,
+            `bossPhase: phase3, damageMultiplier: 16 (1.6×)`,
+            `# boss-graph.yaml — damageMultiplier specPatch (phase3)\nphase: "\${hp * 100 / maxHP > 50 ? 'phase1' : hp * 100 / maxHP > 25 ? 'phase2' : 'phase3'}"\ndamageMultiplier: "\${... > 50 ? '10' : ... > 25 ? '13' : '16'}"  # ×10 integer`
+          )
         }
         if ((updated.spec.heroHP ?? 100) <= 0 && (detail?.spec.heroHP ?? 100) > 0) addEvent('skull', 'Hero has fallen...')
         // DoT floating damage on hero
@@ -504,6 +526,8 @@ export default function App() {
             const color = poisonActive ? '#2ecc71' : '#e74c3c'
             setFloatingDmg({ target: 'hero', amount: `-${dotDmg}`, color })
             setTimeout(() => setFloatingDmg(null), 1200)
+            // #450: fire spec-patch insight on first DoT tick — best teaching moment
+            triggerInsight('dot-applied')
           }
         }
         // Detect monster kill
@@ -553,6 +577,16 @@ export default function App() {
       setLootDrop(pendingLootRef.current)
       triggerInsight('loot-drop')
       setTimeout(() => triggerInsight('loot-drop-string-ops'), 4000)
+      // #444: K8s log entry for loot drop — includeWhen: hp==0 creates Loot CR
+      const lootStr = pendingLootRef.current
+      if (lootStr) {
+        const [itemType, rarity] = lootStr.split('-')
+        addK8s(
+          `kubectl get loot -n ${selected?.ns ?? '...'} -l game.k8s.example/dungeon=${selected?.name ?? '...'}`,
+          `loot CR created — includeWhen: hp==0 fired in monster-graph`,
+          `# monster-graph.yaml — Loot CR (includeWhen: hp==0)\n- id: lootCR\n  includeWhen:\n    - "\${schema.spec.hp <= 0}"\n  template:\n    kind: Loot\n    spec:\n      itemType: ${itemType ?? '?'}\n      rarity: ${rarity ?? '?'}`
+        )
+      }
       pendingLootRef.current = null
     }
   }
@@ -1458,13 +1492,16 @@ function HelpModal({ onClose, onCheat }: { onClose: () => void; onCheat: () => v
       <>
         <p>The boss has three phases based on remaining HP. Higher phases deal more counter-attack damage.</p>
         <table className="help-table">
-          <thead><tr><th>Phase</th><th>HP Range</th><th>Counter Mult</th><th>Special Chance</th></tr></thead>
+          {/* #452: Counter Mult fixed to 1.3x/1.6x (was 1.5x/2.0x); Special Chance replaced with actual hardcoded
+              status effect rates from dungeon-graph combatResolve specPatch (not driven by specialAttackChance) */}
+          <thead><tr><th>Phase</th><th>HP Range</th><th>Counter Mult</th><th>Burn</th><th>Stun</th><th>Poison (R2)</th></tr></thead>
           <tbody>
-            <tr><td>Normal</td><td>&gt;50%</td><td>1.0x</td><td>20%</td></tr>
-            <tr><td style={{color:'#e67e22'}}>ENRAGED</td><td>26–50%</td><td>1.5x</td><td>40%</td></tr>
-            <tr><td style={{color:'#e74c3c'}}>BERSERK</td><td>1–25%</td><td>2.0x</td><td>60%</td></tr>
+            <tr><td>Normal</td><td>&gt;50%</td><td>1.0×</td><td>25%</td><td>15%</td><td>30%</td></tr>
+            <tr><td style={{color:'#e67e22'}}>ENRAGED</td><td>26–50%</td><td>1.3×</td><td>25%</td><td>15%</td><td>30%</td></tr>
+            <tr><td style={{color:'#e74c3c'}}>BERSERK</td><td>1–25%</td><td>1.6×</td><td>25%</td><td>15%</td><td>30%</td></tr>
           </tbody>
         </table>
+        <p>Status effect chances are fixed regardless of boss phase (computed by <code>combatResolve</code> specPatch in dungeon-graph).</p>
         <p><b>Room 2:</b> After defeating the Room 1 boss, treasure opens and the door unlocks automatically. Click the door to enter Room 2 with trolls, ghouls, and a Bat-boss (stronger than Room 1). Mage mana is fully restored on entry. Defeating the Room 2 boss wins the dungeon.</p>
       </>
     )},

--- a/frontend/src/KroGraph.tsx
+++ b/frontend/src/KroGraph.tsx
@@ -175,6 +175,19 @@ export function buildGraph(cr: DungeonCR, reconciling: boolean): { nodes: GraphN
     })
     edges.push({ from: mcmId, to: lootId, label: 'includeWhen', dashed: true })
 
+    // lootInfo ConfigMap (created by loot-graph — item description text)
+    const lootInfoId = `loot-info-m${i}`
+    nodes.push({
+      id: lootInfoId,
+      label: 'LootInfo',
+      kind: 'ConfigMap',
+      state: lootExists ? 'ok' : 'locked',
+      exists: lootExists,
+      concept: 'cel-basics',
+      detail: lootExists ? 'item description CM' : 'created by loot-graph',
+    })
+    edges.push({ from: lootId, to: lootInfoId, label: 'loot-graph', dashed: !lootExists })
+
     // lootSecret Secret (created by loot-graph when Loot CR exists)
     const lootSecretId = `loot-secret-m${i}`
     nodes.push({
@@ -241,7 +254,19 @@ export function buildGraph(cr: DungeonCR, reconciling: boolean): { nodes: GraphN
     concept: 'includeWhen',
     detail: bossLootExists ? 'guaranteed drop' : 'includeWhen: hp==0',
   })
-  edges.push({ from: 'boss-cm', to: 'boss-loot', label: 'includeWhen', dashed: true })
+  edges.push({ from: 'boss', to: 'boss-loot', label: 'boss-graph', dashed: !bossLootExists })
+
+  // Boss lootInfo ConfigMap (created by loot-graph — item description text)
+  nodes.push({
+    id: 'boss-loot-info',
+    label: 'BossLootInfo',
+    kind: 'ConfigMap',
+    state: bossLootExists ? 'ok' : 'locked',
+    exists: bossLootExists,
+    concept: 'cel-basics',
+    detail: bossLootExists ? 'boss item description CM' : 'created by loot-graph',
+  })
+  edges.push({ from: 'boss-loot', to: 'boss-loot-info', label: 'loot-graph', dashed: !bossLootExists })
 
   // Boss lootSecret Secret (created by loot-graph)
   nodes.push({
@@ -338,9 +363,8 @@ export function buildGraph(cr: DungeonCR, reconciling: boolean): { nodes: GraphN
     kind: 'specPatch',
     state: reconciling ? 'reconciling' : 'ok',
     exists: true,
-    concept: 'empty-rgd',
+    concept: 'spec-mutation',
     detail: 'equip/use/door/room logic',
-    pulse: reconciling,
   })
   edges.push({ from: 'dungeon', to: 'action-cm', label: 'specPatch' })
 
@@ -859,14 +883,19 @@ export function KroGraphPanel({ cr, prevCr, reconciling, onViewConcept }: KroGra
       'treasure-secret': 'treasuresecret',
       'modifier': 'modifier',
       'modifier-cm': 'modifiercm',     // Modifier state ConfigMap
+      // #437: boss loot nodes
+      'boss-loot': 'bossloot',
+      'boss-loot-info': 'bosslootinfo',
+      'boss-loot-secret': 'bosslootsecret',
       // combat-cm / action-cm are specPatch virtual nodes — no persistent K8s resource, skip
       // attack-cr / action-cr are empty RGD CRs — no managed resources, skip
     }
 
-    // Extract index from monster-N / monster-cm-N / loot-mN / loot-secret-mN node IDs
+    // Extract index from monster-N / monster-cm-N / loot-mN / loot-info-mN / loot-secret-mN node IDs
     const monsterMatch = nodeId.match(/^monster-(\d+)$/)
     const monsterCmMatch = nodeId.match(/^monster-cm-(\d+)$/)
     const lootMatch = nodeId.match(/^loot-m(\d+)$/)
+    const lootInfoMatch = nodeId.match(/^loot-info-m(\d+)$/)
     const lootSecretMatch = nodeId.match(/^loot-secret-m(\d+)$/)
 
     let kind: ResourceKind | undefined
@@ -877,9 +906,11 @@ export function KroGraphPanel({ cr, prevCr, reconciling, onViewConcept }: KroGra
     } else if (monsterCmMatch) {
       kind = 'monsterstate'; index = parseInt(monsterCmMatch[1])
     } else if (lootMatch) {
-      kind = 'monster'; index = parseInt(lootMatch[1])  // loot node maps to its Monster CR
+      kind = 'loot'; index = parseInt(lootMatch[1])       // #437: Loot CR
+    } else if (lootInfoMatch) {
+      kind = 'lootinfo'; index = parseInt(lootInfoMatch[1])  // #437: LootInfo CM
     } else if (lootSecretMatch) {
-      kind = 'monster'; index = parseInt(lootSecretMatch[1])
+      kind = 'lootsecret'; index = parseInt(lootSecretMatch[1])  // #437: LootSecret
     } else {
       kind = kindMap[nodeId] as ResourceKind | undefined
     }

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -37,6 +37,7 @@ export type KroConceptId =
   | 'cel-playground'
   | 'cel-filter'
   | 'cel-string-ops'
+  | 'spec-patch'
 
 export interface KroConcept {
   id: KroConceptId
@@ -668,12 +669,38 @@ stringData:
   description: "\${'A ' + schema.spec.rarity + ' weapon (+' + string(schema.spec.stat) + ' dmg)'}"`,
     learnMore: 'manifests/rgds/monster-graph.yaml (itemType) and loot-graph.yaml (stringData)',
   },
+
+  // #450: specPatch concept — central kro mechanism driving 9 of 16 dungeon-graph nodes
+  'spec-patch': {
+    id: 'spec-patch',
+    title: 'specPatch — CEL State Machine',
+    tagline: 'kro writes computed values back into the same CR it is watching',
+    body: `\`type: specPatch\` is an RGD resource entry that evaluates a CEL expression and writes the result directly to \`spec.*\` fields on the parent CR. This triggers another reconcile loop iteration — enabling stateful game logic (combat, cooldowns, DoT, room transitions) with no backend code.
+
+9 of dungeon-graph's 16 resource entries are specPatch nodes: \`dungeonInit\`, \`abilityResolve\`, \`tickDoT\`, \`advanceTaunt\`, \`tickCooldown\`, \`regenRing\`, \`combatResolve\`, \`actionResolve\`, \`enterRoom2Resolve\`. Together they implement the entire game engine via CEL — the Go backend only patches trigger fields (\`attackSeq\`, \`lastAbility\`, etc.) and reads the results.`,
+    snippet: `# dungeon-graph.yaml — tickDoT specPatch
+# Fires each attack turn when DoT is active.
+# Reads spec.poisonTurns/burnTurns → writes heroHP, decrements counters.
+- id: tickDoT
+  type: specPatch
+  includeWhen:
+    - "\${schema.spec.poisonTurns > 0 || schema.spec.burnTurns > 0}"
+  patch:
+    heroHP: "\${schema.spec.heroHP
+      - (schema.spec.poisonTurns > 0 ? 5 : 0)
+      - (schema.spec.burnTurns > 0 ? 8 : 0) < 0 ? 0
+      : schema.spec.heroHP - (schema.spec.poisonTurns > 0 ? 5 : 0)
+      - (schema.spec.burnTurns > 0 ? 8 : 0)}"
+    poisonTurns: "\${schema.spec.poisonTurns > 0 ? schema.spec.poisonTurns - 1 : 0}"
+    burnTurns:   "\${schema.spec.burnTurns > 0   ? schema.spec.burnTurns - 1   : 0}"`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — all 9 specPatch nodes',
+  },
 }
 // ─── end KRO_CONCEPTS ────────────────────────────────────────────────────────
 
 /** Map game events to insight triggers */
 export function getInsightForEvent(event: string): InsightTrigger | null {
-  if (event === 'dungeon-created') return { conceptId: 'rgd', headline: 'kro created 7 resources from your one Dungeon CR' }
+  if (event === 'dungeon-created') return { conceptId: 'rgd', headline: 'kro built a full resource graph from your one Dungeon CR — 16 managed entries' }
   if (event === 'spec-schema') return { conceptId: 'spec-schema', headline: 'kro validated your difficulty/heroClass fields against spec.schema enums' }
   if (event === 'schema-validated') return { conceptId: 'schema-validation', headline: 'kro compiled your spec.schema into a CRD — the API server now rejects invalid dungeons' }
   if (event === 'resource-chaining') return { conceptId: 'resource-chaining', headline: 'Hero CR status (maxHP, class) flowed up through dungeon-graph resource chaining' }
@@ -693,9 +720,11 @@ export function getInsightForEvent(event: string): InsightTrigger | null {
   if (event === 'status-conditions') return { conceptId: 'status-conditions', headline: 'kro is reporting its reconcile status via status.conditions — the Kubernetes health contract' }
   if (event === 'second-attack') return { conceptId: 'reconcile-loop', headline: 'The ~1s pause after every action is the kro reconcile loop: watch → CEL eval → write' }
   if (event === 'dungeon-created-2nd') return { conceptId: 'resourceGroup-api', headline: 'kro registered Dungeon as a real Kubernetes API — kubectl get dungeon works natively' }
-  if (event === 'boots-equipped') return { conceptId: 'cel-has-macro', headline: 'has() lets CEL safely access optional spec fields — used throughout dungeon-graph readyWhen' }
+   if (event === 'boots-equipped') return { conceptId: 'cel-has-macro', headline: 'has() lets CEL safely access optional spec fields — used throughout dungeon-graph readyWhen' }
   if (event === 'dungeon-deleted') return { conceptId: 'ownerReferences', headline: 'Deleting the Dungeon CR triggered cascading deletion of all 9 child resources via ownerReferences' }
   if (event === 'cel-playground-unlocked') return { conceptId: 'cel-playground', headline: 'Open the CEL Playground to write and evaluate live kro expressions against your dungeon' }
+  // #450: spec-patch concept fires on first DoT tick — most visible specPatch in action
+  if (event === 'dot-applied') return { conceptId: 'spec-patch', headline: 'tickDoT specPatch fired: CEL decremented heroHP and poisonTurns/burnTurns directly in spec' }
   return null
 }
 
@@ -806,7 +835,7 @@ const CONCEPT_ORDER: KroConceptId[] = [
   'seeded-random', 'secret-output', 'empty-rgd', 'spec-mutation',
   'externalRef', 'status-conditions', 'reconcile-loop',
   'resourceGroup-api', 'cel-has-macro', 'ownerReferences', 'cel-playground',
-  'cel-filter', 'cel-string-ops',
+  'cel-filter', 'cel-string-ops', 'spec-patch',
 ]
 
 interface KroGlossaryProps {
@@ -1388,9 +1417,11 @@ const CEL_EXAMPLES = [
   { label: 'Hero HP check', expr: 'schema.spec.heroHP > 100' },
   { label: 'Difficulty branch', expr: 'schema.spec.difficulty == "hard" ? "big dice" : "small dice"' },
   { label: 'Mage mana', expr: 'schema.spec.heroClass == "mage" && schema.spec.heroMana > 0' },
-  { label: 'Boss state ternary', expr: 'schema.spec.bossHP > 0 ? (schema.spec.monsters == 0 ? "ready" : "pending") : "defeated"' },
+  // #453: schema.spec.monsterHP.all(...) — correct check for all-monsters-dead (schema.spec.monsters is immutable count, not current state)
+  { label: 'Boss state ternary', expr: 'schema.spec.bossHP > 0 ? (schema.spec.monsterHP.all(hp, hp <= 0) ? "ready" : "pending") : "defeated"' },
   { label: 'Damage × 1.3 (mage)', expr: 'schema.spec.heroClass == "mage" ? schema.spec.heroHP * 13 / 10 : schema.spec.heroHP' },
-  { label: 'Optional field', expr: 'self.spec.?modifier.orValue("none")' },
+  // #453: self → schema (kro binds root as 'schema', not 'self')
+  { label: 'Optional field', expr: 'schema.spec.?modifier.orValue("none")' },
   { label: 'String concat', expr: 'string(schema.spec.heroHP) + " / " + string(schema.spec.monsters)' },
   { label: 'Room 2 check', expr: 'schema.spec.currentRoom == 2' },
 ]
@@ -1473,7 +1504,13 @@ export function KroCelPlayground({ dungeonNs, dungeonName, onLearnConcept, onClo
         <div className="kro-playground-body">
           {/* Left: editor + examples */}
           <div className="kro-playground-left">
-            <div className="kro-playground-editor-label">Expression <span className="kro-playground-hint">Ctrl+Enter to run</span></div>
+            <div className="kro-playground-editor-label">
+              Expression <span className="kro-playground-hint">Ctrl+Enter to run</span>
+              {/* #453: show character counter against 500-char backend limit */}
+              <span style={{ marginLeft: 'auto', fontSize: 9, color: expr.length > 450 ? '#e74c3c' : '#888' }}>
+                {expr.length}/500
+              </span>
+            </div>
             <textarea
               ref={inputRef}
               className="kro-playground-input"
@@ -1543,7 +1580,8 @@ export function KroCelPlayground({ dungeonNs, dungeonName, onLearnConcept, onClo
           </button>
           <div style={{ flex: 1 }} />
           <div className="kro-playground-supported">
-            Supported: field access · arithmetic · comparisons · ternary · string() · int() · size()
+            {/* #453: list all kro CEL extensions registered in BaseDeclarations() */}
+            Supported: field access · arithmetic · ternary · string() · int() · size() · has() · cel.bind() · random.seededInt/String() · lists.set/range/filter() · csv.add/remove() · maps.* · 500 char limit
           </div>
         </div>
       </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -175,7 +175,10 @@ export class ApiError extends Error {
 const VALID_RESOURCE_KINDS = [
   'dungeon', 'hero', 'herostate', 'boss', 'bossstate', 'namespace', 'gameconfig',
   'monster', 'monsterstate', 'treasure', 'treasurecm', 'treasuresecret', 'modifier',
-  'combatresult', 'combatcm', 'modifiercm', 'actioncm',
+  'modifiercm',
+  // #437: Loot CR and loot-graph children
+  'loot', 'lootinfo', 'lootsecret',
+  'bossloot', 'bosslootinfo', 'bosslootsecret',
 ] as const
 export type ResourceKind = typeof VALID_RESOURCE_KINDS[number]
 

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -667,6 +667,38 @@ grep -q 'ENRAGED ×1\.5\|BERSERK ×2\.0\|phaseNote.*1\.5\|phaseNote.*2\.0' backe
 # boss-graph damageMultiplier must use 13/16 (not 15/20) — check only the damageMultiplier CEL block
 grep -A6 "damageMultiplier:" manifests/rgds/boss-graph.yaml | grep -q "'15'\|'20'" && fail "#398: boss-graph damageMultiplier still uses 15/20 (should be 13/16)" || pass "#398: boss-graph damageMultiplier uses correct 13/16"
 
+# --- Teaching T2 guardrails (#437, #439, #440, #444, #449, #450, #452, #453) ---
+echo "=== Teaching T2 guardrails"
+
+# #437: lootInfo CM node must exist in KroGraph; boss-loot edge from boss not boss-cm
+grep -q "loot-info-m\${i}\|'loot-info-m'" frontend/src/KroGraph.tsx && pass "#437: lootInfo CM node added to KroGraph" || fail "#437: lootInfo CM node missing from KroGraph"
+grep -q "from: 'boss-cm'.*boss-loot\|boss-cm.*boss-loot" frontend/src/KroGraph.tsx && fail "#440: boss-loot edge source still boss-cm" || pass "#440: boss-loot edge source fixed to boss"
+
+# #437: loot/lootinfo/lootsecret kinds must be in VALID_RESOURCE_KINDS
+grep -q "'loot'" frontend/src/api.ts && pass "#437: 'loot' kind in VALID_RESOURCE_KINDS" || fail "#437: 'loot' kind missing from VALID_RESOURCE_KINDS"
+grep -q "'lootinfo'" frontend/src/api.ts && pass "#437: 'lootinfo' kind in VALID_RESOURCE_KINDS" || fail "#437: 'lootinfo' kind missing"
+grep -q "'lootsecret'" frontend/src/api.ts && pass "#437: 'lootsecret' kind in VALID_RESOURCE_KINDS" || fail "#437: 'lootsecret' kind missing"
+# #437: loot/lootinfo/lootsecret handler cases must exist in GetDungeonResource
+grep -q '"loot":$\|case "loot"' backend/internal/handlers/handlers.go && pass "#437: 'loot' case in GetDungeonResource" || fail "#437: 'loot' case missing from GetDungeonResource"
+
+# #439: actionResolve node concept must be spec-mutation not empty-rgd
+grep -A5 "actionResolve" frontend/src/KroGraph.tsx | grep -q "concept: 'empty-rgd'" && fail "#439: actionResolve node still uses concept: empty-rgd" || pass "#439: actionResolve node uses concept: spec-mutation"
+
+# #449: InsightCard dungeon-created must not say '7 resources'
+grep -q "kro created 7 resources" frontend/src/KroTeach.tsx && fail "#449: dungeon-created InsightCard still says '7 resources'" || pass "#449: dungeon-created InsightCard updated"
+
+# #450: spec-patch concept must exist in KroConceptId and CONCEPT_ORDER
+grep -q "'spec-patch'" frontend/src/KroTeach.tsx && pass "#450: spec-patch concept exists in KroTeach" || fail "#450: spec-patch concept missing from KroTeach"
+grep -q "dot-applied" frontend/src/App.tsx && pass "#450: dot-applied event triggers spec-patch insight" || fail "#450: dot-applied event missing from App.tsx"
+
+# #452: help modal boss phase table must show correct multipliers (1.3x/1.6x not 1.5x/2.0x)
+grep -v '^\s*//' frontend/src/App.tsx | grep -v '{/\*.*#452' | grep -q "1\.5x\|2\.0x\|1\.5×\|2\.0×" && fail "#452: help modal still shows 1.5x/2.0x boss phase multipliers" || pass "#452: help modal shows correct 1.3x/1.6x"
+grep -v '^\s*//' frontend/src/App.tsx | grep -v '{/\*.*#452' | grep -q "Special Chance" && fail "#452: help modal still shows 'Special Chance' column (misleading)" || pass "#452: Special Chance column removed from help modal"
+
+# #453: CEL playground examples — no 'self.spec', must use 'schema.spec'; no wrong boss state expr
+grep -q "'self\.spec\.\?modifier\|self\.spec\.bossHP" frontend/src/KroTeach.tsx && fail "#453: CEL playground still uses self.spec (should be schema.spec)" || pass "#453: CEL playground uses schema.spec"
+grep -q "schema\.spec\.monsters == 0" frontend/src/KroTeach.tsx && fail "#453: boss state ternary still uses schema.spec.monsters == 0 (wrong)" || pass "#453: boss state ternary uses monsterHP.all()"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

- **#437**: Add `lootInfo` CM nodes (monster + boss) to resource graph; fix `kindMap` to route loot nodes to correct K8s resources (Loot CR, LootInfo CM, LootSecret); add `loot`/`lootinfo`/`lootsecret`/`bossloot`/`bosslootinfo`/`bosslootsecret` cases to `GetDungeonResource` and `VALID_RESOURCE_KINDS`
- **#439**: Fix `actionResolve` node in KroGraph — change `concept: 'empty-rgd'` → `'spec-mutation'`
- **#440**: Fix boss-loot edge source from `boss-cm` → `boss` (loot-graph is a child of the Boss CR, not the bossState CM)
- **#444**: Add K8s log entries for room transition (enterRoom2Resolve specPatch), loot drops (includeWhen: hp==0), and boss phase changes (boss-graph CEL fired)
- **#449**: Update `dungeon-created` InsightCard headline from "kro created 7 resources" to "kro built a full resource graph — 16 managed entries"
- **#450**: Add `spec-patch` concept to KroTeach (tagline, body, tickDoT snippet); add to `KroConceptId`, `KRO_CONCEPTS`, `CONCEPT_ORDER`; fire `dot-applied` event from App.tsx on first DoT tick
- **#452**: Fix help modal boss phase table — correct multipliers (1.3×/1.6×), replace misleading "Special Chance" column with actual hardcoded status effect rates (Burn 25%, Stun 15%, Poison 30%)
- **#453**: Fix CEL playground examples — `self.spec` → `schema.spec`, boss state ternary uses `monsterHP.all(hp, hp <= 0)`, add kro extensions to footer, add 500-char counter

## Guardrails

All T2 guardrail checks added and passing. No RGD schema changes.

Closes #437
Closes #439
Closes #440
Closes #444
Closes #449
Closes #450
Closes #452
Closes #453