### PR TITLE
fix: leaderboard regression — filter non-victory entries, add githubLogin (#353)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -412,11 +412,11 @@ func (h *Handler) DeleteDungeon(w http.ResponseWriter, r *http.Request) {
 		spec, _ := dungeon.Object["spec"].(map[string]interface{})
 		kroStatus, _ := dungeon.Object["status"].(map[string]interface{})
 		if spec != nil {
-			go h.recordLeaderboard(spec, kroStatus, name)
 			login := ""
 			if sess2 := sessionFromCtx(r.Context()); sess2 != nil {
 				login = sess2.Login
 			}
+			go h.recordLeaderboard(spec, kroStatus, name, login)
 			go h.recordProfile(login, spec, kroStatus)
 		}
 	}
@@ -436,6 +436,7 @@ func (h *Handler) DeleteDungeon(w http.ResponseWriter, r *http.Request) {
 // LeaderboardEntry represents a single completed dungeon run.
 type LeaderboardEntry struct {
 	DungeonName string `json:"dungeonName"`
+	GitHubLogin string `json:"githubLogin,omitempty"`
 	HeroClass   string `json:"heroClass"`
 	Difficulty  string `json:"difficulty"`
 	Outcome     string `json:"outcome"`
@@ -455,7 +456,7 @@ var leaderboardGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resou
 // recordLeaderboard writes a run completion entry to the krombat-leaderboard ConfigMap.
 // Called asynchronously before dungeon deletion. Silently skips on any error.
 // kroStatus is the kro-derived dungeon status (may be nil if kro hasn't reconciled yet).
-func (h *Handler) recordLeaderboard(spec map[string]interface{}, kroStatus map[string]interface{}, dungeonName string) {
+func (h *Handler) recordLeaderboard(spec map[string]interface{}, kroStatus map[string]interface{}, dungeonName string, githubLogin string) {
 	heroClass, _ := spec["heroClass"].(string)
 	difficulty, _ := spec["difficulty"].(string)
 	currentRoom := getInt(spec, "currentRoom")
@@ -518,6 +519,7 @@ func (h *Handler) recordLeaderboard(spec map[string]interface{}, kroStatus map[s
 	}
 	entry := LeaderboardEntry{
 		DungeonName: dungeonName,
+		GitHubLogin: githubLogin,
 		HeroClass:   heroClass,
 		Difficulty:  difficulty,
 		Outcome:     outcome,
@@ -1164,7 +1166,7 @@ func (h *Handler) GetLeaderboard(w http.ResponseWriter, r *http.Request) {
 	for _, v := range data {
 		raw, _ := v.(string)
 		var e LeaderboardEntry
-		if json.Unmarshal([]byte(raw), &e) == nil {
+		if json.Unmarshal([]byte(raw), &e) == nil && e.Outcome == "victory" {
 			entries = append(entries, e)
 		}
 	}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1086,7 +1086,16 @@ function LeaderboardPanel({ entries, loading, onClose }: {
               {entries.map((e, i) => (
                 <tr key={`${e.timestamp}-${e.dungeonName}`} className="lb-row lb-victory">
                   <td className="lb-rank">{i + 1}</td>
-                  <td className="lb-name">{e.dungeonName}</td>
+                  <td className="lb-name">
+                    {e.githubLogin ? (
+                      <a href={`https://github.com/${e.githubLogin}`} target="_blank" rel="noopener noreferrer"
+                        style={{ display: 'flex', alignItems: 'center', gap: 4, color: 'inherit', textDecoration: 'none' }}>
+                        <img src={`https://github.com/${e.githubLogin}.png?size=16`} alt="" width={16} height={16}
+                          style={{ borderRadius: 2, imageRendering: 'pixelated' }} />
+                        @{e.githubLogin}
+                      </a>
+                    ) : e.dungeonName}
+                  </td>
                   <td><PixelIcon name={CLASS_ICON[e.heroClass] ?? 'sword'} size={10} /></td>
                   <td><span className={`tag tag-${e.difficulty}`}>{e.difficulty}</span></td>
                   <td className="lb-turns">{e.totalTurns}</td>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -117,6 +117,7 @@ export async function deleteDungeon(ns: string, name: string) {
 
 export interface LeaderboardEntry {
   dungeonName: string
+  githubLogin?: string
   heroClass: string
   difficulty: string
   outcome: string  // 'victory' | 'defeat' | 'room1-cleared' | 'in-progress'


### PR DESCRIPTION
## Summary

Regression fix for #353. The issue was closed but two parts of the spec were not implemented, causing the old leaderboard behavior to persist.

**1. Non-victory entries still visible (`GetLeaderboard` missing filter)**

`recordLeaderboard` correctly guards against writing non-victory entries (line 516: `if outcome != "victory" { return }`), but `GetLeaderboard` read back everything in the ConfigMap with no filter — including pre-fix entries written before the guard existed. Fix: added `&& e.Outcome == "victory"` to the unmarshal loop in `GetLeaderboard`. Stale non-victory entries in the ConfigMap are now silently excluded at read time without needing a data migration.

**2. `githubLogin` field never implemented (Phase 2 of #353)**

`LeaderboardEntry` struct had no `GitHubLogin` field. `DeleteDungeon` already extracted `login` from the session for `recordProfile` but didn't pass it to `recordLeaderboard`. The frontend showed `dungeonName` in the Player column.

Changes:
- `LeaderboardEntry` gains `GitHubLogin string \`json:"githubLogin,omitempty"\``
- `recordLeaderboard` signature gains `githubLogin string` parameter; stored in the entry
- `DeleteDungeon` extracts login once and passes it to both `recordLeaderboard` and `recordProfile`
- `api.ts`: `LeaderboardEntry` interface gains `githubLogin?: string`
- `LeaderboardPanel`: Player cell shows `<avatar> @login` (linked to `github.com/<login>`) when `githubLogin` is present; falls back to `dungeonName` for legacy entries