### PR TITLE
fix: regression audit — 30d retention UI, /27 concepts, lastLootDrop clear, enter-room-2 attack cleanup

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -2004,8 +2004,9 @@ func (h *Handler) processAction(ctx context.Context, r *http.Request, ns, name, 
 	}
 
 	patchSpec := map[string]interface{}{
-		"actionSeq":  newSeq,
-		"lastAction": action, // trigger field for kro's actionResolve specPatch
+		"actionSeq":    newSeq,
+		"lastAction":   action, // trigger field for kro's actionResolve specPatch
+		"lastLootDrop": "",     // clear stale loot from previous combat turn (#AGENTS rule)
 	}
 
 	// MIGRATION: state mutations (inventory, heroHP, heroMana, equipment bonuses,
@@ -2186,6 +2187,10 @@ func (h *Handler) processAction(ctx context.Context, r *http.Request, ns, name, 
 		patchSpec["lastEnemyAction"] = ""
 		// Award XP for entering room 2 (#360)
 		patchSpec["xpEarned"] = getInt(spec, "xpEarned") + int64(10)
+		// Delete stale Room 1 Attack CR so it cannot be re-processed in Room 2 (#AGENTS rule)
+		attackCRName := name + "-latest-attack"
+		_ = h.client.Dynamic.Resource(k8s.AttackGVR).Namespace("default").Delete(
+			ctx, attackCRName, metav1.DeleteOptions{})
 		// Business metric: room 2 entered (Issue #358)
 		attackSeqAction := getInt(spec, "attackSeq")
 		slog.Info("room2_entered",
@@ -2770,8 +2775,8 @@ func (h *Handler) RunCard(w http.ResponseWriter, r *http.Request) {
 	if conceptsUnlocked < 0 {
 		conceptsUnlocked = 0
 	}
-	if conceptsUnlocked > 24 {
-		conceptsUnlocked = 24
+	if conceptsUnlocked > 27 {
+		conceptsUnlocked = 27
 	}
 
 	// Sanitise name for display (truncate at 28 chars)
@@ -2807,7 +2812,7 @@ func (h *Handler) RunCard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// kro concept bar (0-24)
-	const totalConcepts = 24
+	const totalConcepts = 27
 	conceptBarWidth := int(float64(conceptsUnlocked) / float64(totalConcepts) * 220)
 
 	svg := fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" width="480" height="270" viewBox="0 0 480 270">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -862,7 +862,7 @@ export default function App() {
           <DungeonList dungeons={dungeons} onSelect={handleSelect} onDelete={handleDelete} deleting={deleting} lastDungeon={resumePrompt ?? undefined} />
           {authUser && (
             <div style={{ textAlign: 'center', marginTop: 8, fontSize: '7px', color: 'var(--text-dim)' }}>
-              Your dungeon data is kept for 4 hours.
+              Your dungeon data is kept for 30 days.
             </div>
           )}
         </>
@@ -2328,7 +2328,7 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
             const ns = cr.metadata.namespace ?? 'default'
             const cardUrl = `/api/v1/run-card/${ns}/${dungeonName}?concepts=${kroUnlocked.size}`
             const absoluteCardUrl = `https://learn-kro.eks.aws.dev${cardUrl}`
-            const tweetText = `I just conquered a dungeon in @kroio powered by kro on Kubernetes! 🗡️ Hero: ${spec.heroClass ?? 'warrior'} | Difficulty: ${spec.difficulty ?? 'normal'} | Turns: ${spec.attackSeq ?? 0} | kro concepts unlocked: ${kroUnlocked.size}/24\n\nPlay it yourself: https://learn-kro.eks.aws.dev`
+            const tweetText = `I just conquered a dungeon in @kroio powered by kro on Kubernetes! 🗡️ Hero: ${spec.heroClass ?? 'warrior'} | Difficulty: ${spec.difficulty ?? 'normal'} | Turns: ${spec.attackSeq ?? 0} | kro concepts unlocked: ${kroUnlocked.size}/27\n\nPlay it yourself: https://learn-kro.eks.aws.dev`
             const handleShare = async () => {
               try {
                 await navigator.clipboard.writeText(`${tweetText}\n\n${absoluteCardUrl}`)

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -995,6 +995,12 @@ grep -q 'Tell the story\|Tell the Story\|blog.*post\|Blog Post' frontend/src/Kro
   && pass "#460: tests/e2e/journeys/40-blog-post-generator.js exists" \
   || fail "#460: tests/e2e/journeys/40-blog-post-generator.js missing"
 
+# --- Data retention UI text (#477) ---
+echo "=== Data retention UI text"
+grep -q "30 days" frontend/src/App.tsx \
+  && pass "#477: UI says dungeon data kept for 30 days" \
+  || fail "#477: UI still says '4 hours' instead of '30 days' — update App.tsx retention string"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

Regression audit found 5 issues introduced by recent PRs. All fixed:

**1. `frontend/src/App.tsx` — "30 days" retention text (regression from PR #513)**
- Line 865: `"Your dungeon data is kept for 4 hours."` → `"30 days."` 
- PR #477 fixed this to 30 days. PR #513 issue #488 accidentally reverted it back to 4 hours.

**2. `frontend/src/App.tsx` — Tweet share text `/24` → `/27`**
- `kroUnlocked.size/24` → `/27` in share tweet text
- PR #516 added 3 concepts (total 27). Tweet text was not updated.

**3. `backend/internal/handlers/handlers.go` — RunCard concept cap 24 → 27**
- Cap and `totalConcepts` constant updated to 27 to match new concept count

**4. `backend/internal/handlers/handlers.go` — `lastLootDrop: ""` in `processAction`**
- Per AGENTS.md: "lastLootDrop must be cleared by ALL non-combat patches"
- `processAction` (use-item, equip, open-treasure, unlock-door, enter-room-2) was missing this clear

**5. `backend/internal/handlers/handlers.go` — Delete stale Attack CR on `enter-room-2`**
- Per AGENTS.md: "enter-room-2 action must delete stale Attack CRs"
- Stale Room 1 Attack CRs could be re-processed after room transition

**6. `tests/guardrails.sh` — New guardrail for #477 retention text**
- Prevents future regressions of the 30-day retention string