### PR TITLE
fix: help modal z-index above all overlays, spec-patch concept on 3rd attack (#495,#500)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -587,6 +587,8 @@ export default function App() {
         if ((detail?.spec.attackSeq ?? 0) === 0 && (updated.spec.attackSeq ?? 0) > 0) triggerInsight('first-attack')
         // Second attack — teach the reconcile loop concept
         if ((detail?.spec.attackSeq ?? 0) === 1 && (updated.spec.attackSeq ?? 0) > 1) triggerInsight('second-attack')
+        // Third attack — teach specPatch (combatResolve fires a specPatch every turn; DoT also fires specPatch but is RNG-gated)
+        if ((detail?.spec.attackSeq ?? 0) === 2 && (updated.spec.attackSeq ?? 0) > 2) triggerInsight('third-attack')
       }
 
       // Don't clear attackPhase/attackTarget — user must dismiss combat modal

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -719,6 +719,7 @@ export function getInsightForEvent(event: string): InsightTrigger | null {
   if (event === 'externalRef') return { conceptId: 'externalRef', headline: 'Your attack created an Attack CR — kro watched it and re-reconciled the dungeon graph' }
   if (event === 'status-conditions') return { conceptId: 'status-conditions', headline: 'kro is reporting its reconcile status via status.conditions — the Kubernetes health contract' }
   if (event === 'second-attack') return { conceptId: 'reconcile-loop', headline: 'The ~1s pause after every action is the kro reconcile loop: watch → CEL eval → write' }
+  if (event === 'third-attack') return { conceptId: 'spec-patch', headline: 'combatResolve fired a specPatch — CEL wrote hero HP, monster HP, and combat seq directly into spec' }
   if (event === 'dungeon-created-2nd') return { conceptId: 'resourceGroup-api', headline: 'kro registered Dungeon as a real Kubernetes API — kubectl get dungeon works natively' }
    if (event === 'boots-equipped') return { conceptId: 'cel-has-macro', headline: 'has() lets CEL safely access optional spec fields — used throughout dungeon-graph readyWhen' }
   if (event === 'dungeon-deleted') return { conceptId: 'ownerReferences', headline: 'Deleting the Dungeon CR triggered cascading deletion of all 9 child resources via ownerReferences' }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -309,6 +309,8 @@ body {
 }
 .help-btn:hover { background: var(--gold); color: #000; }
 .help-modal { max-width: 500px; text-align: left; max-height: 80vh; overflow-y: auto; }
+/* Ensure help modal overlay renders above combat overlay (2000), kro concept modal (2100), etc. */
+.help-modal-portal .modal-overlay { z-index: 3000; }
 .help-section { margin-bottom: 12px; }
 .help-section h3 { font-size: 9px; color: var(--gold); margin-bottom: 6px; }
 .help-section p { font-size: 7px; color: var(--text-dim); margin-bottom: 4px; line-height: 1.8; }


### PR DESCRIPTION
## Summary

- **#495**: Help (?) button appeared to do nothing because the HelpModal's `.modal-overlay` had `z-index: 100`, placing it behind the combat overlay (2000) and kro concept modal (2100). Wrapped in `.help-modal-portal` with `z-index: 3000` so it always renders on top.
- **#500**: The 24th kro concept (`spec-patch`) was only triggered by DoT ticks (poison/burn), which are RNG-gated and may never occur. Added a guaranteed trigger on the 3rd attack — `combatResolve` IS a specPatch and fires every turn, making this the natural teachable moment. The DoT trigger is preserved as an additional path.

Closes #495
Closes #500