### PR TITLE
fix: update journey 15 glossary concept count to 24

### DIFF
--- a/tests/e2e/journeys/15-ownerref-and-glossary.js
+++ b/tests/e2e/journeys/15-ownerref-and-glossary.js
@@ -4,7 +4,7 @@
 //   1. Delete a dungeon → dungeon-deleted event → ownerReferences InsightCard appears
 //   2. Glossary search bar appears after 4+ concepts are unlocked
 //   3. Search bar filters concepts, clear button restores all, empty state for nonsense query
-//   4. Glossary header shows total of /23 concepts
+//   4. Glossary header shows total of /24 concepts
 const { chromium } = require('playwright');
 const { createDungeonUI, attackMonster, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
@@ -164,8 +164,8 @@ async function run() {
     }
     attacksDone > 0 ? ok(`Completed ${attacksDone} attack(s) to unlock concepts`) : warn('No attacks succeeded (all monsters may be dead)');
 
-    // ── Part 3: Glossary tab — /23 total, search bar, filtering ──────────────
-    console.log('\n  [Part 3: kro Glossary tab — /23 count, search bar, filtering]');
+    // ── Part 3: Glossary tab — /24 total, search bar, filtering ──────────────
+    console.log('\n  [Part 3: kro Glossary tab — /24 count, search bar, filtering]');
 
     const kroTabSwitched = await switchToTab(page, 'kro');
     kroTabSwitched ? ok('Switched to kro tab') : fail('kro tab not found');
@@ -174,27 +174,27 @@ async function run() {
     const glossary = page.locator('.kro-glossary');
     (await glossary.count() > 0) ? ok('kro glossary panel is visible') : fail('kro glossary panel not found');
 
-    // Header should show "/23" total concept count
+    // Header should show "/24" total concept count
     const glossaryHeader = page.locator('.kro-glossary-header');
     const headerText = await glossaryHeader.textContent().catch(() => '');
-    (headerText.includes('/23') || headerText.includes('/ 23'))
-      ? ok(`Glossary header shows total of 23: "${headerText.trim()}"`)
-      : fail(`Glossary header does not show "/23": "${headerText.trim()}"`);
+    (headerText.includes('/24') || headerText.includes('/ 24'))
+      ? ok(`Glossary header shows total of 24: "${headerText.trim()}"`)
+      : fail(`Glossary header does not show "/24": "${headerText.trim()}"`);
 
     // Count unlocked concepts
     const unlockedItems = page.locator('.kro-glossary-item.unlocked');
     const unlockedCount = await unlockedItems.count();
     unlockedCount >= 1 ? ok(`${unlockedCount} concept(s) unlocked in glossary`) : fail('No concepts unlocked in glossary');
 
-    // All 23 grid items should be rendered (some locked, some unlocked)
+    // All 24 grid items should be rendered (some locked, some unlocked)
     const allItems = page.locator('.kro-glossary-item');
     const allItemsCount = await allItems.count();
-    allItemsCount === 23 ? ok('Glossary grid renders exactly 23 concept items') : fail(`Glossary grid has ${allItemsCount} items, expected 23`);
+    allItemsCount === 24 ? ok('Glossary grid renders exactly 24 concept items') : fail(`Glossary grid has ${allItemsCount} items, expected 24`);
 
     // Locked items show "Keep playing to unlock"
     const lockedItems = page.locator('.kro-glossary-item.locked');
     const lockedCount = await lockedItems.count();
-    lockedCount > 0 ? ok(`${lockedCount} locked concept(s) show "Keep playing" state`) : warn('All 23 concepts already unlocked (unusual at this stage)');
+    lockedCount > 0 ? ok(`${lockedCount} locked concept(s) show "Keep playing" state`) : warn('All 24 concepts already unlocked (unusual at this stage)');
 
     // ── Part 4: Search bar — appears at 4+ unlocked concepts ─────────────────
     console.log('\n  [Part 4: Glossary search bar]');
@@ -209,31 +209,31 @@ async function run() {
       if (await searchInput.count() > 0) {
         ok('Search input (.kro-glossary-search-input) found');
 
-        // Count current visible items (should be all 23 before searching)
+        // Count current visible items (should be all 24 before searching)
         const beforeSearch = await page.locator('.kro-glossary-item').count();
-        beforeSearch === 23 ? ok(`All 23 concepts visible before search (no active filter)`) : fail(`Expected 23 items before search, got ${beforeSearch}`);
+        beforeSearch === 24 ? ok(`All 24 concepts visible before search (no active filter)`) : fail(`Expected 24 items before search, got ${beforeSearch}`);
 
         // Type a known concept keyword — "ResourceGraph" / "RGD" / "cel" should narrow results
         await searchInput.fill('cel');
         await page.waitForTimeout(300);
 
         const afterSearch = await page.locator('.kro-glossary-item').count();
-        afterSearch < 23
-          ? ok(`Search "cel" narrowed results: ${afterSearch} item(s) shown (was 23)`)
+        afterSearch < 24
+          ? ok(`Search "cel" narrowed results: ${afterSearch} item(s) shown (was 24)`)
           : fail(`Search "cel" did not narrow results (still showing ${afterSearch} items)`);
 
         // Clear button (×) should appear when search is non-empty
         const clearBtn = page.locator('.kro-glossary-search-clear');
         (await clearBtn.count() > 0) ? ok('Clear button (×) appears when search is non-empty') : fail('Clear button (×) missing while search is non-empty');
 
-        // Click clear — all 23 items should reappear
+        // Click clear — all 24 items should reappear
         if (await clearBtn.count() > 0) {
           await clearBtn.click();
           await page.waitForTimeout(300);
           const afterClear = await page.locator('.kro-glossary-item').count();
-          afterClear === 23
-            ? ok(`Clear button restores all 23 concepts (was ${afterSearch} during filter)`)
-            : fail(`After clearing, expected 23 items but got ${afterClear}`);
+          afterClear === 24
+            ? ok(`Clear button restores all 24 concepts (was ${afterSearch} during filter)`)
+            : fail(`After clearing, expected 24 items but got ${afterClear}`);
 
           // Clear button should disappear once search is empty
           const clearAfter = await page.locator('.kro-glossary-search-clear').count();
@@ -270,7 +270,7 @@ async function run() {
           await page.waitForTimeout(300);
         }
         const finalCount = await page.locator('.kro-glossary-item').count();
-        finalCount === 23 ? ok('All 23 concepts restored after clearing nonsense search') : fail(`Expected 20 after restore, got ${finalCount}`);
+        finalCount === 24 ? ok('All 24 concepts restored after clearing nonsense search') : fail(`Expected 20 after restore, got ${finalCount}`);
 
       } else {
         fail('Search input (.kro-glossary-search-input) not found');
@@ -287,8 +287,8 @@ async function run() {
     // ── Part 5: kro tab label reflects correct totals ─────────────────────────
     console.log('\n  [Part 5: kro tab label concept count format]');
     const kroTabLabel = await page.locator('button.log-tab.kro-tab').textContent().catch(() => '');
-    kroTabLabel.match(/kro \(\d+\/23\)/)
-      ? ok(`kro tab label shows correct format with /23: "${kroTabLabel.trim()}"`)
+    kroTabLabel.match(/kro \(\d+\/24\)/)
+      ? ok(`kro tab label shows correct format with /24: "${kroTabLabel.trim()}"`)
       : fail(`kro tab label format unexpected: "${kroTabLabel.trim()}"`);
 
     // ── Console errors ────────────────────────────────────────────────────────


### PR DESCRIPTION
Journey 15 hardcoded /23 but the glossary now has 24 concepts (spec-patch was added in a prior PR). Update all count assertions from 23 → 24.