### PR TITLE
infra: remove module.kro EKS capability — kro runs as patched Helm fork

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,3 +370,21 @@ If anything outside the intended scope appears, do NOT open the PR — clean the
 - GitHub: `pnz1990/krombat`
 - 9 RGDs active, Argo CD syncing from `manifests/`
 - CI: `.github/workflows/build-images.yml` — builds on PR, pushes to ECR + rollout restart on main merge
+
+### Terraform
+
+- Working directory: `infra/`
+- AWS profile: `319279230668-Admin`
+- **Remote state**: S3 bucket `krombat-terraform-state-319279230668`, key `krombat/terraform.tfstate`, region `us-west-2`
+- **State locking**: DynamoDB table `krombat-terraform-locks` (issue #425)
+- The local `infra/terraform.tfstate` file is **not authoritative** — always use remote state via `terraform init` + `terraform plan/apply`
+- **CI does NOT run `terraform apply`** — infra changes require a manual `terraform apply` from `infra/` after merging to main
+- CloudWatch dashboards (`krombat-game`, `krombat-application`, `krombat-kubernetes`, `krombat-business`, `krombat-kro`) are all managed in `infra/observability.tf` and require `terraform apply` to take effect
+
+```bash
+# Standard terraform workflow
+cd infra/
+terraform init          # pulls remote state from S3
+terraform plan          # review changes
+terraform apply         # deploy — requires valid 319279230668-Admin AWS credentials
+```

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -129,12 +129,8 @@ data "aws_identitystore_user" "admin" {
 
 # --- EKS Capabilities ---
 
-module "kro" {
-  source = "terraform-aws-modules/eks/aws//modules/capability"
-
-  type         = "KRO"
-  cluster_name = module.eks.cluster_name
-}
+# kro is installed manually via Helm (patched fork cel-writeback-d) — NOT via EKS capability.
+# Do NOT add module.kro here; it would replace the patched version with the upstream EKS-managed one.
 
 module "argocd" {
   source = "terraform-aws-modules/eks/aws//modules/capability"

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -10,9 +10,7 @@ output "region" {
   value = var.region
 }
 
-output "kro_capability_arn" {
-  value = module.kro.arn
-}
+# kro is installed via Helm (patched fork), not EKS capability — no ARN output.
 
 output "argocd_capability_arn" {
   value = module.argocd.arn


### PR DESCRIPTION
## Summary

- Removes `module.kro` from `infra/main.tf` — this would install upstream EKS-managed kro and overwrite the patched fork (`cel-writeback-d`) the game depends on
- Removes the dangling `kro_capability_arn` output
- Updates `AGENTS.md` with Terraform remote state (S3 + DynamoDB lock table), CI-does-not-run-apply note, and CloudWatch dashboard list

CloudWatch dashboards already deployed via `terraform apply` (separately). This PR just prevents future `terraform apply` from accidentally replacing kro.

No game logic changes. No backend/frontend changes.