### PR TITLE
fix: cert toast repeat and stun missing enemy counter-attack in log

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -1743,13 +1743,13 @@ func deriveCombatLog(
 	var notes []string
 
 	if wasStunned {
-		// Hero was stunned: no damage dealt
+		// Hero was stunned: no damage dealt, but enemies still counter-attack.
+		// Set heroAction and fall through to compute enemyAction from pre→post HP diff.
 		if diceFormula != "" {
 			heroAction = fmt.Sprintf("[%s] Hero STUNNED! — no attack this turn", diceFormula)
 		} else {
 			heroAction = "Hero STUNNED! — no attack this turn"
 		}
-		return heroAction, "Hero was stunned this turn."
 	}
 
 	// Compute effective damage from spec diff
@@ -1817,8 +1817,10 @@ func deriveCombatLog(
 	if diceFormula != "" {
 		formulaStr = fmt.Sprintf("[%s] ", diceFormula)
 	}
-	heroAction = fmt.Sprintf("%sHero (%s) deals %d damage to %s (HP: %d -> %d)%s",
-		formulaStr, heroClass, effectiveDamage, realTarget, oldHP, newHP, noteStr)
+	if !wasStunned {
+		heroAction = fmt.Sprintf("%sHero (%s) deals %d damage to %s (HP: %d -> %d)%s",
+			formulaStr, heroClass, effectiveDamage, realTarget, oldHP, newHP, noteStr)
+	}
 
 	// --- Enemy action ---
 	heroDmgTaken := preHeroHP - postHeroHP

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -174,6 +174,9 @@ export default function App() {
   const reconcileCycleCountRef = useRef(0)
   const reconcileWasActiveRef = useRef(false)
   const celTraceSeenRef = useRef(false)
+  // Track certs that have already been triggered this session to prevent repeat toasts
+  // (insightDismissCountRef keeps incrementing past the threshold on each dismiss)
+  const certTriggeredThisSessionRef = useRef<Set<string>>(new Set())
 
   const triggerInsight = useCallback((event: string) => {
     const trigger = getInsightForEvent(event)
@@ -187,16 +190,16 @@ export default function App() {
 
   // Tier 2 certificate trigger (#361) — called from UI interaction callbacks
   const handleCertTrigger = useCallback(async (certId: string) => {
-    if (profile?.kroCertificates?.includes(certId)) return // already earned
+    if (profile?.kroCertificates?.includes(certId)) return // already earned (persisted)
+    if (certTriggeredThisSessionRef.current.has(certId)) return // already triggered this session
+    certTriggeredThisSessionRef.current.add(certId)
     const updated = await awardCert(certId)
     if (!updated) return
     setProfile(prev => prev ? { ...prev, kroCertificates: updated } : prev)
-    if (!profile?.kroCertificates?.includes(certId)) {
-      // Show toast
-      if (certToastTimerRef.current) clearTimeout(certToastTimerRef.current)
-      setCertToast(certId)
-      certToastTimerRef.current = setTimeout(() => setCertToast(null), 4000)
-    }
+    // Show toast
+    if (certToastTimerRef.current) clearTimeout(certToastTimerRef.current)
+    setCertToast(certId)
+    certToastTimerRef.current = setTimeout(() => setCertToast(null), 4000)
   }, [profile])
 
   // Auto-surface CEL Playground once the player is engaged (10+ concepts unlocked)


### PR DESCRIPTION
## Summary

Two bugs fixed.

**1. "Insight Reader" cert toast repeating within the same dungeon run**

`insightDismissCountRef` keeps incrementing past the threshold (3) on every subsequent InsightCard dismissal. The 4th, 5th... dismissals each call `handleCertTrigger('insight-card')` again. The existing `profile?.kroCertificates?.includes(certId)` guard failed to stop this because `profile` in the `useCallback` closure is stale between renders.

Fix: added `certTriggeredThisSessionRef` (a `Set<string>`) that records which certs have already been triggered in this session. `handleCertTrigger` now returns immediately if the cert is already in the set, before even calling the API. Simplified the toast logic — the redundant second `includes` check was removed since the guard at the top now reliably covers both cases.

**2. STUNNED turn: enemy counter-attack not shown in combat log**

`deriveCombatLog` early-returned with `"Hero was stunned this turn."` as the enemy action, skipping the entire enemy action derivation block. This meant the log showed no counter-attack damage even though kro CEL correctly computed and applied it (the hero's HP did decrease).

Fix: removed the early return. The stun branch now sets `heroAction` and falls through to the normal enemy action derivation. Added a `!wasStunned` guard around the `heroAction = fmt.Sprintf(...)` damage string at the end of the hero section so the stun message is not overwritten.