### PR TITLE
fix: exclude test user and no-login entries from leaderboard

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -1162,13 +1162,26 @@ func (h *Handler) GetLeaderboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data, _ := cm.Object["data"].(map[string]interface{})
+	testUser := os.Getenv("KROMBAT_TEST_USER") // exclude test-user entries from the public board
 	entries := make([]LeaderboardEntry, 0, len(data))
 	for _, v := range data {
 		raw, _ := v.(string)
 		var e LeaderboardEntry
-		if json.Unmarshal([]byte(raw), &e) == nil && e.Outcome == "victory" {
-			entries = append(entries, e)
+		if json.Unmarshal([]byte(raw), &e) != nil {
+			continue
 		}
+		if e.Outcome != "victory" {
+			continue
+		}
+		// Exclude entries with no githubLogin (legacy/test runs before auth was required)
+		if e.GitHubLogin == "" {
+			continue
+		}
+		// Exclude entries from the test user
+		if testUser != "" && e.GitHubLogin == testUser {
+			continue
+		}
+		entries = append(entries, e)
 	}
 
 	// Sort by fewest turns (ascending), then by timestamp descending for ties


### PR DESCRIPTION
## Summary

Prevents test data from appearing on the public leaderboard.

`GetLeaderboard` now rejects an entry unless **all** of these are true:
1. `outcome == "victory"` (already filtered in #524)
2. `githubLogin` is non-empty (excludes legacy entries written before auth was required, and any unauthenticated run)
3. `githubLogin != KROMBAT_TEST_USER` (excludes entries created by the test suite — the test token is a 64-char hex string from the `krombat-test-auth` Secret)

The `KROMBAT_TEST_USER` env var is already injected into the backend pod from the same Secret the tests use, so no new config is needed. If the env var is unset, only the no-login filter applies.

Entries already in the ConfigMap are not deleted — they are simply excluded at read time.