### PR TITLE
fix: escape hyphen in DNS label pattern attribute

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -976,7 +976,7 @@ function CreateForm({ onCreate }: { onCreate: (n: string, m: number, d: string, 
           onChange={e => setName(e.target.value)}
           placeholder="my-dungeon"
           maxLength={63}
-          pattern="[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?"
+          pattern="[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?"
         />
         {!nameValid && <div className="input-error">Name: lowercase letters, numbers, hyphens only. Max 63 chars. Must start and end with alphanumeric.</div>}
       </div>


### PR DESCRIPTION
## Summary

Fixes a console error on dungeon creation form:

> Pattern attribute value \`[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\` is not a valid regular expression: Uncaught SyntaxError: Invalid regular expression: /[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?/v: Invalid character class

Chrome 112+ uses the Unicode sets (`v`) flag when validating `pattern` attributes, which is stricter than `u` mode. In `v` mode, an unescaped `-` between characters in a class (`[a-z0-9-]`) is interpreted as a range operator between `0` and `-`, which is invalid since `-` (U+002D) sorts before `0` (U+0030).

**Fix:** escape the hyphen as `\-` in the HTML `pattern` attribute string (`[a-z0-9\-]`). The JS regex on line 966 (`/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/`) is unaffected — JS regex literals do not use the `v` flag by default.