### PR TITLE
fix: mana potion disabled for non-mage; test cleanup scoped to test user

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2838,10 +2838,11 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
                       {items.map((item, i) => {
                         const rarity = item.split('-').pop()!
                         const isPotion = item.includes('potion')
+                        const isManaPotion = item.includes('manapotion')
                         const desc =                           item.includes('weapon') ? `Weapon (${rarity}) — click to equip, +damage for 3 attacks` :
                           item.includes('armor') ? `Armor (${rarity}) — click to equip, +defense for dungeon` :
                           item.includes('hppotion') ? `HP Potion (${rarity}) — click to restore HP` :
-                          item.includes('manapotion') ? `Mana Potion (${rarity}) — click to restore mana` :
+                          isManaPotion ? (heroClass === 'mage' ? `Mana Potion (${rarity}) — click to restore mana` : `Mana Potion (${rarity}) — Mage only`) :
                           item.includes('helmet') ? `Helmet (${rarity}) — click to equip, +crit chance` :
                           item.includes('pants') ? `Pants (${rarity}) — click to equip, +dodge chance` :
                           item.includes('boots') ? `Boots (${rarity}) — click to equip, +status resist` :
@@ -2849,7 +2850,7 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
                           item.includes('amulet') ? `Amulet (${rarity}) — click to equip, +% damage boost` : item
                         return (
                           <Tooltip key={i} text={desc}>
-                            <button className="backpack-slot" disabled={gameOver || !!attackPhase}
+                            <button className="backpack-slot" disabled={gameOver || !!attackPhase || (isManaPotion && heroClass !== 'mage')}
                               style={{ borderColor: RARITY_COLOR[rarity] || '#555' }}
                               onClick={() => onAttack(isPotion ? `use-${item}` : `equip-${item}`, 0)}>
                               <ItemSprite id={item} size={22} />

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -54,10 +54,18 @@ wait_group "Abilities"      $PID_ABILITIES /tmp/test-abilities.log
 wait_group "Features"       $PID_FEATURES /tmp/test-features.log
 wait_group "Infra"          $PID_INFRA /tmp/test-infra.log
 
-# Cleanup all test dungeons
+# Cleanup test dungeons only — scope to the test user's owner label.
+# NEVER delete user dungeons owned by real GitHub logins.
 echo "=== Cleanup ==="
 kctl delete attacks --all --ignore-not-found --wait=false 2>/dev/null || true
-kctl delete dungeons --all --ignore-not-found --wait=false 2>/dev/null || true
+_CLEANUP_USER="$(kubectl --context "${KUBECTL_CONTEXT:-arn:aws:eks:us-west-2:319279230668:cluster/krombat}" \
+  get secret krombat-test-auth -n rpg-system \
+  -o jsonpath='{.data.KROMBAT_TEST_USER}' 2>/dev/null | base64 -d || true)"
+if [ -n "$_CLEANUP_USER" ]; then
+  kctl delete dungeons -l "krombat.io/owner=${_CLEANUP_USER}" --ignore-not-found --wait=false 2>/dev/null || true
+else
+  echo "  Warning: could not resolve test user — skipping dungeon cleanup to protect user data"
+fi
 
 # Count totals
 TOTAL_PASS=$(grep -rh "^  PASS:" /tmp/test-*.log 2>/dev/null | wc -l | tr -d ' ')


### PR DESCRIPTION
## Summary

Two fixes.

**1. Mana potion unusable for non-mage (`App.tsx`)**

Warriors and rogues could click mana potions in the backpack, triggering a `POST /attacks 400 Bad Request` with no visible error message (the console logged the error but the UI showed nothing useful to the player).

Fix: in the backpack render, mana potion buttons are now `disabled` when `heroClass !== 'mage'`. The tooltip changes from "click to restore mana" to "Mage only" for non-mage heroes, so the reason is clear before they even try.

**2. Test cleanup deleting user dungeons (`tests/run.sh`)**

`run.sh` cleanup ran `kctl delete dungeons --all`, which deleted every dungeon in the cluster including dungeons owned by real users. This ran on every push via the pre-push hook.

Fix: cleanup now reads `KROMBAT_TEST_USER` from the `krombat-test-auth` secret (same token the tests use to create dungeons) and deletes only dungeons with `krombat.io/owner=<test-user>`. If the secret can't be resolved, cleanup is skipped with a warning rather than nuking everything.

Also deleted the stuck `dungeon-reaper-29557440` job that had been in `ImagePullBackOff` for 2+ days, blocking new reaper runs (`concurrencyPolicy: Forbid` prevented new jobs while it was "active").