### PR TITLE
fix: stun now correctly skips next hero attack

### DIFF
--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -300,22 +300,21 @@ spec:
         abilityProcessedSeq: "${schema.spec.attackSeq}"
         lastAbility: "${''}"
 
-     # --- DoT tick: decrement poison/burn/stun and apply HP damage, once per attack turn ---
-     # Gate: attackSeq has advanced past dotProcessedSeq AND combatResolve has fired first
-     # (dotProcessedSeq < combatProcessedSeq prevents firing the same reconcile cycle that
-     # applied the DoT via counter-attack, which would give an extra tick)
-     # AND at least one DoT is active
-     # AND lastAttackTarget is empty (combatResolve already ran and cleared the target)
-     # AND lastAbility is empty.
+      # --- DoT tick: decrement poison/burn and apply HP damage, once per attack turn ---
+      # Gate: attackSeq has advanced past dotProcessedSeq AND combatResolve has fired first
+      # (dotProcessedSeq < combatProcessedSeq prevents firing the same reconcile cycle that
+      # applied the DoT via counter-attack, which would give an extra tick)
+      # AND at least one DoT is active (poison or burn only — stun is consumed by combatResolve)
+      # AND lastAttackTarget is empty (combatResolve already ran and cleared the target)
+      # AND lastAbility is empty.
     - id: tickDoT
       type: specPatch
       includeWhen:
-        - "${schema.spec.attackSeq > schema.spec.dotProcessedSeq && schema.spec.dotProcessedSeq < schema.spec.combatProcessedSeq && (schema.spec.poisonTurns > 0 || schema.spec.burnTurns > 0 || schema.spec.stunTurns > 0) && schema.spec.lastAttackTarget == '' && schema.spec.lastAbility == ''}"
+        - "${schema.spec.attackSeq > schema.spec.dotProcessedSeq && schema.spec.dotProcessedSeq < schema.spec.combatProcessedSeq && (schema.spec.poisonTurns > 0 || schema.spec.burnTurns > 0) && schema.spec.lastAttackTarget == '' && schema.spec.lastAbility == ''}"
       patch:
         heroHP: "${schema.spec.heroHP - (schema.spec.poisonTurns > 0 ? 5 : 0) - (schema.spec.burnTurns > 0 ? 8 : 0) < 0 ? 0 : schema.spec.heroHP - (schema.spec.poisonTurns > 0 ? 5 : 0) - (schema.spec.burnTurns > 0 ? 8 : 0)}"
         poisonTurns: "${schema.spec.poisonTurns > 0 ? schema.spec.poisonTurns - 1 : 0}"
         burnTurns: "${schema.spec.burnTurns > 0 ? schema.spec.burnTurns - 1 : 0}"
-        stunTurns: "${schema.spec.stunTurns > 0 ? schema.spec.stunTurns - 1 : 0}"
         dotProcessedSeq: "${schema.spec.attackSeq}"
 
     # --- Taunt advancement: 1→2 (protecting) → 0 (expired), once per attack turn ---
@@ -600,7 +599,9 @@ spec:
             : bt
           ))))))}
 
-        # --- Stun: boss stun (15%) OR archer stun (20% per alive archer, boots resist) ---
+        # --- Stun: consume existing stun OR apply new stun from boss (15%) / archer (20%) ---
+        # When hero is already stunned (wasStunned), consume one turn (st-1).
+        # When not stunned, check for new stun infliction.
         stunTurns: >-
           ${cel.bind(s, schema.spec.lastAttackSeed,
           cel.bind(st, schema.spec.stunTurns,
@@ -609,8 +610,9 @@ spec:
           cel.bind(effectRoll, random.seededInt(0, 100, s + '-fx'),
           cel.bind(resistRoll, random.seededInt(0, 100, s + '-boots-resist'),
           cel.bind(resisted, schema.spec.bootsBonus > 0 && resistRoll < schema.spec.bootsBonus,
-            isBoss ?
-              (effectRoll < 15 && st == 0 && !wasStunned && !resisted ? 1 : st)
+            wasStunned ? st - 1
+            : isBoss ?
+              (effectRoll < 15 && !resisted ? 1 : st)
             : cel.bind(idx, schema.spec.lastAttackIndex,
               cel.bind(diff, schema.spec.difficulty,
               cel.bind(baseDmg,
@@ -636,7 +638,7 @@ spec:
                   schema.spec.monsterHP[idx] - finalDmg < 0 ? 0 : schema.spec.monsterHP[idx] - finalDmg)
                 : schema.spec.monsterHP,
               cel.bind(postAlive, postArr.filter(h, h > 0).size(),
-                postAlive > 0 && st == 0 && !wasStunned ?
+                postAlive > 0 ?
                   cel.bind(archerResistRoll, random.seededInt(0, 100, s + '-boots-resist-archer'),
                   cel.bind(archerResisted, schema.spec.bootsBonus > 0 && archerResistRoll < schema.spec.bootsBonus,
                   cel.bind(archerHit,

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -440,6 +440,9 @@ grep -q "getMonsterName" frontend/src/Sprite.tsx && pass "Sprite.tsx exports get
 grep -q "getMonsterName" frontend/src/App.tsx && pass "App.tsx uses getMonsterName for display labels" || fail "App.tsx not using getMonsterName"
 grep -q "Archer.*STUNNED\|STUNNED.*Archer\|archer.*stun\|stun.*archer" backend/internal/handlers/handlers.go && pass "Backend implements Archer stun mechanic" || fail "Archer stun mechanic missing from backend"
 grep -q "Shaman.*heal\|shaman.*heal" backend/internal/handlers/handlers.go && pass "Backend implements Shaman heal mechanic" || fail "Shaman heal mechanic missing from backend"
+# Stun must be consumed by combatResolve (not tickDoT) — tickDoT only handles poison/burn HP damage
+! grep -A10 "id: tickDoT" manifests/rgds/dungeon-graph.yaml | grep -q "stunTurns.*-.*1\|stunTurns.*stun" && pass "Stun not decremented in tickDoT (consumed by combatResolve)" || fail "tickDoT still decrements stunTurns — stun will be silently cleared before it takes effect"
+grep -A5 "id: combatResolve" manifests/rgds/dungeon-graph.yaml | grep -q "combatResolve\|type: specPatch" && grep -q "wasStunned ? st - 1" manifests/rgds/dungeon-graph.yaml && pass "combatResolve consumes stun (wasStunned ? st - 1)" || fail "combatResolve missing stun consumption (wasStunned ? st - 1)"
 
 # --- New Game+ guardrails ---
 echo "=== New Game+ guardrails"


### PR DESCRIPTION
## Bug

When an archer or boss stunned the hero, the stun was immediately consumed by `tickDoT` in the same reconcile cycle it was inflicted — before the hero's next attack. On the following turn `stunTurns` was already 0, so `finalDmg` was never zeroed and the hero dealt full damage. The stun had no effect.

## Root cause

`tickDoT` decremented `stunTurns` (alongside poison/burn) as part of the DoT tick that fires after `combatResolve` each turn. So the sequence was:

1. Turn N: hero attacks → `combatResolve` sets `stunTurns = 1` → `tickDoT` decrements 1→0
2. Turn N+1: `stunTurns = 0` → hero attacks normally, no skip

## Fix

- **`tickDoT`**: removed `stunTurns` from the gate condition and the patch. `tickDoT` now only handles poison and burn HP damage.
- **`combatResolve`**: merged stun consumption into the existing `stunTurns` CEL expression. When `wasStunned` (st > 0 at turn start), returns `st - 1` immediately before checking for new stun infliction. This ensures stun is consumed **on the turn the hero is supposed to skip**, not prematurely.

New sequence:
1. Turn N: hero attacks → `combatResolve` sets `stunTurns = 1` (inflicted)
2. Turn N+1: hero attacks → `combatResolve` sees `wasStunned=true`, sets `finalDmg=0` (hero skipped), decrements `stunTurns` 1→0
3. Turn N+2: `stunTurns = 0` → hero attacks normally

Guardrails added to enforce: stun never decremented in `tickDoT`, and `combatResolve` always has `wasStunned ? st - 1` consumption.