### PR TITLE
fix: concurrent write panic in WebSocket hub

### DIFF
--- a/backend/internal/ws/hub.go
+++ b/backend/internal/ws/hub.go
@@ -59,20 +59,38 @@ type connFilter struct {
 	name      string
 }
 
+// client wraps a WebSocket connection with a per-connection write mutex.
+// gorilla/websocket connections are not safe for concurrent writes; the mutex
+// ensures only one goroutine calls WriteMessage at a time per connection.
+type client struct {
+	conn    *websocket.Conn
+	writeMu sync.Mutex
+	filter  connFilter
+}
+
+func (c *client) writeMessage(msgType int, data []byte) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return c.conn.WriteMessage(msgType, data)
+}
+
 type Hub struct {
 	mu      sync.RWMutex
-	clients map[*websocket.Conn]connFilter
+	clients map[*websocket.Conn]*client
 }
 
 func NewHub() *Hub {
-	return &Hub{clients: make(map[*websocket.Conn]connFilter)}
+	return &Hub{clients: make(map[*websocket.Conn]*client)}
 }
 
 func (h *Hub) Run() {}
 
 func (h *Hub) Add(conn *websocket.Conn, namespace, name string) {
 	h.mu.Lock()
-	h.clients[conn] = connFilter{namespace: namespace, name: name}
+	h.clients[conn] = &client{
+		conn:   conn,
+		filter: connFilter{namespace: namespace, name: name},
+	}
 	h.mu.Unlock()
 	wsConnections.Inc()
 }
@@ -88,16 +106,17 @@ func (h *Hub) Remove(conn *websocket.Conn) {
 func (h *Hub) Broadcast(msg []byte, eventNS, eventName string) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	for conn, f := range h.clients {
+	for _, c := range h.clients {
+		f := c.filter
 		if f.namespace != "" && f.namespace != eventNS {
 			continue
 		}
 		if f.name != "" && f.name != eventName {
 			continue
 		}
-		if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+		if err := c.writeMessage(websocket.TextMessage, msg); err != nil {
 			slog.Warn("ws write error", "error", err)
-			go h.Remove(conn)
+			go h.Remove(c.conn)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a `panic: concurrent write to websocket connection` crash in the WebSocket hub that was causing backend pods to crash-loop.

## Root Cause

`Hub.Broadcast` held only an `RLock`, allowing multiple goroutines to call it simultaneously. Each goroutine called `conn.WriteMessage` directly on the same `*websocket.Conn`, violating gorilla/websocket's requirement that only one goroutine writes at a time.

## Fix

- Introduced a `client` struct that wraps `*websocket.Conn` with a `sync.Mutex`
- All writes go through `client.writeMessage()` which locks the per-connection mutex before calling `conn.WriteMessage`
- `Hub.clients` map updated from `map[*websocket.Conn]connFilter` to `map[*websocket.Conn]*client`
- The `Hub`-level `RWMutex` is unchanged — it still protects the clients map; the new per-connection mutex serializes writes to each individual connection