### PR TITLE
fix: kro Guaranteed QoS — memory request=limit 8Gi, CPU request=4 no limit (#473)

### DIFF
--- a/manifests/system/kro-resources.yaml
+++ b/manifests/system/kro-resources.yaml
@@ -2,6 +2,10 @@
 # Helm-managed kro Deployment. Terraform EKS capability module owns the Helm
 # release (image tag, initial install); this manifest owns resource limits and
 # concurrency env vars so they are tracked in Git and survive helm upgrades.
+#
+# Resource policy (#473):
+#   memory request == limit (8Gi) → Guaranteed QoS → last pod evicted under pressure
+#   cpu request = 4, no cpu limit → guaranteed 4 cores, can burst freely
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,11 +18,11 @@ spec:
         - name: kro
           resources:
             requests:
-              cpu: "1"
-              memory: "1Gi"
-            limits:
               cpu: "4"
               memory: "8Gi"
+            limits:
+              memory: "8Gi"
+              # No CPU limit — allow bursting above 4 cores during reconcile spikes
           env:
             - name: KRO_RESOURCE_GROUP_CONCURRENT_RECONCILES
               value: "16"


### PR DESCRIPTION
## Summary

- Sets `memory request = memory limit = 8Gi` → kro pod enters Guaranteed QoS class, last to be evicted under node memory pressure
- Sets `cpu request = 4`, removes `cpu limit` → kro gets guaranteed 4 cores but can burst freely during reconcile spikes without CPU throttling
- Removes the old `cpu: "1"` request and `cpu: "4"` limit

Closes #473