### PR TITLE
fix: reaper 30d retention, unauthenticated tour, active_dungeons metric, game+kro dashboards (#474,#475,#476,#477,#478)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -45,6 +45,8 @@ func (h *Handler) pollGameMetrics() {
 		if err == nil {
 			var alive, dead, bPend, bReady, bDef, wins, losses float64
 			activeDungeons.Set(float64(len(list.Items)))
+			// #475: emit structured log for CloudWatch active_dungeons metric filter
+			slog.Info("active_dungeons", "component", "game", "count", len(list.Items))
 			for _, d := range list.Items {
 				spec, _ := d.Object["spec"].(map[string]interface{})
 				status, _ := d.Object["status"].(map[string]interface{})

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -112,7 +112,11 @@ export default function App() {
   useEffect(() => {
     if (authCheckedRef.current) return
     authCheckedRef.current = true
-    getMe().then(user => setAuthUser(user ?? false))
+    getMe().then(user => {
+      setAuthUser(user ?? false)
+      // #478: unauthenticated users always see the intro tour, regardless of localStorage
+      if (!user) setShowOnboarding(true)
+    })
   }, [])
 
   const handleLogout = useCallback(async () => {
@@ -120,6 +124,7 @@ export default function App() {
     setAuthUser(false)
     setDungeons([])
     setDetail(null)
+    setShowOnboarding(true) // re-show intro on logout
     navigate('/')
   }, [navigate])
 
@@ -736,13 +741,14 @@ export default function App() {
 
       {!selected ? (
         <>
-          {showOnboarding && <KroOnboardingOverlay onDismiss={() => setShowOnboarding(false)} />}
+          {showOnboarding && <KroOnboardingOverlay onDismiss={() => setShowOnboarding(false)} isAuthenticated={!!authUser} />}
           <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
             <div style={{ position: 'relative' }} onMouseLeave={() => setShowHamburger(false)}>
               <button className="hamburger-btn" aria-label="Menu" onClick={() => setShowHamburger(v => !v)}>☰</button>
               {showHamburger && (
                 <div className="hamburger-menu">
                   <button className="hamburger-item" onClick={() => { setShowHamburger(false); handleOpenLeaderboard() }}>Leaderboard</button>
+                  <button className="hamburger-item" onClick={() => { setShowHamburger(false); setShowOnboarding(true) }}>About kro</button>
                   {authUser && <button className="hamburger-item" onClick={() => { setShowHamburger(false); handleOpenProfile() }}>Profile @{authUser.login}</button>}
                   {authUser && <button className="hamburger-item" onClick={() => { setShowHamburger(false); handleLogout() }}>Logout @{authUser.login}</button>}
                 </div>
@@ -760,6 +766,11 @@ export default function App() {
             </div>
           )}
           <DungeonList dungeons={dungeons} onSelect={handleSelect} onDelete={handleDelete} deleting={deleting} lastDungeon={resumePrompt ?? undefined} />
+          {authUser && (
+            <div style={{ textAlign: 'center', marginTop: 8, fontSize: '7px', color: 'var(--text-dim)' }}>
+              Your dungeon data is kept for 30 days.
+            </div>
+          )}
         </>
       ) : loading ? (
         <div className="loading">Initializing dungeon</div>

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -1373,14 +1373,16 @@ client.Resource(dungeonGVR).Namespace(ns).Patch(ctx,
   },
 ]
 
-export function KroOnboardingOverlay({ onDismiss }: { onDismiss: () => void }) {
+export function KroOnboardingOverlay({ onDismiss, isAuthenticated }: { onDismiss: () => void; isAuthenticated: boolean }) {
   const [slide, setSlide] = useState(0)
   const total = ONBOARDING_SLIDES.length
   const s = ONBOARDING_SLIDES[slide]
   const isLast = slide === total - 1
 
   const handleDismiss = () => {
-    localStorage.setItem('kroOnboardingDone', '1')
+    // #478: only persist dismissal for authenticated users — unauthenticated users
+    // always see the tour on page load so conference/demo visitors can always learn
+    if (isAuthenticated) localStorage.setItem('kroOnboardingDone', '1')
     onDismiss()
   }
 

--- a/infra/observability.tf
+++ b/infra/observability.tf
@@ -45,7 +45,7 @@ resource "aws_cloudwatch_dashboard" "krombat" {
   dashboard_name = "${var.cluster_name}-game"
   dashboard_body = jsonencode({
     widgets = [
-      # Row 1: CPU and Memory
+      # Row 1: CPU — Average + Max per pod, including kro (#474)
       {
         type   = "metric"
         x      = 0
@@ -53,18 +53,22 @@ resource "aws_cloudwatch_dashboard" "krombat" {
         width  = 12
         height = 6
         properties = {
-          title   = "CPU Utilization (%)"
+          title   = "CPU Utilization (%) — Avg and Max per Pod"
           region  = var.region
           view    = "timeSeries"
           stacked = false
           period  = 60
-          stat    = "Average"
           metrics = [
-            ["ContainerInsights", "pod_cpu_utilization", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-backend", { label = "Backend" }],
-            ["ContainerInsights", "pod_cpu_utilization", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-frontend", { label = "Frontend" }]
+            ["ContainerInsights", "pod_cpu_utilization", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-backend", { label = "Backend avg", stat = "Average" }],
+            ["ContainerInsights", "pod_cpu_utilization", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-backend", { label = "Backend max", stat = "Maximum", color = "#d62728" }],
+            ["ContainerInsights", "pod_cpu_utilization", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-frontend", { label = "Frontend avg", stat = "Average" }],
+            ["ContainerInsights", "pod_cpu_utilization", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-frontend", { label = "Frontend max", stat = "Maximum", color = "#ff7f0e" }],
+            ["ContainerInsights", "pod_cpu_utilization", "ClusterName", var.cluster_name, "Namespace", "kro", { label = "kro avg", stat = "Average", color = "#9467bd" }],
+            ["ContainerInsights", "pod_cpu_utilization", "ClusterName", var.cluster_name, "Namespace", "kro", { label = "kro max", stat = "Maximum", color = "#8c564b" }]
           ]
         }
       },
+      # Row 1 right: Memory — Average + Max per pod, including kro (#474)
       {
         type   = "metric"
         x      = 12
@@ -72,19 +76,22 @@ resource "aws_cloudwatch_dashboard" "krombat" {
         width  = 12
         height = 6
         properties = {
-          title   = "Memory Utilization (%)"
+          title   = "Memory Utilization (%) — Avg and Max per Pod"
           region  = var.region
           view    = "timeSeries"
           stacked = false
           period  = 60
-          stat    = "Average"
           metrics = [
-            ["ContainerInsights", "pod_memory_utilization", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-backend", { label = "Backend" }],
-            ["ContainerInsights", "pod_memory_utilization", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-frontend", { label = "Frontend" }]
+            ["ContainerInsights", "pod_memory_utilization", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-backend", { label = "Backend avg", stat = "Average" }],
+            ["ContainerInsights", "pod_memory_utilization", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-backend", { label = "Backend max", stat = "Maximum", color = "#d62728" }],
+            ["ContainerInsights", "pod_memory_utilization", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-frontend", { label = "Frontend avg", stat = "Average" }],
+            ["ContainerInsights", "pod_memory_utilization", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-frontend", { label = "Frontend max", stat = "Maximum", color = "#ff7f0e" }],
+            ["ContainerInsights", "pod_memory_utilization", "ClusterName", var.cluster_name, "Namespace", "kro", { label = "kro avg", stat = "Average", color = "#9467bd" }],
+            ["ContainerInsights", "pod_memory_utilization", "ClusterName", var.cluster_name, "Namespace", "kro", { label = "kro max", stat = "Maximum", color = "#8c564b" }]
           ]
         }
       },
-      # Row 2: Network and Pod Health
+      # Row 2: Network and Pod Restarts (including kro, #474)
       {
         type   = "metric"
         x      = 0
@@ -111,7 +118,7 @@ resource "aws_cloudwatch_dashboard" "krombat" {
         width  = 12
         height = 6
         properties = {
-          title   = "Pod Restarts & Status"
+          title   = "Pod Restarts — Backend, Frontend, kro (#474)"
           region  = var.region
           view    = "timeSeries"
           stacked = false
@@ -120,12 +127,11 @@ resource "aws_cloudwatch_dashboard" "krombat" {
           metrics = [
             ["ContainerInsights", "pod_number_of_container_restarts", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-backend", { label = "Backend Restarts", color = "#d62728" }],
             ["ContainerInsights", "pod_number_of_container_restarts", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-frontend", { label = "Frontend Restarts", color = "#ff7f0e" }],
-            ["ContainerInsights", "pod_number_of_running_containers", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-backend", { label = "Backend Running", color = "#2ca02c" }],
-            ["ContainerInsights", "pod_number_of_running_containers", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-frontend", { label = "Frontend Running", color = "#1f77b4" }]
+            ["ContainerInsights", "pod_number_of_container_restarts", "ClusterName", var.cluster_name, "Namespace", "kro", { label = "kro Restarts", color = "#9467bd" }]
           ]
         }
       },
-      # Row 3: Game activity (running pods = active dungeons) and cluster overview
+      # Row 3: Replica readiness (shows actual replica count, not container count, #474)
       {
         type   = "metric"
         x      = 0
@@ -133,18 +139,23 @@ resource "aws_cloudwatch_dashboard" "krombat" {
         width  = 12
         height = 6
         properties = {
-          title   = "Running Pods by Namespace (Active Dungeons)"
+          title   = "Ready Replicas — Backend, Frontend, kro (#474)"
           region  = var.region
           view    = "timeSeries"
-          stacked = true
+          stacked = false
           period  = 60
           stat    = "Average"
           metrics = [
-            ["ContainerInsights", "namespace_number_of_running_pods", "ClusterName", var.cluster_name, "Namespace", "rpg-system", { label = "rpg-system" }],
-            ["ContainerInsights", "namespace_number_of_running_pods", "ClusterName", var.cluster_name, "Namespace", "default", { label = "default (attacks)" }]
+            ["ContainerInsights", "replicas_ready", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "Service", "rpg-backend", { label = "Backend replicas ready" }],
+            ["ContainerInsights", "replicas_ready", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "Service", "rpg-frontend", { label = "Frontend replicas ready" }],
+            ["ContainerInsights", "replicas_ready", "ClusterName", var.cluster_name, "Namespace", "kro", { label = "kro replicas ready", color = "#9467bd" }]
           ]
+          annotations = {
+            horizontal = [{ label = "Expected minimum", value = 3, color = "#2ca02c" }]
+          }
         }
       },
+      # Row 3 right: Active Dungeons — live CR count from gauge metric (#475)
       {
         type   = "metric"
         x      = 12
@@ -152,69 +163,82 @@ resource "aws_cloudwatch_dashboard" "krombat" {
         width  = 12
         height = 6
         properties = {
-          title  = "Backend Availability (Running Containers)"
-          region = var.region
-          view   = "singleValue"
-          period = 60
-          stat   = "Average"
+          title   = "Active Dungeons (Live CR Count) (#475)"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          period  = 60
+          stat    = "Maximum"
           metrics = [
-            ["ContainerInsights", "pod_number_of_running_containers", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-backend", { label = "Backend" }],
-            ["ContainerInsights", "pod_number_of_running_containers", "ClusterName", var.cluster_name, "Namespace", "rpg-system", "PodName", "rpg-frontend", { label = "Frontend" }],
-            ["ContainerInsights", "replicas_ready", "ClusterName", var.cluster_name, "Namespace", "rpg-system", { label = "Ready Replicas" }]
+            ["Krombat/Game", "ActiveDungeons", { label = "Active Dungeons", color = "#f5c518" }]
           ]
         }
       },
-      # Row 4: Active Dungeons count and Victory Rate
+      # Row 4: Victory Rate and Attacks/Actions throughput (#474)
       {
-        type   = "log"
+        type   = "metric"
         x      = 0
         y      = 18
         width  = 12
         height = 6
         properties = {
-          title  = "Active Dungeons (Live Count)"
-          region = var.region
-          query  = "SOURCE '/eks/${var.cluster_name}/rpg-system' | fields @timestamp, @message | filter @message like /dungeon.*created|namespace.*dungeon/ | stats count() as created by bin(5m) | sort @timestamp desc"
+          title   = "Victory Rate (Boss Defeats / 5 min) (#474)"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          period  = 300
+          stat    = "Sum"
+          metrics = [
+            ["Krombat/Business", "DungeonVictory", { label = "Victories", color = "#2ca02c" }],
+            ["Krombat/Business", "DungeonDefeat", { label = "Defeats", color = "#d62728" }]
+          ]
         }
       },
       {
-        type   = "log"
+        type   = "metric"
         x      = 12
         y      = 18
         width  = 12
         height = 6
         properties = {
-          title  = "Victory Rate (Boss Defeated Events / 5 min)"
-          region = var.region
-          query  = "SOURCE '/eks/${var.cluster_name}/game' | fields @timestamp, @message | filter @message like /boss.*defeated|bossHP.*0|victory|dungeon.*complete/ | stats count() as victories by bin(5m) | sort @timestamp desc"
+          title   = "Attacks & Actions per 5 min (#474)"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          period  = 300
+          stat    = "Sum"
+          metrics = [
+            ["Krombat/Game", "AttackCount", { label = "Attacks", color = "#1f77b4" }],
+            ["Krombat/Game", "ActionCount", { label = "Actions", color = "#ff7f0e" }]
+          ]
         }
       },
-      # Row 5: Attack Latency and Logs
+      # Row 5: Backend API Logs and Errors (#474)
       {
         type   = "log"
         x      = 0
-        y      = 24
-        width  = 12
-        height = 6
-        properties = {
-          title  = "Attack Job Latency P95 (seconds)"
-          region = var.region
-          query  = "SOURCE '/eks/${var.cluster_name}/game' | fields @timestamp, @message | filter @message like /Turn complete|Attack complete|attack.*duration/ | parse @message /duration[=: ]+(?<duration_sec>[0-9.]+)/ | stats pct(duration_sec, 95) as p95_latency, avg(duration_sec) as avg_latency, count() as total_attacks by bin(5m) | sort @timestamp desc"
-        }
-      },
-      {
-        type   = "log"
-        x      = 12
         y      = 24
         width  = 12
         height = 6
         properties = {
           title  = "Backend API Logs"
           region = var.region
-          query  = "SOURCE '/aws/containerinsights/${var.cluster_name}/application' | fields @timestamp, @message | filter @logStream like /rpg-backend/ | sort @timestamp desc | limit 20"
+          query  = "SOURCE '/eks/${var.cluster_name}/rpg-system' | fields @timestamp, level, msg, method, path, status, duration_ms | filter ispresent(method) | sort @timestamp desc | limit 50"
         }
       },
-      # Row 6: Error logs and Reaper activity
+      {
+        type   = "log"
+        x      = 12
+        y      = 24
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Backend Errors (#474)"
+          region = var.region
+          query  = "SOURCE '/eks/${var.cluster_name}/rpg-system' | fields @timestamp, level, msg, path, status | filter level = \"error\" or level = \"ERROR\" or msg like /error/i | sort @timestamp desc | limit 20"
+        }
+      },
+      # Row 6: Reaper Activity (#474)
       {
         type   = "log"
         x      = 0
@@ -222,21 +246,27 @@ resource "aws_cloudwatch_dashboard" "krombat" {
         width  = 12
         height = 6
         properties = {
-          title  = "Errors & Attack Jobs"
+          title  = "Dungeon Reaper Activity (#474)"
           region = var.region
-          query  = "SOURCE '/aws/containerinsights/${var.cluster_name}/application' | fields @timestamp, @message | filter @message like /error|Error|Hero attacks|Turn complete|Attack failed/ | sort @timestamp desc | limit 20"
+          query  = "SOURCE '/eks/${var.cluster_name}/rpg-system' | fields @timestamp, @message | filter @message like /reaper/ | sort @timestamp desc | limit 20"
         }
       },
       {
-        type   = "log"
+        type   = "metric"
         x      = 12
         y      = 30
         width  = 12
         height = 6
         properties = {
-          title  = "Dungeon Reaper Activity"
-          region = var.region
-          query  = "SOURCE '/eks/${var.cluster_name}/game' | fields @timestamp, @message | filter @message like /reaper|dungeon.*delete|expired.*dungeon|cleanup/ | sort @timestamp desc | limit 20"
+          title   = "Reaper Success Count (#474)"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          period  = 600
+          stat    = "Sum"
+          metrics = [
+            ["Krombat/Game", "ReaperSuccess", { label = "Reaper runs succeeded", color = "#2ca02c" }]
+          ]
         }
       }
     ]
@@ -506,6 +536,22 @@ resource "aws_cloudwatch_log_metric_filter" "rate_limited" {
     name          = "RateLimited"
     namespace     = "Krombat/Game"
     value         = "1"
+    default_value = "0"
+    unit          = "Count"
+  }
+}
+
+# #475: Active dungeon count gauge — emitted every 30s by pollGameMetrics.
+# Uses $.count from the structured log so the metric reflects the actual live CR count.
+resource "aws_cloudwatch_log_metric_filter" "active_dungeons" {
+  name           = "${var.cluster_name}-active-dungeons"
+  log_group_name = aws_cloudwatch_log_group.rpg_system.name
+  pattern        = "{ $.msg = \"active_dungeons\" }"
+
+  metric_transformation {
+    name          = "ActiveDungeons"
+    namespace     = "Krombat/Game"
+    value         = "$.count"
     default_value = "0"
     unit          = "Count"
   }
@@ -1440,6 +1486,136 @@ resource "aws_cloudwatch_dashboard" "krombat_business" {
           title  = "Boss Kills by Room and Difficulty"
           region = var.region
           query  = "SOURCE '/eks/${var.cluster_name}/rpg-system' | filter msg = \"boss_killed\" | stats count(*) by room, difficulty"
+        }
+      }
+    ]
+  })
+}
+
+# =============================================================================
+# Issue #476 — Dashboard 5: krombat-kro (kro operator observability)
+# =============================================================================
+
+resource "aws_cloudwatch_dashboard" "krombat_kro" {
+  dashboard_name = "${var.cluster_name}-kro"
+  dashboard_body = jsonencode({
+    widgets = [
+      # Row 1: kro CPU and Memory utilisation
+      {
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title   = "kro CPU Utilization (%)"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          period  = 60
+          metrics = [
+            ["ContainerInsights", "pod_cpu_utilization", "ClusterName", var.cluster_name, "Namespace", "kro", { label = "kro avg", stat = "Average", color = "#9467bd" }],
+            ["ContainerInsights", "pod_cpu_utilization", "ClusterName", var.cluster_name, "Namespace", "kro", { label = "kro max", stat = "Maximum", color = "#8c564b" }]
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title   = "kro Memory Utilization (%)"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          period  = 60
+          metrics = [
+            ["ContainerInsights", "pod_memory_utilization", "ClusterName", var.cluster_name, "Namespace", "kro", { label = "kro avg", stat = "Average", color = "#9467bd" }],
+            ["ContainerInsights", "pod_memory_utilization", "ClusterName", var.cluster_name, "Namespace", "kro", { label = "kro max", stat = "Maximum", color = "#8c564b" }]
+          ]
+        }
+      },
+      # Row 2: kro Pod Restarts and Replicas Ready
+      {
+        type   = "metric"
+        x      = 0
+        y      = 6
+        width  = 12
+        height = 6
+        properties = {
+          title   = "kro Pod Restarts"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          period  = 60
+          stat    = "Sum"
+          metrics = [
+            ["ContainerInsights", "pod_number_of_container_restarts", "ClusterName", var.cluster_name, "Namespace", "kro", { label = "kro Restarts", color = "#d62728" }]
+          ]
+          annotations = {
+            horizontal = [{ label = "Alert threshold", value = 1, color = "#d62728" }]
+          }
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 6
+        width  = 12
+        height = 6
+        properties = {
+          title   = "kro Ready Replicas"
+          region  = var.region
+          view    = "timeSeries"
+          stacked = false
+          period  = 60
+          stat    = "Average"
+          metrics = [
+            ["ContainerInsights", "replicas_ready", "ClusterName", var.cluster_name, "Namespace", "kro", { label = "kro replicas ready", color = "#9467bd" }]
+          ]
+          annotations = {
+            horizontal = [{ label = "Expected", value = 1, color = "#2ca02c" }]
+          }
+        }
+      },
+      # Row 3: kro Reconcile Errors and CEL Evaluation Errors (log widgets)
+      {
+        type   = "log"
+        x      = 0
+        y      = 12
+        width  = 12
+        height = 6
+        properties = {
+          title  = "kro Reconcile Errors"
+          region = var.region
+          query  = "SOURCE '/eks/${var.cluster_name}/kro' | fields @timestamp, @message | filter @message like /error/i or @message like /failed/i | sort @timestamp desc | limit 50"
+        }
+      },
+      {
+        type   = "log"
+        x      = 12
+        y      = 12
+        width  = 12
+        height = 6
+        properties = {
+          title  = "kro CEL Evaluation Errors"
+          region = var.region
+          query  = "SOURCE '/eks/${var.cluster_name}/kro' | fields @timestamp, @message | filter @message like /cel/i or @message like /expression/i or @message like /CEL/i | sort @timestamp desc | limit 50"
+        }
+      },
+      # Row 4: RGD Status events (acceptance, rejection, reconciliation)
+      {
+        type   = "log"
+        x      = 0
+        y      = 18
+        width  = 24
+        height = 6
+        properties = {
+          title  = "RGD Status (acceptance / rejection / reconcile events)"
+          region = var.region
+          query  = "SOURCE '/eks/${var.cluster_name}/kro' | fields @timestamp, @message | filter @message like /ResourceGraphDefinition/i or @message like /rgd/i or @message like /reconcil/i | sort @timestamp desc | limit 50"
         }
       }
     ]

--- a/manifests/system/dungeon-reaper.yaml
+++ b/manifests/system/dungeon-reaper.yaml
@@ -72,20 +72,38 @@ spec:
               args:
                 - |
                   set -e
-                  MAX_AGE_HOURS=${MAX_AGE_HOURS:-4}
-                  MAX_AGE_SECONDS=$((MAX_AGE_HOURS * 3600))
                   NOW=$(date +%s)
 
-                  echo "Reaping dungeons older than ${MAX_AGE_HOURS}h..."
+                  # #477: retention policy
+                  #   test-infra dungeons (krombat.io/owner=test-infra or no label): reap after 4h
+                  #   user dungeons (real GitHub login):                             reap after 30 days
+                  TEST_MAX_AGE=$((4 * 3600))
+                  USER_MAX_AGE=$((30 * 24 * 3600))
+
+                  echo "Reaping dungeons (test: 4h, user: 30d)..."
 
                   # #427: role is now namespaced to default only — use -n default
                   kubectl get dungeons -n default -o json | jq -r '
                     .items[] |
-                    "default/\(.metadata.name) \(.metadata.creationTimestamp)"
-                  ' | while read -r DUNGEON TS; do
+                    [
+                      "default/\(.metadata.name)",
+                      (.metadata.creationTimestamp),
+                      (.metadata.labels["krombat.io/owner"] // "")
+                    ] | @tsv
+                  ' | while IFS=$'\t' read -r DUNGEON TS OWNER; do
                     CREATED=$(date -d "$TS" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$TS" +%s 2>/dev/null || echo 0)
                     AGE=$((NOW - CREATED))
-                    if [ "$AGE" -gt "$MAX_AGE_SECONDS" ]; then
+
+                    # Determine max age by owner (#477)
+                    if [ "$OWNER" = "test-infra" ] || [ -z "$OWNER" ]; then
+                      MAX_AGE=$TEST_MAX_AGE
+                      POLICY="test (4h)"
+                    else
+                      MAX_AGE=$USER_MAX_AGE
+                      POLICY="user (30d)"
+                    fi
+
+                    if [ "$AGE" -gt "$MAX_AGE" ]; then
                       NS=$(echo "$DUNGEON" | cut -d/ -f1)
                       NAME=$(echo "$DUNGEON" | cut -d/ -f2)
 
@@ -99,15 +117,12 @@ spec:
                         continue
                       fi
 
-                      echo "Deleting dungeon $NAME (namespace $NS, age: $((AGE/3600))h)"
+                      echo "Deleting dungeon $NAME (namespace $NS, age: $((AGE/3600))h, policy: $POLICY)"
                       kubectl delete dungeon "$NAME" -n "$NS" --wait=false || true
                     fi
                   done
 
                   echo "Reaper complete."
-              env:
-                - name: MAX_AGE_HOURS
-                  value: "4"
               resources:
                 requests:
                   memory: "64Mi"


### PR DESCRIPTION
## Summary

- **#477**: Dungeon reaper now retains user dungeons for 30 days; only test dungeons (`krombat.io/owner: test-infra` or no label) still reap after 4h. UI shows "Your dungeon data is kept for 30 days." for authenticated users.
- **#478**: Unauthenticated users always see the intro tour on page load (localStorage gate ignored). Authenticated users keep existing once-and-done behaviour. "About kro" button added to hamburger menu to replay the tour at any time. On logout, tour is re-shown.
- **#475**: `pollGameMetrics` emits structured `slog.Info("active_dungeons", "component", "game", "count", ...)` log line every 30s. CloudWatch metric filter `active_dungeons` added to `observability.tf` using `$.count` as the value so the gauge reflects the real live CR count.
- **#474**: Game CloudWatch dashboard rewritten — stale "Attack Jobs" widgets removed, pod count fixed to replica readiness metric (not container count), kro included in all CPU/memory/restart widgets, Active Dungeons moved to real `Krombat/Game` metric, Victory Rate and Attacks/Actions use `Krombat/Business`/`Krombat/Game` metrics (not flaky log queries), Reaper Activity log corrected.
- **#476**: New `krombat-kro` CloudWatch dashboard added — kro CPU/memory utilisation, pod restarts with alert annotation, reconcile error log, CEL evaluation error log, RGD status event log.

Closes #474
Closes #475
Closes #476
Closes #477
Closes #478