### PR TITLE
feat: class-specific kro deep dives — Warrior/Mage/Rogue InsightCards (#459)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -587,6 +587,10 @@ export default function App() {
         if ((detail?.spec.attackSeq ?? 0) === 0 && (updated.spec.attackSeq ?? 0) > 0) triggerInsight('first-attack')
         // Second attack — teach the reconcile loop concept
         if ((detail?.spec.attackSeq ?? 0) === 1 && (updated.spec.attackSeq ?? 0) > 1) triggerInsight('second-attack')
+        // #459: class-specific deep dive triggers
+        if (heroAction.includes('Taunt activated')) triggerInsight('warrior-taunt-used')
+        if (heroAction.includes('heals for')) triggerInsight('mage-heal-used')
+        if (enemyAction.includes('dodged') || heroAction.includes('Rogue dodged')) triggerInsight('rogue-dodge-fired')
       }
 
       // Don't clear attackPhase/attackTarget — user must dismiss combat modal

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -38,6 +38,9 @@ export type KroConceptId =
   | 'cel-filter'
   | 'cel-string-ops'
   | 'spec-patch'
+  | 'taunt-state-machine'
+  | 'mana-lifecycle'
+  | 'cel-probability'
 
 export interface KroConcept {
   id: KroConceptId
@@ -695,6 +698,78 @@ stringData:
     burnTurns:   "\${schema.spec.burnTurns > 0   ? schema.spec.burnTurns - 1   : 0}"`,
     learnMore: 'manifests/rgds/dungeon-graph.yaml — all 9 specPatch nodes',
   },
+  'taunt-state-machine': {
+    id: 'taunt-state-machine',
+    title: 'specPatch Counter — Warrior Taunt Lifecycle',
+    tagline: 'CEL runs a 3-state counter in spec: 0 (idle) → 2 (queued) → 1 (active) → 0 (expired)',
+    body: `When you activate Taunt, the backend patches \`spec.tauntActive = 2\`. On every subsequent attack turn, the \`advanceTaunt\` specPatch node in dungeon-graph fires and decrements it:
+
+- **tauntActive = 2** — queued, damage reduction not yet applied
+- **tauntActive = 1** — active this combat turn (60% damage reduction applied in combatResolve)
+- **tauntActive = 0** — expired, ability available again
+
+This is a **3-state CEL counter** implemented entirely in kro specPatch nodes. No backend code tracks the cooldown — kro reconciles it from spec on every attack. The Warrior's class identity is a state machine in YAML.`,
+    snippet: `# dungeon-graph.yaml — advanceTaunt specPatch
+# Fires when tauntActive > 0, decrements counter each attack turn.
+- id: advanceTaunt
+  type: specPatch
+  includeWhen:
+    - "\${schema.spec.tauntActive > 0 && schema.spec.combatProcessedSeq > 0}"
+  patch:
+    tauntActive: "\${schema.spec.tauntActive - 1}"
+# combatResolve reads tauntActive == 1 to apply 50% damage reduction:
+# heroDmgTaken: "\${tauntActive == 1 ? int(baseDmg * 0.5) : int(baseDmg)}"`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — advanceTaunt and combatResolve specPatch nodes',
+  },
+  'mana-lifecycle': {
+    id: 'mana-lifecycle',
+    title: 'CEL bind() — Mage Mana as a Bounded Counter',
+    tagline: 'cel.bind() eliminates repeated sub-expressions and makes CEL readable at scale',
+    body: `The Mage's heal ability must clamp the result to \`maxMana\` — a value read from \`hero-graph\` status via resource chaining. Without \`cel.bind()\`, the expression repeats the same sub-expressions multiple times. With bind:
+
+\`\`\`
+cel.bind(newMana, schema.spec.heroMana + 2,
+  newMana > int(heroCR.status.maxMana)
+    ? int(heroCR.status.maxMana)
+    : newMana)
+\`\`\`
+
+\`cel.bind(var, expr, body)\` evaluates \`expr\` once, binds it to \`var\`, then evaluates \`body\` with \`var\` in scope. It reads like a \`let\` binding. This pattern appears throughout dungeon-graph wherever a computed intermediate value is needed more than once — boss HP percentages, damage clamps, room-2 scaling.`,
+    snippet: `# dungeon-graph.yaml — abilityResolve specPatch (mage heal)
+- id: abilityResolve
+  type: specPatch
+  includeWhen:
+    - "\${schema.spec.lastAbility == 'heal' && schema.spec.heroMana >= 2}"
+  patch:
+    # cel.bind avoids computing (heroMana+2) twice
+    heroMana: "\${cel.bind(m, schema.spec.heroMana - 2 + 1,
+      m > int(heroCR.status.?maxMana.orValue('8')) ? int(heroCR.status.?maxMana.orValue('8')) : m)}"
+    heroHP:   "\${cel.bind(h, schema.spec.heroHP + 40,
+      h > int(heroCR.status.?maxHP.orValue('120')) ? int(heroCR.status.?maxHP.orValue('120')) : h)}"`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — abilityResolve specPatch, hero-graph RGD',
+  },
+  'cel-probability': {
+    id: 'cel-probability',
+    title: 'Seeded Probability — Rogue Dodge in CEL',
+    tagline: 'A deterministic random value modulo 100 gives a percentage chance in pure CEL',
+    body: `The Rogue has a 25% chance to dodge counter-attacks. This is implemented in the \`combatResolve\` specPatch using \`random.seededInt()\`:
+
+\`\`\`
+cel.bind(dodgeRoll, random.seededInt(0, 99, attackUID + "dodge"),
+  dodgeRoll < 25 ? 0 : baseDmg)  // 0-24 = dodge (25%), 25-99 = hit
+\`\`\`
+
+The seed is the Attack CR UID concatenated with \`"dodge"\` — making every dodge roll **deterministic and reproducible** for a given attack. Re-running the same Attack CR with the same UID always produces the same dodge outcome. This is how kro implements game-quality randomness: seeded random, not cryptographic, but deterministic and auditable.
+
+The same pattern applies to backstab critical hits, boss status effect chances (poison/burn/stun), and loot rarity rolls throughout the RGDs.`,
+    snippet: `# dungeon-graph.yaml — combatResolve specPatch (rogue dodge)
+cel.bind(isRogue, schema.spec.heroClass == 'rogue',
+  cel.bind(dodgeRoll, random.seededInt(0, 99, attackCR.metadata.uid + "dodge"),
+    cel.bind(dodged, isRogue && dodgeRoll < 25,
+      # dodged == true: hero takes 0 damage from this counter-attack
+      dodged ? int(0) : int(baseDmg))))`,
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — combatResolve specPatch, kro random.seededInt extension',
+  },
 }
 // ─── end KRO_CONCEPTS ────────────────────────────────────────────────────────
 
@@ -725,6 +800,10 @@ export function getInsightForEvent(event: string): InsightTrigger | null {
   if (event === 'cel-playground-unlocked') return { conceptId: 'cel-playground', headline: 'Open the CEL Playground to write and evaluate live kro expressions against your dungeon' }
   // #450: spec-patch concept fires on first DoT tick — most visible specPatch in action
   if (event === 'dot-applied') return { conceptId: 'spec-patch', headline: 'tickDoT specPatch fired: CEL decremented heroHP and poisonTurns/burnTurns directly in spec' }
+  // #459: class-specific kro deep dives
+  if (event === 'warrior-taunt-used') return { conceptId: 'taunt-state-machine', headline: 'Taunt activated — advanceTaunt specPatch will count down tauntActive from 2→1→0 each turn' }
+  if (event === 'mage-heal-used') return { conceptId: 'mana-lifecycle', headline: 'Heal used — cel.bind() clamps heroMana and heroHP to their maxima in abilityResolve specPatch' }
+  if (event === 'rogue-dodge-fired') return { conceptId: 'cel-probability', headline: 'Dodge fired — random.seededInt(0,99,uid+"dodge") < 25: a 25% chance gate in pure CEL' }
   return null
 }
 
@@ -836,6 +915,8 @@ const CONCEPT_ORDER: KroConceptId[] = [
   'externalRef', 'status-conditions', 'reconcile-loop',
   'resourceGroup-api', 'cel-has-macro', 'ownerReferences', 'cel-playground',
   'cel-filter', 'cel-string-ops', 'spec-patch',
+  // #459: class-specific deep dives (Warrior, Mage, Rogue)
+  'taunt-state-machine', 'mana-lifecycle', 'cel-probability',
 ]
 
 interface KroGlossaryProps {

--- a/tests/e2e/journeys/15-ownerref-and-glossary.js
+++ b/tests/e2e/journeys/15-ownerref-and-glossary.js
@@ -4,7 +4,7 @@
 //   1. Delete a dungeon → dungeon-deleted event → ownerReferences InsightCard appears
 //   2. Glossary search bar appears after 4+ concepts are unlocked
 //   3. Search bar filters concepts, clear button restores all, empty state for nonsense query
-//   4. Glossary header shows total of /24 concepts
+//   4. Glossary header shows total of /27 concepts
 const { chromium } = require('playwright');
 const { createDungeonUI, attackMonster, waitForCombatResult, dismissLootPopup, navigateHome, deleteDungeon , testLogin} = require('./helpers');
 
@@ -164,8 +164,8 @@ async function run() {
     }
     attacksDone > 0 ? ok(`Completed ${attacksDone} attack(s) to unlock concepts`) : warn('No attacks succeeded (all monsters may be dead)');
 
-    // ── Part 3: Glossary tab — /24 total, search bar, filtering ──────────────
-    console.log('\n  [Part 3: kro Glossary tab — /24 count, search bar, filtering]');
+    // ── Part 3: Glossary tab — /27 total, search bar, filtering ──────────────
+    console.log('\n  [Part 3: kro Glossary tab — /27 count, search bar, filtering]');
 
     const kroTabSwitched = await switchToTab(page, 'kro');
     kroTabSwitched ? ok('Switched to kro tab') : fail('kro tab not found');
@@ -174,27 +174,27 @@ async function run() {
     const glossary = page.locator('.kro-glossary');
     (await glossary.count() > 0) ? ok('kro glossary panel is visible') : fail('kro glossary panel not found');
 
-    // Header should show "/24" total concept count
+    // Header should show "/27" total concept count
     const glossaryHeader = page.locator('.kro-glossary-header');
     const headerText = await glossaryHeader.textContent().catch(() => '');
-    (headerText.includes('/24') || headerText.includes('/ 24'))
-      ? ok(`Glossary header shows total of 24: "${headerText.trim()}"`)
-      : fail(`Glossary header does not show "/24": "${headerText.trim()}"`);
+    (headerText.includes('/27') || headerText.includes('/ 27'))
+      ? ok(`Glossary header shows total of 27: "${headerText.trim()}"`)
+      : fail(`Glossary header does not show "/27": "${headerText.trim()}"`);
 
     // Count unlocked concepts
     const unlockedItems = page.locator('.kro-glossary-item.unlocked');
     const unlockedCount = await unlockedItems.count();
     unlockedCount >= 1 ? ok(`${unlockedCount} concept(s) unlocked in glossary`) : fail('No concepts unlocked in glossary');
 
-    // All 24 grid items should be rendered (some locked, some unlocked)
+    // All 27 grid items should be rendered (some locked, some unlocked)
     const allItems = page.locator('.kro-glossary-item');
     const allItemsCount = await allItems.count();
-    allItemsCount === 24 ? ok('Glossary grid renders exactly 24 concept items') : fail(`Glossary grid has ${allItemsCount} items, expected 24`);
+    allItemsCount === 27 ? ok('Glossary grid renders exactly 27 concept items') : fail(`Glossary grid has ${allItemsCount} items, expected 27`);
 
     // Locked items show "Keep playing to unlock"
     const lockedItems = page.locator('.kro-glossary-item.locked');
     const lockedCount = await lockedItems.count();
-    lockedCount > 0 ? ok(`${lockedCount} locked concept(s) show "Keep playing" state`) : warn('All 24 concepts already unlocked (unusual at this stage)');
+    lockedCount > 0 ? ok(`${lockedCount} locked concept(s) show "Keep playing" state`) : warn('All 27 concepts already unlocked (unusual at this stage)');
 
     // ── Part 4: Search bar — appears at 4+ unlocked concepts ─────────────────
     console.log('\n  [Part 4: Glossary search bar]');
@@ -209,31 +209,31 @@ async function run() {
       if (await searchInput.count() > 0) {
         ok('Search input (.kro-glossary-search-input) found');
 
-        // Count current visible items (should be all 24 before searching)
+        // Count current visible items (should be all 27 before searching)
         const beforeSearch = await page.locator('.kro-glossary-item').count();
-        beforeSearch === 24 ? ok(`All 24 concepts visible before search (no active filter)`) : fail(`Expected 24 items before search, got ${beforeSearch}`);
+        beforeSearch === 27 ? ok(`All 27 concepts visible before search (no active filter)`) : fail(`Expected 27 items before search, got ${beforeSearch}`);
 
         // Type a known concept keyword — "ResourceGraph" / "RGD" / "cel" should narrow results
         await searchInput.fill('cel');
         await page.waitForTimeout(300);
 
         const afterSearch = await page.locator('.kro-glossary-item').count();
-        afterSearch < 24
-          ? ok(`Search "cel" narrowed results: ${afterSearch} item(s) shown (was 24)`)
+        afterSearch < 27
+          ? ok(`Search "cel" narrowed results: ${afterSearch} item(s) shown (was 27)`)
           : fail(`Search "cel" did not narrow results (still showing ${afterSearch} items)`);
 
         // Clear button (×) should appear when search is non-empty
         const clearBtn = page.locator('.kro-glossary-search-clear');
         (await clearBtn.count() > 0) ? ok('Clear button (×) appears when search is non-empty') : fail('Clear button (×) missing while search is non-empty');
 
-        // Click clear — all 24 items should reappear
+        // Click clear — all 27 items should reappear
         if (await clearBtn.count() > 0) {
           await clearBtn.click();
           await page.waitForTimeout(300);
           const afterClear = await page.locator('.kro-glossary-item').count();
-          afterClear === 24
-            ? ok(`Clear button restores all 24 concepts (was ${afterSearch} during filter)`)
-            : fail(`After clearing, expected 24 items but got ${afterClear}`);
+          afterClear === 27
+            ? ok(`Clear button restores all 27 concepts (was ${afterSearch} during filter)`)
+            : fail(`After clearing, expected 27 items but got ${afterClear}`);
 
           // Clear button should disappear once search is empty
           const clearAfter = await page.locator('.kro-glossary-search-clear').count();
@@ -270,7 +270,7 @@ async function run() {
           await page.waitForTimeout(300);
         }
         const finalCount = await page.locator('.kro-glossary-item').count();
-        finalCount === 24 ? ok('All 24 concepts restored after clearing nonsense search') : fail(`Expected 20 after restore, got ${finalCount}`);
+        finalCount === 27 ? ok('All 27 concepts restored after clearing nonsense search') : fail(`Expected 20 after restore, got ${finalCount}`);
 
       } else {
         fail('Search input (.kro-glossary-search-input) not found');
@@ -287,8 +287,8 @@ async function run() {
     // ── Part 5: kro tab label reflects correct totals ─────────────────────────
     console.log('\n  [Part 5: kro tab label concept count format]');
     const kroTabLabel = await page.locator('button.log-tab.kro-tab').textContent().catch(() => '');
-    kroTabLabel.match(/kro \(\d+\/24\)/)
-      ? ok(`kro tab label shows correct format with /24: "${kroTabLabel.trim()}"`)
+    kroTabLabel.match(/kro \(\d+\/27\)/)
+      ? ok(`kro tab label shows correct format with /27: "${kroTabLabel.trim()}"`)
       : fail(`kro tab label format unexpected: "${kroTabLabel.trim()}"`);
 
     // ── Console errors ────────────────────────────────────────────────────────

--- a/tests/e2e/journeys/17-cel-playground.js
+++ b/tests/e2e/journeys/17-cel-playground.js
@@ -230,17 +230,17 @@ async function run() {
     await glossary.waitFor({ timeout: TIMEOUT }).catch(() => {});
     (await glossary.count() > 0) ? ok('kro Glossary visible in kro tab') : fail('kro Glossary not found');
 
-    // Total concept count should be 24
+    // Total concept count should be 27
     const headerText = await page.locator('.kro-glossary-header').textContent();
-    headerText.includes('/ 24') ? ok('Glossary shows 24 total concepts') : fail(`Glossary concept count incorrect: "${headerText}"`);
+    headerText.includes('/ 27') ? ok('Glossary shows 27 total concepts') : fail(`Glossary concept count incorrect: "${headerText}"`);
 
     // ── Concept count badge ───────────────────────────────────────────────────
     console.log('\n  [kro tab badge]');
     await switchToTab(page, 'kro'); // ensure we're on kro tab; re-read badge in tabs row
     const kroTabBtn = page.locator('button.kro-tab');
     const badgeText = await kroTabBtn.textContent();
-    // Format: "kro (N/24)" — check it ends with /24)
-    /\/24\)/.test(badgeText) ? ok(`kro tab badge shows /24: "${badgeText.trim()}"`) : fail(`kro tab badge does not show /24: "${badgeText.trim()}"`);
+    // Format: "kro (N/27)" — check it ends with /27)
+    /\/27\)/.test(badgeText) ? ok(`kro tab badge shows /27: "${badgeText.trim()}"`) : fail(`kro tab badge does not show /27: "${badgeText.trim()}"`);
 
     // ── No critical JS errors ─────────────────────────────────────────────────
     console.log('\n  [Error check]');


### PR DESCRIPTION
## Summary

Adds 3 new class-specific kro InsightCards (27 total, up from 24) that teach the kro/CEL concept behind each hero class mechanic:

| Class | Trigger | New Concept | What it teaches |
|---|---|---|---|
| Warrior | Taunt activated | `taunt-state-machine` | advanceTaunt specPatch: CEL counter 2→1→0, class identity as state machine in YAML |
| Mage | Heal used | `mana-lifecycle` | cel.bind() pattern for clamping computed intermediates — used throughout dungeon-graph |
| Rogue | Dodge fires | `cel-probability` | random.seededInt() < 25 as a 25% probability gate — same pattern as loot rarity, boss status effects |

All three concepts are triggered by class-specific gameplay events that every player on that class will encounter naturally during a run.

### Glossary / concept count updated: 24 → 27

- `KroConceptId` union type: 27 entries
- `KRO_CONCEPTS` record: 27 entries  
- `CONCEPT_ORDER` array: 27 entries
- Journey 15 (`ownerref-and-glossary`) updated: all 24 refs → 27
- Journey 17 (`cel-playground`) updated: all 24 refs → 27
- Guardrail concept-count sync check passes (union == KRO_CONCEPTS == CONCEPT_ORDER == 27)

### kro teaching constraint
All new concepts are backed by real RGD YAML — the snippets reference `advanceTaunt`, `abilityResolve`, and `combatResolve` specPatch nodes in `dungeon-graph.yaml`. No game logic added to backend or frontend.

Closes #459