### PR TITLE
feat: blog post generator — one-click run narrative with kro CEL narration (#460)

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -60,6 +60,7 @@ func main() {
 	mux.HandleFunc("GET /api/v1/dungeons/{namespace}/{name}/resources", h.GetDungeonResource)
 	mux.HandleFunc("POST /api/v1/dungeons/{namespace}/{name}/cel-eval", h.CelEvalHandler)
 	mux.HandleFunc("GET /api/v1/run-card/{namespace}/{name}", h.RunCard)
+	mux.HandleFunc("GET /api/v1/run-narrative/{namespace}/{name}", h.RunNarrative)
 	mux.HandleFunc("GET /api/v1/leaderboard", h.GetLeaderboard)
 	mux.HandleFunc("GET /api/v1/profile", h.GetProfile)
 	mux.HandleFunc("POST /api/v1/profile/cert", h.AwardCert)

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -2899,3 +2899,284 @@ func (h *Handler) RunCard(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	fmt.Fprint(w, svg)
 }
+
+// RunNarrative generates a shareable Markdown blog post for a completed dungeon run.
+// The post narrates the key kro events that occurred during the run, lists unlocked
+// concepts, includes the dungeon CR YAML snippet, and closes with a kro CTA.
+//
+// Query params:
+//   - concepts=id1,id2,...  — comma-separated kro concept IDs unlocked (from frontend localStorage)
+//
+// Authenticated + ownership-checked (unlike RunCard which is intentionally public).
+func (h *Handler) RunNarrative(w http.ResponseWriter, r *http.Request) {
+	ns := r.PathValue("namespace")
+	name := r.PathValue("name")
+	if !validateNamespace(w, ns) {
+		return
+	}
+
+	dungeon, err := h.client.Dynamic.Resource(k8s.DungeonGVR).Namespace(ns).Get(
+		context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		writeError(w, sanitizeK8sError(err), http.StatusNotFound)
+		return
+	}
+
+	if ownerErr := requireDungeonOwner(r, dungeon); ownerErr != nil {
+		writeError(w, ownerErr.Error(), http.StatusForbidden)
+		return
+	}
+
+	spec, _ := dungeon.Object["spec"].(map[string]interface{})
+	if spec == nil {
+		writeError(w, "dungeon spec not found", http.StatusNotFound)
+		return
+	}
+
+	heroClass, _ := spec["heroClass"].(string)
+	if heroClass == "" {
+		heroClass = "warrior"
+	}
+	difficulty, _ := spec["difficulty"].(string)
+	if difficulty == "" {
+		difficulty = "normal"
+	}
+	attackSeq := getInt(spec, "attackSeq")
+	currentRoom := getInt(spec, "currentRoom")
+	if currentRoom < 1 {
+		currentRoom = 1
+	}
+	bossHP := getInt(spec, "bossHP")
+	room2BossHP := getInt(spec, "room2BossHP")
+	modifier, _ := spec["modifier"].(string)
+	monstersRaw, _ := spec["monsters"].(int64)
+	monsters := int(monstersRaw)
+	if monsters == 0 {
+		monsters = 1
+	}
+
+	// Parse unlocked concept IDs from query param
+	conceptsParam := r.URL.Query().Get("concepts")
+	conceptIDs := []string{}
+	if conceptsParam != "" {
+		for _, id := range strings.Split(conceptsParam, ",") {
+			if id = strings.TrimSpace(id); id != "" {
+				conceptIDs = append(conceptIDs, id)
+			}
+		}
+	}
+
+	// Concept ID → human-readable label + kro docs link
+	conceptLabels := map[string]string{
+		"resource-graph":      "Resource Graphs",
+		"cel-expressions":     "CEL Expressions",
+		"reconcile-loop":      "Reconcile Loop",
+		"crd-schema":          "CRD Schema",
+		"spec-status-split":   "Spec/Status Split",
+		"owner-references":    "Owner References",
+		"cel-conditionals":    "CEL Conditionals",
+		"cel-functions":       "CEL Functions",
+		"cel-writeback":       "CEL Writeback",
+		"rgd-template":        "RGD Templates",
+		"namespace-scoping":   "Namespace Scoping",
+		"kro-instance":        "kro Instances",
+		"kro-rbac":            "kro RBAC",
+		"ready-when":          "readyWhen Conditions",
+		"cel-math":            "CEL Math",
+		"cel-strings":         "CEL Strings",
+		"cel-maps":            "CEL Maps",
+		"cel-lists":           "CEL Lists",
+		"cel-comprehensions":  "CEL Comprehensions",
+		"spec-patch":          "Spec Patch",
+		"kro-defaults":        "kro Defaults",
+		"multi-resource-rgd":  "Multi-Resource RGDs",
+		"kro-status-fields":   "kro Status Fields",
+		"cel-ternary":         "CEL Ternary",
+		"taunt-state-machine": "State Machines in CEL",
+		"mana-lifecycle":      "Resource Lifecycle via CEL",
+		"cel-probability":     "Probability in CEL",
+	}
+	kroDocsBase := "https://kro.run/docs"
+
+	// Build concept section
+	var conceptLines []string
+	for _, id := range conceptIDs {
+		label := conceptLabels[id]
+		if label == "" {
+			label = strings.ReplaceAll(id, "-", " ")
+		}
+		conceptLines = append(conceptLines, fmt.Sprintf("- [%s](%s/concepts/%s)", label, kroDocsBase, id))
+	}
+
+	// Key kro events narrated from spec fields
+	type kroEvent struct {
+		turn int64
+		desc string
+		cel  string
+		rgd  string
+	}
+	var events []kroEvent
+
+	// Event 1: Dungeon CR created → kro reconciles 16 child resources
+	events = append(events, kroEvent{
+		turn: 1,
+		desc: fmt.Sprintf("The Dungeon CR `%s` was created. kro's `dungeon-graph` RGD immediately reconciled and created a Namespace, Hero CR, %d Monster CR(s), a Boss CR, Treasure CR, Modifier CR, and supporting ConfigMaps — all from a single custom resource.", name, monsters),
+		cel:  `size(schema.spec.monsterHP.filter(hp, hp > 0))  // monstersAlive count`,
+		rgd:  "dungeon-graph",
+	})
+
+	// Event 2: Hero class stats via CEL (hero-graph)
+	classHP := map[string]int{"warrior": 200, "mage": 120, "rogue": 150}[heroClass]
+	if classHP == 0 {
+		classHP = 150
+	}
+	classMana := map[string]int{"warrior": 0, "mage": 8, "rogue": 4}[heroClass]
+	events = append(events, kroEvent{
+		turn: 1,
+		desc: fmt.Sprintf("The `hero-graph` RGD computed the Hero's stats via CEL: max HP = %d for a %s, max mana = %d. The Hero ConfigMap was created with these values, written back by kro's CEL writeback feature.", classHP, heroClass, classMana),
+		cel:  fmt.Sprintf(`schema.spec.heroClass == "%s" ? %d : (schema.spec.heroClass == "warrior" ? 200 : 150)  // maxHP`, heroClass, classHP),
+		rgd:  "hero-graph",
+	})
+
+	// Event 3: Modifier effect
+	if modifier != "" && modifier != "none" {
+		modDesc := map[string]string{
+			"curse-darkness":      "Curse of Darkness — hero damage reduced by 20%.",
+			"curse-fury":          "Curse of Fury — monsters deal 30% more damage.",
+			"curse-fortitude":     "Curse of Fortitude — boss HP increased by 25%.",
+			"blessing-strength":   "Blessing of Strength — hero damage increased by 25%.",
+			"blessing-resilience": "Blessing of Resilience — hero takes 25% less damage.",
+			"blessing-fortune":    "Blessing of Fortune — loot drop chance doubled.",
+		}[modifier]
+		if modDesc == "" {
+			modDesc = modifier
+		}
+		events = append(events, kroEvent{
+			turn: 1,
+			desc: fmt.Sprintf("The dungeon modifier `%s` was active: %s The `modifier-graph` RGD computed the effect and multiplier entirely in CEL — no backend code involved.", modifier, modDesc),
+			cel:  `schema.spec.modifier == "blessing-strength" ? 1.25 : (schema.spec.modifier == "curse-darkness" ? 0.80 : 1.0)`,
+			rgd:  "modifier-graph",
+		})
+	}
+
+	// Event 4: Boss phase transitions (if boss was ever engaged)
+	if bossHP >= 0 {
+		events = append(events, kroEvent{
+			turn: attackSeq / 3,
+			desc: fmt.Sprintf("As the battle progressed, the `boss-graph` RGD tracked the boss phase in real time via CEL. When boss HP dropped below 50%%, kro recomputed `damageMultiplier` from 1.0 → 1.3; below 25%% it became 1.6. No backend code was needed — CEL expressions in the RGD drove the entire state machine."),
+			cel:  `schema.spec.bossHP <= schema.status.maxBossHP * 0.25 ? 1.6 : (schema.spec.bossHP <= schema.status.maxBossHP * 0.5 ? 1.3 : 1.0)`,
+			rgd:  "boss-graph",
+		})
+	}
+
+	// Event 5: Room 2 transition (if player made it)
+	if currentRoom >= 2 && room2BossHP > 0 {
+		events = append(events, kroEvent{
+			turn: attackSeq / 2,
+			desc: fmt.Sprintf("After clearing Room 1, the dungeon transitioned to Room 2. kro patched `spec.monsterHP` with 1.5x scaled values (trolls and ghouls replace goblins) and `spec.bossHP` with 1.3x values. The entire room state was driven by a single PATCH to the Dungeon CR spec — kro's `dungeon-graph` RGD reconciled all 16 child resources automatically."),
+			cel:  `schema.spec.currentRoom >= 2 ? int(schema.spec.room2BossHP * 1.3) : schema.spec.bossHP`,
+			rgd:  "dungeon-graph",
+		})
+	}
+
+	// Event 6: Loot drop via loot-graph (if inventory non-empty)
+	inventory, _ := spec["inventory"].(string)
+	if inventory != "" {
+		items := strings.Split(inventory, ",")
+		firstItem := ""
+		for _, it := range items {
+			it = strings.TrimSpace(it)
+			if it != "" {
+				firstItem = it
+				break
+			}
+		}
+		if firstItem != "" {
+			events = append(events, kroEvent{
+				turn: attackSeq / 4,
+				desc: fmt.Sprintf("A monster kill triggered a loot drop. The `loot-graph` RGD computed the item type (`%s`), rarity, and description entirely in CEL — the result was written to a Kubernetes Secret managed by kro, then surfaced to the frontend via the dungeon spec.", firstItem),
+				cel:  `schema.spec.difficulty == "hard" ? "epic" : (random.seededInt(0, 3, schema.metadata.uid) == 0 ? "rare" : "common")`,
+				rgd:  "loot-graph",
+			})
+		}
+	}
+
+	// Build YAML snippet from key spec fields
+	yamlSnippet := fmt.Sprintf(`apiVersion: rpg.krombat.io/v1alpha1
+kind: Dungeon
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  heroClass: %s
+  difficulty: %s
+  monsters: %d
+  heroHP: %d
+  bossHP: %d
+  attackSeq: %d
+  currentRoom: %d
+  modifier: "%s"
+  inventory: "%s"`,
+		name, ns,
+		heroClass, difficulty,
+		monsters,
+		getInt(spec, "heroHP"),
+		bossHP,
+		attackSeq, currentRoom,
+		modifier, inventory,
+	)
+
+	// Assemble the post
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("# I played a dungeon RPG on Kubernetes — here's what kro did\n\n"))
+	capitalize := func(s string) string {
+		if len(s) == 0 {
+			return s
+		}
+		return strings.ToUpper(s[:1]) + s[1:]
+	}
+	sb.WriteString(fmt.Sprintf("> **%s** | **%s** difficulty | **%d turns** | dungeon: `%s`\n\n", capitalize(heroClass), capitalize(difficulty), attackSeq, name))
+
+	if currentRoom >= 2 && bossHP <= 0 {
+		sb.WriteString("**Victory!** Both rooms cleared.\n\n")
+	} else if currentRoom >= 2 {
+		sb.WriteString("**Room 2 reached.** Final boss still standing.\n\n")
+	} else {
+		sb.WriteString("**Room 1 cleared.**\n\n")
+	}
+
+	sb.WriteString("---\n\n")
+	sb.WriteString("## What kro did during this run\n\n")
+	sb.WriteString("Every attack, every HP change, every loot drop — all driven by [kro](https://github.com/kubernetes-sigs/kro) ResourceGraphDefinitions on Kubernetes. Here are the key reconcile events:\n\n")
+
+	for i, ev := range events {
+		sb.WriteString(fmt.Sprintf("### %d. %s\n\n", i+1, ev.desc))
+		sb.WriteString(fmt.Sprintf("**RGD:** `%s`\n\n", ev.rgd))
+		sb.WriteString(fmt.Sprintf("**CEL expression:**\n```cel\n%s\n```\n\n", ev.cel))
+	}
+
+	sb.WriteString("---\n\n")
+
+	if len(conceptLines) > 0 {
+		sb.WriteString("## kro concepts I learned\n\n")
+		for _, l := range conceptLines {
+			sb.WriteString(l + "\n")
+		}
+		sb.WriteString("\n")
+		sb.WriteString("---\n\n")
+	}
+
+	sb.WriteString("## The Dungeon CR YAML\n\n")
+	sb.WriteString("This single Kubernetes custom resource describes the entire game state:\n\n")
+	sb.WriteString(fmt.Sprintf("```yaml\n%s\n```\n\n", yamlSnippet))
+
+	sb.WriteString("---\n\n")
+	sb.WriteString("## Try it yourself\n\n")
+	sb.WriteString("Play at **[learn-kro.eks.aws.dev](https://learn-kro.eks.aws.dev)** — no local setup needed.\n\n")
+	sb.WriteString("Built with **[kro](https://github.com/kubernetes-sigs/kro)** — Kubernetes Resource Orchestrator.\n\n")
+	sb.WriteString("> kro lets you define a graph of Kubernetes resources as a single custom resource, with CEL expressions for dynamic values and conditions. No controllers, no operators — just YAML and CEL.\n")
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"markdown": sb.String()})
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1927,6 +1927,20 @@ function HelpModal({ onClose, onCheat }: { onClose: () => void; onCheat: () => v
         <p>Use <b>Pause</b> to freeze the stream while reading. Use <b>Copy JSON</b> to export the full event log for debugging.</p>
       </>
     )},
+    { title: 'Blog Post Generator', content: (
+      <>
+        <p>After winning, click <b>Tell the story of this run</b> on the victory screen to generate a shareable Markdown blog post about your run.</p>
+        <p>The post includes:</p>
+        <ul>
+          <li>Hero class, difficulty, turn count, and dungeon name</li>
+          <li>Narrated kro events — boss phase transitions, loot drops, room transitions — each with the responsible CEL expression and RGD</li>
+          <li>All kro concepts you unlocked, linked to the kro docs</li>
+          <li>The full Dungeon CR YAML snippet</li>
+          <li>A CTA linking to <code>learn-kro.eks.aws.dev</code></li>
+        </ul>
+        <p><b>Copy Markdown</b> copies the post to your clipboard. <b>Open in GitHub Discussions</b> opens a new tab pre-filled in the kro repo's show-and-tell category.</p>
+      </>
+    )},
   ]
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -2040,6 +2054,10 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
   const [showPlayground, setShowPlayground] = useState(false)
   const [showTerminal, setShowTerminal] = useState(false)  // #457 kubectl terminal
   const [shareCopied, setShareCopied] = useState(false)   // #456 run card share feedback
+  const [showNarrative, setShowNarrative] = useState(false)   // #460 blog post generator
+  const [narrativeText, setNarrativeText] = useState('')       // #460
+  const [narrativeLoading, setNarrativeLoading] = useState(false)  // #460
+  const [narrativeCopied, setNarrativeCopied] = useState(false)    // #460
   // Auto-show certificate once on room-2 victory
   const certShownRef = useRef(false)
   useEffect(() => {
@@ -2329,13 +2347,37 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
                   className="run-card-img"
                   loading="lazy"
                 />
-                <button
-                  className="btn run-card-share-btn"
-                  onClick={handleShare}
-                  title="Copy shareable tweet + card link to clipboard"
-                >
-                  {shareCopied ? '✓ Copied!' : '↗ Share Run'}
-                </button>
+                <div style={{ display: 'flex', gap: 6, justifyContent: 'center', flexWrap: 'wrap' }}>
+                  <button
+                    className="btn run-card-share-btn"
+                    onClick={handleShare}
+                    title="Copy shareable tweet + card link to clipboard"
+                  >
+                    {shareCopied ? '✓ Copied!' : '↗ Share Run'}
+                  </button>
+                  <button
+                    className="btn run-narrative-btn"
+                    onClick={async () => {
+                      setNarrativeLoading(true)
+                      setShowNarrative(true)
+                      setNarrativeText('')
+                      try {
+                        const conceptsList = Array.from(kroUnlocked).join(',')
+                        const res = await fetch(`/api/v1/run-narrative/${ns}/${dungeonName}?concepts=${conceptsList}`, { credentials: 'include' })
+                        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+                        const data = await res.json()
+                        setNarrativeText(data.markdown || '')
+                      } catch (e: any) {
+                        setNarrativeText(`# Error\n\nFailed to generate narrative: ${e?.message ?? 'unknown error'}`)
+                      } finally {
+                        setNarrativeLoading(false)
+                      }
+                    }}
+                    title="Generate a shareable Markdown blog post about this run"
+                  >
+                    Tell the story
+                  </button>
+                </div>
               </div>
             )
           })()}
@@ -2365,6 +2407,56 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
           unlocked={kroUnlocked}
           onClose={() => setShowCertificate(false)}
         />
+      )}
+
+      {/* #460 — Blog post / run narrative modal */}
+      {showNarrative && (
+        <div className="modal-overlay" onClick={() => setShowNarrative(false)}>
+          <div className="modal run-narrative-modal" role="dialog" aria-modal="true" aria-label="Run narrative" onClick={e => e.stopPropagation()}>
+            <h2 style={{ color: 'var(--gold)', fontSize: 11, marginBottom: 8 }}>Tell the story of this run</h2>
+            {narrativeLoading ? (
+              <div style={{ textAlign: 'center', padding: '24px 0', color: 'var(--text-dim)', fontSize: 9 }}>Generating narrative...</div>
+            ) : (
+              <>
+                <textarea
+                  className="run-narrative-textarea"
+                  readOnly
+                  value={narrativeText}
+                  aria-label="Generated Markdown blog post"
+                />
+                <div style={{ display: 'flex', gap: 8, justifyContent: 'center', marginTop: 10, flexWrap: 'wrap' }}>
+                  <button
+                    className="btn btn-gold"
+                    style={{ fontSize: 7 }}
+                    onClick={async () => {
+                      try {
+                        await navigator.clipboard.writeText(narrativeText)
+                        setNarrativeCopied(true)
+                        setTimeout(() => setNarrativeCopied(false), 2500)
+                      } catch {
+                        window.prompt('Copy Markdown:', narrativeText)
+                      }
+                    }}
+                  >
+                    {narrativeCopied ? '✓ Copied!' : 'Copy Markdown'}
+                  </button>
+                  <button
+                    className="btn"
+                    style={{ fontSize: 7 }}
+                    onClick={() => {
+                      const body = encodeURIComponent(narrativeText)
+                      window.open(`https://github.com/kubernetes-sigs/kro/discussions/new?category=show-and-tell&body=${body}`, '_blank', 'noopener')
+                    }}
+                    title="Open a new GitHub Discussion pre-filled with this post"
+                  >
+                    Open in GitHub Discussions
+                  </button>
+                  <button className="btn" style={{ fontSize: 7 }} onClick={() => setShowNarrative(false)}>Close</button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
       )}
 
       {lootDrop && !combatModal && (

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -1500,6 +1500,23 @@ GET /api/v1/run-card/<ns>/<dungeon-name>?concepts=N
     RGD: dungeon-graph (bossCR template)
     CEL: size(schema.spec.monsterHP.filter(hp, hp > 0))`,
   },
+  {
+    title: 'Tell the Story of Your Run',
+    body: "After winning, click \"Tell the story of this run\" on the victory screen. The backend generates a Markdown blog post narrating the key kro events — boss phase transitions, loot drops, room transitions — each with the CEL expression that drove it. Copy to clipboard or open directly in GitHub Discussions.",
+    snippet: `# I played a dungeon RPG on Kubernetes — here's what kro did
+
+> Warrior | Hard difficulty | 42 turns | dungeon: my-dungeon
+
+### 1. The Dungeon CR triggered 16 kro reconciliations
+RGD: dungeon-graph
+CEL: size(schema.spec.monsterHP.filter(hp, hp > 0))
+
+## kro concepts I learned
+- [CEL Expressions](https://kro.run/docs/concepts/cel-expressions)
+- [Resource Graphs](https://kro.run/docs/concepts/resource-graph)
+
+Built with kro — https://github.com/kubernetes-sigs/kro`,
+  },
 ]
 
 export function KroOnboardingOverlay({ onDismiss, isAuthenticated }: { onDismiss: () => void; isAuthenticated: boolean }) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2199,6 +2199,43 @@ body {
 .run-card-share-btn:hover { background: rgba(91,140,245,0.18); }
 .run-card-share-btn:active { background: rgba(91,140,245,0.25); }
 
+/* #460 Blog post / run narrative */
+.run-narrative-btn {
+  font-size: 7px;
+  padding: 4px 12px;
+  border-color: #a855f7;
+  color: #a855f7;
+  background: rgba(168,85,247,0.08);
+  transition: background 0.15s;
+}
+.run-narrative-btn:hover { background: rgba(168,85,247,0.18); }
+.run-narrative-btn:active { background: rgba(168,85,247,0.25); }
+
+.run-narrative-modal {
+  max-width: 680px;
+  width: 96vw;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+.run-narrative-textarea {
+  flex: 1;
+  min-height: 320px;
+  max-height: 50vh;
+  width: 100%;
+  background: #0a0a1a;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-family: 'Courier New', monospace;
+  font-size: 9px;
+  line-height: 1.5;
+  padding: 10px;
+  resize: vertical;
+  box-sizing: border-box;
+}
+.run-narrative-textarea:focus { outline: 1px solid #a855f7; }
+
 /* ── #462 Reconcile Stream tab ──────────────────────────────────────────── */
 .log-tab.reconcile-tab { color: #5dade2; }
 .log-tab.reconcile-tab.active { color: #00d4ff; }

--- a/tests/e2e/journeys/40-blog-post-generator.js
+++ b/tests/e2e/journeys/40-blog-post-generator.js
@@ -1,0 +1,409 @@
+// Journey 40: Blog Post Generator (#460)
+// UI-ONLY: no kubectl, no direct fetch/api, no execSync
+// Tests:
+//   1.  Complete a full dungeon (room 1 + room 2) on easy with warrior
+//   2.  Victory banner appears on room 2 win
+//   3.  "Tell the story of this run" button is present in the victory banner
+//   4.  Clicking the button opens the narrative modal
+//   5.  Narrative modal shows a loading state initially
+//   6.  Narrative modal eventually shows generated Markdown content
+//   7.  Generated Markdown contains hero class
+//   8.  Generated Markdown contains difficulty
+//   9.  Generated Markdown contains dungeon name
+//   10. Generated Markdown contains turn count
+//   11. Generated Markdown contains at least one CEL expression (cel: or ```cel)
+//   12. Generated Markdown contains "kro" (kro brand)
+//   13. Generated Markdown contains "learn-kro.eks.aws.dev" CTA
+//   14. "Copy Markdown" button is present
+//   15. Clicking "Copy Markdown" changes text to "✓ Copied!"
+//   16. "Open in GitHub Discussions" button is present
+//   17. "Close" button dismisses the modal
+//   18. Help modal has "Blog Post Generator" page
+//   19. Intro tour has "Tell the Story" slide
+//   20. Backend /api/v1/run-narrative endpoint returns 200
+//   21. Backend response JSON has "markdown" field
+//   22. Backend markdown contains CEL expression section
+//   23. Backend markdown contains Dungeon CR YAML snippet
+//   24. No JS console errors from narrative code
+const { chromium } = require('playwright');
+const {
+  createDungeonUI, attackMonster, attackBoss, waitForCombatResult,
+  dismissLootPopup, aliveMonsterCount, getBodyText, deleteDungeon, testLogin
+} = require('./helpers');
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const TIMEOUT = 25000;
+let passed = 0, failed = 0, warnings = 0;
+function ok(msg)   { console.log(`  ✅ ${msg}`); passed++; }
+function fail(msg) { console.log(`  ❌ ${msg}`); failed++; }
+function warn(msg) { console.log(`  ⚠️  ${msg}`); warnings++; }
+
+async function clearModals(page) {
+  for (let i = 0; i < 6; i++) {
+    const cb = page.locator('button:has-text("Continue")');
+    if (await cb.count() > 0) { await cb.click({ force: true }).catch(() => {}); await page.waitForTimeout(500); continue; }
+    const gi = page.locator('button:has-text("Got it!")');
+    if (await gi.count() > 0) { await gi.click({ force: true }).catch(() => {}); await page.waitForTimeout(500); continue; }
+    const certClose = page.locator('.kro-cert-overlay');
+    if (await certClose.count() > 0) {
+      await page.evaluate(() => { const el = document.querySelector('.kro-cert-overlay'); if (el) el.click(); }).catch(() => {});
+      await page.waitForTimeout(600);
+      continue;
+    }
+    const narrativeModal = page.locator('.run-narrative-modal');
+    if (await narrativeModal.count() > 0) {
+      const closeBtn = narrativeModal.locator('button:has-text("Close")');
+      if (await closeBtn.count() > 0) { await closeBtn.click({ force: true }).catch(() => {}); await page.waitForTimeout(400); }
+      continue;
+    }
+    break;
+  }
+}
+
+async function run() {
+  console.log('Journey 40: Blog Post Generator\n');
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const dName = `j40-${Date.now()}`;
+  const consoleErrors = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR'))
+      consoleErrors.push(msg.text());
+  });
+
+  try {
+    // === Setup ===
+    await testLogin(page, BASE_URL);
+    await page.goto(BASE_URL, { timeout: TIMEOUT });
+    await page.waitForTimeout(2000);
+
+    // === 1: Create dungeon (1 monster, easy) ===
+    console.log('=== Step 1: Create dungeon ===');
+    const created = await createDungeonUI(page, dName, { monsters: 1, difficulty: 'easy', heroClass: 'warrior' });
+    created ? ok('Dungeon created') : fail('Dungeon did not load');
+
+    // === 2: Clear room 1 — monsters ===
+    console.log('\n=== Step 2: Clear room 1 ===');
+    for (let i = 0; i < 40; i++) {
+      await clearModals(page);
+      const alive = await aliveMonsterCount(page);
+      if (alive === 0) break;
+      const btn = page.locator('.arena-entity.monster-entity:not(.dead) .arena-atk-btn.btn-primary');
+      if (await btn.count() === 0) break;
+      await btn.first().click({ force: true }).catch(() => {});
+      await page.waitForTimeout(2500);
+    }
+    await clearModals(page);
+    const aliveAfterMonsters = await aliveMonsterCount(page);
+    aliveAfterMonsters === 0 ? ok('Room 1 monster killed') : fail(`Room 1 monster still alive (${aliveAfterMonsters})`);
+
+    // Kill room 1 boss
+    for (let i = 0; i < 60; i++) {
+      await clearModals(page);
+      const bossBtn = page.locator('.arena-entity.boss-entity .arena-atk-btn.btn-primary');
+      if (await bossBtn.count() === 0) break;
+      await bossBtn.click({ force: true }).catch(() => {});
+      await page.waitForTimeout(2500);
+    }
+    await clearModals(page);
+    await page.waitForTimeout(5000);
+    await clearModals(page);
+
+    // Enter room 2
+    await page.waitForSelector('[aria-label="Enter Room 2"]', { timeout: 10000 }).catch(() => {});
+    const treasureBtn = page.locator('button:has-text("Open Treasure")');
+    if (await treasureBtn.count() > 0) {
+      await treasureBtn.click({ force: true }).catch(() => {});
+      await page.waitForTimeout(1500);
+      await clearModals(page);
+    }
+    await page.waitForTimeout(4000);
+    await clearModals(page);
+
+    let r2Loaded = false;
+    for (let attempt = 0; attempt < 5 && !r2Loaded; attempt++) {
+      if (attempt > 0) await page.waitForTimeout(3000);
+      await page.evaluate(() => {
+        const door = document.querySelector('[role="button"][aria-label="Enter Room 2"], .arena-entity.door-entity');
+        if (door) door.click();
+      }).catch(() => {});
+      for (let i = 0; i < 20; i++) {
+        const atkButtons = await page.locator('.arena-atk-btn.btn-primary').count();
+        const doorGone = await page.locator('[aria-label="Enter Room 2"]').count() === 0;
+        if (atkButtons > 0 && doorGone) { r2Loaded = true; break; }
+        await page.waitForTimeout(2000);
+      }
+    }
+    r2Loaded ? ok('Entered room 2') : warn('Room 2 entry uncertain — continuing');
+
+    // === 3: Clear room 2 ===
+    console.log('\n=== Step 3: Clear room 2 ===');
+    for (let i = 0; i < 60; i++) {
+      await clearModals(page);
+      const alive2 = await aliveMonsterCount(page);
+      if (alive2 === 0) break;
+      const btn2 = page.locator('.arena-entity.monster-entity:not(.dead) .arena-atk-btn.btn-primary');
+      if (await btn2.count() === 0) break;
+      await btn2.first().click({ force: true }).catch(() => {});
+      await page.waitForTimeout(2500);
+    }
+    await clearModals(page);
+
+    for (let i = 0; i < 80; i++) {
+      await clearModals(page);
+      const victoryBannerPresent = await page.locator('.victory-banner').count() > 0;
+      if (victoryBannerPresent) break;
+      const boss2Btn = page.locator('.arena-entity.boss-entity .arena-atk-btn.btn-primary');
+      if (await boss2Btn.count() === 0) break;
+      await boss2Btn.click({ force: true }).catch(() => {});
+      await page.waitForTimeout(2500);
+    }
+    await clearModals(page);
+
+    await page.waitForSelector('.victory-banner', { timeout: 20000 }).catch(() => {});
+    const hasVictory = await page.locator('.victory-banner').count() > 0;
+    hasVictory ? ok('Victory banner visible') : fail('Victory banner not visible after clearing room 2');
+    await page.waitForTimeout(2000);
+
+    // === 4: "Tell the story" button ===
+    console.log('\n=== Step 4: Tell the story button ===');
+
+    // Dismiss cert modal first
+    await page.waitForTimeout(500);
+    for (let i = 0; i < 5; i++) {
+      const certOverlay = page.locator('.kro-cert-overlay');
+      if (await certOverlay.count() === 0) break;
+      await page.evaluate(() => { const el = document.querySelector('.kro-cert-overlay'); if (el) el.click(); }).catch(() => {});
+      await page.waitForTimeout(700);
+    }
+
+    const storyBtn = page.locator('button.run-narrative-btn');
+    const storyBtnCount = await storyBtn.count();
+    storyBtnCount > 0 ? ok('"Tell the story of this run" button present') : fail('"Tell the story" button not found (.run-narrative-btn)');
+
+    // === 5–13: Click the button and check the modal ===
+    console.log('\n=== Step 5: Narrative modal ===');
+    let narrativeMarkdown = '';
+    if (storyBtnCount > 0) {
+      await storyBtn.first().click({ force: true }).catch(() => {});
+      await page.waitForTimeout(500);
+
+      // Modal should appear
+      const modalAppeared = await page.locator('.run-narrative-modal').count() > 0;
+      modalAppeared ? ok('Narrative modal opened') : fail('Narrative modal not found (.run-narrative-modal)');
+
+      // Wait for loading to finish (up to 15s)
+      await page.waitForTimeout(1000);
+      for (let i = 0; i < 14; i++) {
+        const loading = await page.locator('.run-narrative-modal').getByText('Generating narrative...').count();
+        if (loading === 0) break;
+        await page.waitForTimeout(1000);
+      }
+
+      // Read the textarea
+      const textarea = page.locator('.run-narrative-textarea');
+      const textareaCount = await textarea.count();
+      textareaCount > 0 ? ok('Narrative textarea rendered') : fail('Narrative textarea not found (.run-narrative-textarea)');
+
+      if (textareaCount > 0) {
+        narrativeMarkdown = await textarea.inputValue().catch(() => '');
+        narrativeMarkdown.length > 100 ? ok(`Generated Markdown has content (${narrativeMarkdown.length} chars)`) : fail('Generated Markdown is too short or empty');
+
+        // Content checks
+        const lowerMd = narrativeMarkdown.toLowerCase();
+        lowerMd.includes('warrior') ? ok('Markdown contains hero class (warrior)') : fail('Markdown missing hero class');
+        lowerMd.includes('easy') ? ok('Markdown contains difficulty (easy)') : fail('Markdown missing difficulty');
+        narrativeMarkdown.includes(dName.substring(0, 10)) ? ok(`Markdown contains dungeon name fragment`) : warn(`Markdown may have truncated dungeon name`);
+        // Turn count — may be 0 if game was very fast
+        (narrativeMarkdown.includes('turns') || narrativeMarkdown.includes('turn')) ? ok('Markdown contains "turns"') : fail('Markdown missing turn count');
+        (narrativeMarkdown.includes('```cel') || narrativeMarkdown.includes('CEL') || narrativeMarkdown.includes('cel:')) ? ok('Markdown contains CEL expression section') : fail('Markdown missing CEL expressions');
+        narrativeMarkdown.includes('kro') ? ok('Markdown contains "kro" branding') : fail('Markdown missing "kro" brand');
+        narrativeMarkdown.includes('learn-kro.eks.aws.dev') ? ok('Markdown contains learn-kro.eks.aws.dev CTA') : fail('Markdown missing learn-kro.eks.aws.dev');
+      }
+
+      // === 14–16: Action buttons ===
+      console.log('\n=== Step 6: Modal action buttons ===');
+      const copyBtn = page.locator('.run-narrative-modal button:has-text("Copy Markdown")');
+      const copyBtnCount = await copyBtn.count();
+      copyBtnCount > 0 ? ok('"Copy Markdown" button present') : fail('"Copy Markdown" button not found');
+
+      if (copyBtnCount > 0) {
+        const ctx = browser.contexts()[0];
+        await ctx.grantPermissions(['clipboard-write']);
+        await copyBtn.first().click({ force: true }).catch(() => {});
+        await page.waitForTimeout(500);
+        const btnText = await copyBtn.first().textContent().catch(() => '');
+        btnText && btnText.includes('Copied') ? ok('"Copy Markdown" changes to "✓ Copied!"') : warn(`Copy button text: "${btnText}" (clipboard may be restricted)`);
+      }
+
+      const ghBtn = page.locator('.run-narrative-modal button:has-text("Open in GitHub Discussions")');
+      const ghBtnCount = await ghBtn.count();
+      ghBtnCount > 0 ? ok('"Open in GitHub Discussions" button present') : fail('"Open in GitHub Discussions" button not found');
+
+      // Close the modal
+      const closeBtn = page.locator('.run-narrative-modal button:has-text("Close")');
+      if (await closeBtn.count() > 0) {
+        await closeBtn.first().click({ force: true }).catch(() => {});
+        await page.waitForTimeout(400);
+        const modalGone = await page.locator('.run-narrative-modal').count() === 0;
+        modalGone ? ok('Narrative modal closed on Close button') : fail('Narrative modal still visible after Close');
+      } else {
+        fail('"Close" button not found in narrative modal');
+      }
+    } else {
+      // Skip modal tests if button wasn't found
+      for (let i = 0; i < 8; i++) { fail('Skipped (story button not found)'); }
+    }
+
+    // === Backend API check ===
+    console.log('\n=== Step 7: Backend API ===');
+    // Use the page's fetch (authenticated via session cookie)
+    const apiResult = await page.evaluate(async (dungeonName) => {
+      try {
+        const r = await fetch(`/api/v1/run-narrative/dungeon-${dungeonName}/${dungeonName}?concepts=resource-graph,cel-expressions`, { credentials: 'include' });
+        if (r.status === 404) {
+          // Try without namespace prefix (depends on dungeon creation)
+          const r2 = await fetch(`/api/v1/run-narrative/${dungeonName}/${dungeonName}?concepts=resource-graph`, { credentials: 'include' });
+          return { status: r2.status, body: await r2.text().catch(() => '') };
+        }
+        return { status: r.status, body: await r.text().catch(() => '') };
+      } catch (e) {
+        return { status: 0, body: '' };
+      }
+    }, dName);
+    // The dungeon namespace follows the pattern dungeon-{name} (from dungeon-graph.yaml)
+    // or same as name — the exact ns depends on dungeon-graph CR creation
+    // We check the endpoint via the page which has the correct session cookie
+    // but we don't know the exact namespace — use the /api/v1/dungeons list instead
+    const listResult = await page.evaluate(async () => {
+      try {
+        const r = await fetch('/api/v1/dungeons', { credentials: 'include' });
+        return { status: r.status, body: await r.text().catch(() => '') };
+      } catch (e) {
+        return { status: 0, body: '' };
+      }
+    });
+
+    let narrativeNs = '';
+    let narrativeName = dName;
+    if (listResult.status === 200) {
+      try {
+        const dungeons = JSON.parse(listResult.body);
+        const items = (dungeons.items || []);
+        const match = items.find(d => d.metadata && d.metadata.name === dName);
+        if (match) {
+          narrativeNs = match.metadata.namespace || '';
+          narrativeName = match.metadata.name || dName;
+        }
+      } catch (e) {}
+    }
+
+    if (narrativeNs) {
+      const narrativeResult = await page.evaluate(async ({ ns, name }) => {
+        try {
+          const r = await fetch(`/api/v1/run-narrative/${ns}/${name}?concepts=resource-graph,cel-expressions,reconcile-loop`, { credentials: 'include' });
+          return { status: r.status, contentType: r.headers.get('content-type') || '', body: await r.text().catch(() => '') };
+        } catch (e) {
+          return { status: 0, contentType: '', body: '' };
+        }
+      }, { ns: narrativeNs, name: narrativeName });
+
+      narrativeResult.status === 200 ? ok(`Backend /api/v1/run-narrative returns 200`) : fail(`Backend returned ${narrativeResult.status}`);
+
+      if (narrativeResult.status === 200) {
+        try {
+          const parsed = JSON.parse(narrativeResult.body);
+          typeof parsed.markdown === 'string' ? ok('Response JSON has "markdown" field') : fail('Response JSON missing "markdown" field');
+          if (typeof parsed.markdown === 'string') {
+            (parsed.markdown.includes('```cel') || parsed.markdown.includes('CEL')) ? ok('Backend markdown contains CEL expression section') : fail('Backend markdown missing CEL expressions');
+            parsed.markdown.includes('```yaml') ? ok('Backend markdown contains YAML snippet') : fail('Backend markdown missing YAML snippet');
+          }
+        } catch (e) {
+          fail(`Backend response is not valid JSON: ${e.message}`);
+        }
+      }
+    } else {
+      warn('Could not determine dungeon namespace — skipping backend API checks');
+      warn('Skipped: backend /api/v1/run-narrative status');
+      warn('Skipped: Response JSON has "markdown" field');
+      warn('Skipped: backend markdown CEL expressions');
+      warn('Skipped: backend markdown YAML snippet');
+    }
+
+    // === Help modal check ===
+    console.log('\n=== Step 8: Help modal ===');
+    for (let i = 0; i < 5; i++) {
+      const certOverlay = page.locator('.kro-cert-overlay');
+      if (await certOverlay.count() === 0) break;
+      await page.evaluate(() => { const el = document.querySelector('.kro-cert-overlay'); if (el) el.click(); }).catch(() => {});
+      await page.waitForTimeout(700);
+    }
+    const helpBtn = page.locator('button.help-btn').first();
+    if (await helpBtn.count() > 0) {
+      await helpBtn.click({ force: true }).catch(() => {});
+      await page.waitForTimeout(800);
+      let foundBlogPage = false;
+      for (let p = 0; p < 16; p++) {
+        const helpBody = await page.textContent('.help-modal').catch(() => '');
+        if (helpBody.includes('Blog Post') || helpBody.includes('Tell the story') || helpBody.includes('narrative')) { foundBlogPage = true; break; }
+        const nextBtn = page.locator('.help-nav button').filter({ hasText: /Next/ }).first();
+        const isDisabled = await nextBtn.isDisabled().catch(() => true);
+        if (isDisabled) break;
+        await nextBtn.click({ force: true }).catch(() => {});
+        await page.waitForTimeout(400);
+      }
+      foundBlogPage ? ok('Help modal has "Blog Post Generator" page') : fail('Help modal missing Blog Post Generator page');
+      const closeHelpBtn = page.locator('.help-nav button').filter({ hasText: 'Close' }).first();
+      await closeHelpBtn.click({ force: true }).catch(() => {});
+      await page.waitForTimeout(300);
+    } else {
+      fail('Help button not found');
+    }
+
+    // === Intro tour check ===
+    console.log('\n=== Step 9: Intro tour ===');
+    await page.evaluate(() => localStorage.removeItem('kroOnboardingDone'));
+    await page.reload({ waitUntil: 'networkidle', timeout: 20000 }).catch(() => {});
+    await page.waitForTimeout(2000);
+    await testLogin(page, BASE_URL);
+    await page.goto(BASE_URL, { timeout: TIMEOUT });
+    await page.waitForTimeout(2000);
+
+    const onboardingVisible = await page.locator('.kro-onboard-overlay').count() > 0;
+    if (onboardingVisible) {
+      let tourFound = false;
+      for (let p = 0; p < 12; p++) {
+        const tourBody = await page.textContent('.kro-onboard-modal').catch(() => '');
+        if (tourBody.includes('Tell the story') || tourBody.includes('blog') || tourBody.includes('narrative') || tourBody.includes('Blog Post')) { tourFound = true; break; }
+        const nextBtn = page.locator('.kro-onboard-modal button:has-text("Next")');
+        if (await nextBtn.count() === 0) break;
+        await nextBtn.click({ force: true }).catch(() => {});
+        await page.waitForTimeout(300);
+      }
+      tourFound ? ok('Intro tour has "Tell the story" slide') : fail('Intro tour missing "Tell the story" slide');
+      const skipBtn = page.locator('button.kro-onboard-skip');
+      await skipBtn.click({ force: true }).catch(() => {});
+      await page.waitForTimeout(400);
+    } else {
+      warn('Onboarding overlay not shown after localStorage clear — skipping intro tour check');
+    }
+
+    // No JS errors
+    console.log('\n=== Step 10: Console errors ===');
+    if (consoleErrors.length === 0) {
+      ok('No JS console errors');
+    } else {
+      fail(`JS console errors: ${consoleErrors.slice(0, 3).join('; ')}`);
+    }
+
+  } catch (err) {
+    fail(`Unexpected error: ${err.message}`);
+  } finally {
+    await browser.close();
+  }
+
+  console.log(`\n--- Journey 40: ${passed} passed, ${failed} failed, ${warnings} warnings ---`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch(err => { console.error(err); process.exit(1); });

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -938,6 +938,63 @@ grep -q 'Reconcile Stream' frontend/src/KroTeach.tsx \
   && pass "#462: tests/e2e/journeys/39-reconcile-stream.js exists" \
   || fail "#462: tests/e2e/journeys/39-reconcile-stream.js missing"
 
+# ─── #460 Blog Post Generator guardrails ─────────────────────────────────────
+
+# RunNarrative handler must exist in handlers.go
+grep -q 'func (h \*Handler) RunNarrative' backend/internal/handlers/handlers.go \
+  && pass "#460: RunNarrative handler exists in handlers.go" \
+  || fail "#460: RunNarrative handler missing from handlers.go"
+
+# run-narrative route must be registered in main.go
+grep -q 'GET /api/v1/run-narrative/' backend/cmd/main.go \
+  && pass "#460: GET /api/v1/run-narrative route registered in main.go" \
+  || fail "#460: GET /api/v1/run-narrative route missing from main.go"
+
+# RunNarrative must return application/json Content-Type
+grep -q '"application/json"' backend/internal/handlers/handlers.go \
+  && pass "#460: handlers.go uses application/json (RunNarrative)" \
+  || fail "#460: handlers.go missing application/json"
+
+# Frontend must have run-narrative-btn
+grep -q 'run-narrative-btn' frontend/src/App.tsx \
+  && pass "#460: run-narrative-btn in App.tsx" \
+  || fail "#460: run-narrative-btn missing from App.tsx"
+
+# Frontend must have run-narrative-modal
+grep -q 'run-narrative-modal' frontend/src/App.tsx \
+  && pass "#460: run-narrative-modal in App.tsx" \
+  || fail "#460: run-narrative-modal missing from App.tsx"
+
+# Frontend must have Copy Markdown button
+grep -q 'Copy Markdown' frontend/src/App.tsx \
+  && pass "#460: Copy Markdown button in App.tsx" \
+  || fail "#460: Copy Markdown button missing from App.tsx"
+
+# Frontend must have Open in GitHub Discussions button
+grep -q 'Open in GitHub Discussions' frontend/src/App.tsx \
+  && pass "#460: Open in GitHub Discussions button in App.tsx" \
+  || fail "#460: Open in GitHub Discussions button missing from App.tsx"
+
+# CSS must have run-narrative styles
+grep -q 'run-narrative-modal\|run-narrative-btn\|run-narrative-textarea' frontend/src/index.css \
+  && pass "#460: run-narrative CSS styles in index.css" \
+  || fail "#460: run-narrative CSS styles missing from index.css"
+
+# Help modal must document Blog Post Generator
+grep -q 'Blog Post Generator\|Tell the story\|run narrative\|run-narrative' frontend/src/App.tsx \
+  && pass "#460: Help modal documents Blog Post Generator" \
+  || fail "#460: Help modal missing Blog Post Generator documentation"
+
+# Intro tour must have Tell the story slide
+grep -q 'Tell the story\|Tell the Story\|blog.*post\|Blog Post' frontend/src/KroTeach.tsx \
+  && pass "#460: KroTeach.tsx intro tour has Tell the story slide" \
+  || fail "#460: KroTeach.tsx missing Tell the story intro slide"
+
+# Journey 40 must exist
+[ -f "tests/e2e/journeys/40-blog-post-generator.js" ] \
+  && pass "#460: tests/e2e/journeys/40-blog-post-generator.js exists" \
+  || fail "#460: tests/e2e/journeys/40-blog-post-generator.js missing"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
Closes #460

## Summary

- **Backend**: New `GET /api/v1/run-narrative/{namespace}/{name}` endpoint — assembles a shareable Markdown blog post from the dungeon spec. Narrates 4–6 key kro events (dungeon creation, hero stat computation, modifier, boss phases, room 2 transition, loot drop), each with the responsible CEL expression and RGD name. Lists unlocked kro concepts with links to kro docs. Includes full Dungeon CR YAML snippet. Closes with a CTA to `learn-kro.eks.aws.dev` and the kro GitHub repo. Authenticated + ownership-checked.
- **Frontend**: "Tell the story of this run" button added to victory banner (next to ↗ Share Run). Clicking fetches the narrative and opens a modal with a read-only textarea showing the Markdown. Two action buttons: "Copy Markdown" (clipboard) and "Open in GitHub Discussions" (pre-fills `kubernetes-sigs/kro` show-and-tell via `?body=` URL param).
- **Help modal**: New "Blog Post Generator" page (page 13).
- **Onboarding**: New 9th slide "Tell the Story of Your Run" showing a sample post snippet.
- **Guardrails**: 11 new guardrail checks for #460 in `tests/guardrails.sh`.
- **Journey 40**: New `tests/e2e/journeys/40-blog-post-generator.js` — 24 tests covering button presence, modal open/close, Markdown content checks, Copy Markdown feedback, GitHub Discussions button, backend API response shape, help modal page, and intro tour slide.

## Files changed

- `backend/internal/handlers/handlers.go` — `RunNarrative` handler (~150 lines)
- `backend/cmd/main.go` — route registration
- `frontend/src/App.tsx` — button, modal, state
- `frontend/src/KroTeach.tsx` — 9th onboarding slide
- `frontend/src/index.css` — `.run-narrative-btn`, `.run-narrative-modal`, `.run-narrative-textarea`
- `tests/guardrails.sh` — 11 new #460 guardrails
- `tests/e2e/journeys/40-blog-post-generator.js` — new journey (24 tests)