### PR TITLE
feat: workshop kit — 3-day self-paced kro learning path (#461)

### DIFF
--- a/Docs/workshop/README.md
+++ b/Docs/workshop/README.md
@@ -1,0 +1,75 @@
+# kro Workshop — Learn Kubernetes Resource Orchestration by Playing a Dungeon RPG
+
+This is a self-paced 3-day workshop that teaches [kro (Kubernetes Resource Orchestrator)](https://github.com/kubernetes-sigs/kro) using Krombat as a live teaching environment.
+
+Krombat is a turn-based dungeon RPG where all game state lives in Kubernetes Custom Resources on a real EKS cluster. Nine production-grade kro ResourceGraphDefinitions orchestrate the entire resource graph. You will play the game, read the RGDs, and extend one.
+
+No local cluster required for Day 1 or Day 2. Day 3 requires forking the repo and deploying via ArgoCD.
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| A modern browser | Chrome or Firefox recommended |
+| A GitHub account | Required to log in and save your profile |
+| kubectl CLI | Required for Day 3 only |
+| Basic Kubernetes familiarity | You know what a Pod, ConfigMap, and CRD are |
+| ~8 hours total | Day 1: 2-3h, Day 2: 2-3h, Day 3: 3-4h |
+
+---
+
+## What you will learn
+
+By the end of this workshop you will be able to:
+
+- Explain what a ResourceGraphDefinition (RGD) is and why it exists
+- Read real production kro RGDs and understand every CEL expression
+- Use `readyWhen`, `includeWhen`, `forEach`, and `specPatch` in practice
+- Write your first kro RGD from scratch and deploy it via ArgoCD
+- Describe the kro reconcile loop and how CEL expressions drive derived state
+
+---
+
+## The teaching environment
+
+All exercises use the live Krombat deployment at `https://learn-kro.eks.aws.dev`. You do not need to run anything locally for Day 1 and Day 2.
+
+The game exposes everything you need inside the browser:
+
+- **kro panel** — the live resource graph for your dungeon, updated in real time as you play
+- **Reconcile Stream tab** — raw kro watch events showing every field change and the CEL expression that drove it
+- **K8s log tab** — annotated kubectl commands with kro commentary for each event
+- **CEL Playground** — an in-browser REPL where you can evaluate CEL expressions from the RGDs
+- **Concept glossary** — 27 kro concepts that unlock as you play
+
+---
+
+## Schedule
+
+| Day | Title | Duration | Goal |
+|---|---|---|---|
+| 1 | [Explore](day-1-explore.md) | 2-3 hours | Understand what kro is doing by playing the game |
+| 2 | [Read the RGDs](day-2-read-the-rgds.md) | 2-3 hours | Read all 9 RGDs and understand every CEL expression |
+| 3 | [Extend](day-3-extend.md) | 3-4 hours | Write your first kro RGD by adding a new modifier type |
+
+---
+
+## Exercises and solutions
+
+| File | Purpose |
+|---|---|
+| [exercises/day-1-exercises.md](exercises/day-1-exercises.md) | 5 questions answered by inspecting the live resource graph |
+| [exercises/day-2-exercises.md](exercises/day-2-exercises.md) | 5 CEL expression exercises using the in-browser CEL Playground |
+| [exercises/day-3-exercises.md](exercises/day-3-exercises.md) | Guided RGD authoring exercise with scaffolded steps |
+| [solutions/day-3-solution.yaml](solutions/day-3-solution.yaml) | Reference solution for the Day 3 RGD exercise |
+
+---
+
+## Help and feedback
+
+- Use the **?** button inside the game for in-game help on any mechanic
+- Open the kro concept glossary (kro panel footer) to look up any term
+- Post questions or share your run blog post in [GitHub Discussions](https://github.com/kubernetes-sigs/kro/discussions)
+- File issues against this repo for workshop content bugs

--- a/Docs/workshop/day-1-explore.md
+++ b/Docs/workshop/day-1-explore.md
@@ -1,0 +1,132 @@
+# Day 1 — Explore (2-3 hours)
+
+**Goal:** Understand what kro is and what it does by playing Krombat and observing the resource graph.
+
+No local cluster required. Everything runs in your browser at `https://learn-kro.eks.aws.dev`.
+
+---
+
+## Learning outcomes
+
+By the end of Day 1 you will be able to:
+
+- Describe what a ResourceGraphDefinition (RGD) is and why it exists
+- Identify every node in the Krombat resource graph and what it represents
+- Find kro reconcile events in the K8s log tab and explain what CEL expression fired
+- Explain what `spec.schema`, `forEach`, `readyWhen`, and `status-aggregation` mean in plain English
+
+---
+
+## Step 1 — Log in and create your first dungeon (30 min)
+
+1. Open `https://learn-kro.eks.aws.dev` in your browser
+2. Sign in with your GitHub account
+3. Click **New Dungeon** and create a dungeon with these settings:
+   - Hero class: **Warrior**
+   - Difficulty: **Normal**
+   - Leave the dungeon name as the auto-generated name
+4. The game starts. Look at the top of the screen — this is your dungeon name, which is also the name of the Dungeon Custom Resource on the live EKS cluster.
+
+**Checkpoint:** You just ran `kubectl apply -f dungeon.yaml` against a real Kubernetes cluster. The intro tour explains what happened. Read through all 9 slides before continuing.
+
+---
+
+## Step 2 — Open the kro panel (20 min)
+
+1. Inside your dungeon, click the **kro** tab in the event log panel at the bottom of the screen
+2. You will see the resource graph for your dungeon rendered as a directed graph
+3. Identify and label each node:
+
+| Node color | Node type | What kro did |
+|---|---|---|
+| Blue (root) | Dungeon CR | You applied this — kro watches it |
+| Purple | Namespace | kro created this |
+| Green | Hero CR | kro created this from `heroCR` resource in dungeon-graph |
+| Green | Monster CR × N | kro created one per monster via `forEach` |
+| Green | Boss CR | kro created this from `bossCR` resource |
+| Green | Treasure CR | kro created this |
+| Green | Modifier CR | kro created this |
+| Yellow | GameConfig CM | kro created this ConfigMap with dice formula and HP tables |
+| Orange | specPatch nodes | kro writes CEL-computed values back to Dungeon CR `spec` |
+
+**Question to answer:** How many resources did kro create from your single Dungeon CR? *(See [exercises/day-1-exercises.md](exercises/day-1-exercises.md), Q1)*
+
+---
+
+## Step 3 — Watch kro reconcile during combat (30 min)
+
+1. Click the **Reconcile Stream** tab in the event log panel
+2. Attack a monster by clicking on it
+3. Watch the stream — you will see entries like:
+
+```
+[14:22:01] configmap/my-dungeon-monster-0  MODIFIED  rv:1847
+  data.entityState: alive → dead
+    RGD: monster-graph
+    CEL: schema.spec.hp > 0 ? "alive" : "dead"
+```
+
+4. Click **Why?** on any field to expand the CEL expression, which RGD it lives in, and the concept card
+5. Kill all 3 monsters, then kill the boss
+
+**Question to answer:** Which RGD is responsible for the `entityState` field on a monster ConfigMap? *(Q2)*
+
+---
+
+## Step 4 — Read the K8s log tab (20 min)
+
+1. Click the **K8s log** tab in the event log panel
+2. Each entry shows a simulated `kubectl` command with a **[kro]** annotation block
+3. Find an entry for an attack action and expand the kro annotation
+4. The annotation shows which RGD reconciled, which CEL expression fired, and links to the concept
+
+**Question to answer:** What does the `combatResolve` specPatch node write back to the Dungeon CR spec? *(Q3)*
+
+---
+
+## Step 5 — Unlock kro concepts (30 min)
+
+1. Click the **kro** tab and look at the concept glossary at the bottom
+2. Continue playing — defeat the boss in Room 1, open the treasure, enter Room 2, defeat the Room 2 boss
+3. As you play, new concepts unlock. Aim to unlock at least 15 concepts by the end of the run
+4. After winning, click **Tell the story of this run** to generate a Markdown blog post narrating the key kro events in your dungeon
+
+**Question to answer:** What is the difference between `readyWhen` and `includeWhen` in kro? *(Q4)*
+
+---
+
+## Step 6 — Use the CEL Playground (20 min)
+
+1. Click the **CEL** button in the kro panel header (or open it from the concept glossary)
+2. The playground shows a live CEL REPL connected to the current dungeon state
+3. Try evaluating these expressions:
+
+```
+schema.spec.heroHP > 0 ? "alive" : "dead"
+```
+
+```
+schema.spec.difficulty == "hard" ? 3 : schema.spec.difficulty == "normal" ? 2 : 1
+```
+
+4. Modify the expression to return the number of monsters with HP > 0
+
+**Question to answer:** What CEL function does the boss-graph use to determine `bossPhase`? *(Q5)*
+
+---
+
+## Day 1 exercises
+
+Complete the five questions in [exercises/day-1-exercises.md](exercises/day-1-exercises.md). All answers can be found by inspecting the live game UI — no code reading required.
+
+---
+
+## Day 1 summary
+
+You have now:
+- Applied a real Kubernetes CR and watched kro orchestrate 16 resources from it
+- Observed kro reconciling the resource graph in real time during combat
+- Identified `forEach`, `readyWhen`, `specPatch`, and `status-aggregation` patterns in the wild
+- Unlocked at least 15 of 27 kro concepts
+
+Proceed to [Day 2 — Read the RGDs](day-2-read-the-rgds.md).

--- a/Docs/workshop/day-2-read-the-rgds.md
+++ b/Docs/workshop/day-2-read-the-rgds.md
@@ -1,0 +1,214 @@
+# Day 2 — Read the RGDs (2-3 hours)
+
+**Goal:** Read all 9 kro RGDs in the Krombat repo and understand every CEL expression.
+
+No local cluster required. You will read the RGD YAML files on GitHub and use the in-browser CEL Playground at `https://learn-kro.eks.aws.dev` to verify expressions.
+
+---
+
+## Learning outcomes
+
+By the end of Day 2 you will be able to:
+
+- Read a kro RGD YAML file and explain what every section does
+- Explain `cel.bind()`, `readyWhen`, `includeWhen`, `specPatch`, and `forEach` from first principles
+- Trace a CEL expression from the RGD to its effect on game state
+- Use the CEL Playground to evaluate expressions interactively
+
+---
+
+## The 9 RGDs
+
+All RGDs live in `manifests/rgds/` in the repo. The canonical source is:
+
+```
+https://github.com/pnz1990/krombat/tree/main/manifests/rgds/
+```
+
+Or browse them directly:
+
+| RGD | File | What it manages |
+|---|---|---|
+| `dungeon-graph` | `dungeon-graph.yaml` | Root graph: Namespace, all child CRs, GameConfig, specPatch nodes |
+| `hero-graph` | `hero-graph.yaml` | Hero CR → ConfigMap with maxHP, maxMana, classNote |
+| `monster-graph` | `monster-graph.yaml` | Monster CR → ConfigMap with `entityState` (alive/dead) |
+| `boss-graph` | `boss-graph.yaml` | Boss CR → ConfigMap with `entityState`, `bossPhase`, `damageMultiplier` |
+| `treasure-graph` | `treasure-graph.yaml` | Treasure CR → ConfigMap + Secret with `state` (opened/unopened) |
+| `modifier-graph` | `modifier-graph.yaml` | Modifier CR → ConfigMap with `effect` description string |
+| `loot-graph` | `loot-graph.yaml` | Loot CR → Secret with item type, rarity, stat, description |
+| `attack-graph` | `attack-graph.yaml` | Defines the Attack CRD only — no managed resources |
+| `action-graph` | `action-graph.yaml` | Defines the Action CRD only — no managed resources |
+
+---
+
+## Step 1 — Read modifier-graph (30 min)
+
+Start with the simplest RGD: `modifier-graph.yaml`. It is 37 lines.
+
+```yaml
+# manifests/rgds/modifier-graph.yaml
+spec:
+  schema:
+    spec:
+      dungeonName: string | required=true
+      modifierType: string | default="none"
+      multiplier: string | default="1.0"
+    status:
+      effect: "${modifierState.data.effect}"
+      modifierType: "${modifierState.data.modifierType}"
+      multiplier: "${modifierState.data.multiplier}"
+
+  resources:
+    - id: modifierState
+      readyWhen:
+        - "${modifierState.data.modifierType != ''}"
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        data:
+          effect: >-
+            ${
+              schema.spec.modifierType == 'curse-fortitude' ?
+                'Curse of Fortitude: All monsters have 50% more HP.' :
+              schema.spec.modifierType == 'blessing-strength' ?
+                'Blessing of Strength: Your attacks deal 50% more damage!' :
+              'No modifier'
+            }
+```
+
+**Questions to answer:**
+
+1. What does `readyWhen` do here? When does the resource become "ready"?
+2. What happens if `modifierType` is `"blessing-fortune"` — what is the computed `effect` string?
+3. The status block has `effect: "${modifierState.data.effect}"`. What does `modifierState` refer to?
+
+*(See [exercises/day-2-exercises.md](exercises/day-2-exercises.md), Q1-Q2)*
+
+---
+
+## Step 2 — Read boss-graph (30 min)
+
+`boss-graph.yaml` is more complex. Focus on these sections:
+
+**Phase derivation:**
+
+```yaml
+phase: >-
+  ${
+    schema.spec.hp <= 0 ? 'defeated' :
+    schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 50 ? 'phase1' :
+    schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 25 ? 'phase2' :
+    'phase3'
+  }
+```
+
+**Damage multiplier:**
+
+```yaml
+damageMultiplier: >-
+  ${
+    schema.spec.hp <= 0 ? '10' :
+    schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 50 ? '10' :
+    schema.spec.hp * 100 / (schema.spec.maxHP > 0 ? schema.spec.maxHP : 400) > 25 ? '13' :
+    '16'
+  }
+```
+
+Notice that the HP-percentage expression is repeated three times. Why can't you use `cel.bind()` to avoid this? *(This is a real constraint — research it.)*
+
+**Loot drop via `includeWhen`:**
+
+```yaml
+- id: lootCR
+  includeWhen:
+    - ${schema.spec.hp == 0}
+  template:
+    apiVersion: game.k8s.example/v1alpha1
+    kind: Loot
+```
+
+*(See exercises Q3)*
+
+---
+
+## Step 3 — Read dungeon-graph (45 min)
+
+`dungeon-graph.yaml` is the largest RGD (~980 lines). Focus on these patterns:
+
+**forEach fan-out:**
+
+```yaml
+- id: monsterCRs
+  forEach:
+    in: "${schema.spec.monsterHP}"
+    as: hp
+    index: idx
+  template:
+    apiVersion: game.k8s.example/v1alpha1
+    kind: Monster
+    metadata:
+      name: "${schema.spec.dungeonName + '-monster-' + string(idx)}"
+    spec:
+      hp: ${hp}
+```
+
+This creates one Monster CR per element in `schema.spec.monsterHP`. With 3 monsters, kro creates 3 CRs.
+
+**specPatch — CEL writes back to spec:**
+
+```yaml
+- id: combatResolve
+  template:
+    apiVersion: kro.run/v1alpha1
+    kind: specPatch
+    spec:
+      target: dungeons.game.k8s.example
+      patch:
+        heroHP: ${...}
+        bossHP: ${...}
+```
+
+A `specPatch` resource is a kro-specific type that writes computed values back to the parent CR's `spec`. This is how CEL expressions on the server can mutate game state.
+
+*(See exercises Q4-Q5)*
+
+---
+
+## Step 4 — Read the remaining 6 RGDs (30 min)
+
+Read `hero-graph.yaml`, `monster-graph.yaml`, `treasure-graph.yaml`, `loot-graph.yaml`, `attack-graph.yaml`, and `action-graph.yaml`.
+
+Note for `attack-graph` and `action-graph`: these RGDs contain only a `schema` block and no `resources` block. Their sole purpose is to define a CRD. The Go backend creates Attack and Action CRs, and kro watches them — but kro creates no child resources from them. They are empty RGDs used purely as CRD factories.
+
+---
+
+## Step 5 — CEL Playground verification (30 min)
+
+Open a dungeon at `https://learn-kro.eks.aws.dev` and click the **CEL** button in the kro panel.
+
+Verify each of the following expressions produces the expected output:
+
+| Expression | Expected output |
+|---|---|
+| `schema.spec.difficulty == "hard" ? "3d20+8" : schema.spec.difficulty == "normal" ? "2d12+6" : "1d20+3"` | The dice formula for your difficulty |
+| `schema.spec.heroHP > 0 ? "alive" : "dead"` | `"alive"` (if your hero is alive) |
+| `size(schema.spec.monsterHP.filter(hp, hp > 0))` | Number of monsters still alive |
+| `schema.spec.bossHP * 100 / 400 > 50 ? "phase1" : schema.spec.bossHP * 100 / 400 > 25 ? "phase2" : "phase3"` | Current boss phase |
+
+---
+
+## Day 2 exercises
+
+Complete the five questions in [exercises/day-2-exercises.md](exercises/day-2-exercises.md). All answers require reading the RGD YAML files and using the CEL Playground.
+
+---
+
+## Day 2 summary
+
+You have now:
+- Read all 9 production kro RGDs
+- Understood `readyWhen`, `includeWhen`, `forEach`, and `specPatch` from real examples
+- Used the CEL Playground to verify expressions interactively
+- Identified the real constraints of CEL (no `let` bindings, no stateful iteration)
+
+Proceed to [Day 3 — Extend](day-3-extend.md).

--- a/Docs/workshop/day-3-extend.md
+++ b/Docs/workshop/day-3-extend.md
@@ -1,0 +1,194 @@
+# Day 3 — Extend (3-4 hours)
+
+**Goal:** Write your first kro RGD by adding a new modifier type to `modifier-graph.yaml` that gives the hero a +10% dodge chance.
+
+This day requires forking the repo and deploying your change via ArgoCD.
+
+---
+
+## Learning outcomes
+
+By the end of Day 3 you will be able to:
+
+- Author a real production kro RGD with a new CEL expression
+- Deploy a kro change via ArgoCD (GitOps)
+- Run the Krombat test suite and verify all tests pass
+- Explain how the reconcile loop picks up a schema change and reflects it in a running game
+
+---
+
+## Prerequisites
+
+- A GitHub account with permission to fork `pnz1990/krombat`
+- kubectl CLI installed locally
+- Access to a Kubernetes cluster where you can install kro (or use the Krombat cluster if you have access)
+- If you do not have cluster access: you can still complete the RGD authoring exercise and validate the CEL expressions using the CEL Playground at `https://learn-kro.eks.aws.dev` — skip the deploy steps
+
+---
+
+## The exercise
+
+You will add a new modifier type called `blessing-agility` to `modifier-graph.yaml`.
+
+**Effect:** The hero gains a +10% chance to dodge counter-attacks.
+
+**What needs to change:**
+
+1. `manifests/rgds/modifier-graph.yaml` — add `blessing-agility` to the `effect` CEL ternary chain
+2. `backend/internal/handlers/handlers.go` — add the game logic: when `modifier == "blessing-agility"`, add 10 to the rogue/warrior dodge roll (the backend is the game engine — see AGENTS.md)
+3. `frontend/src/App.tsx` — add `"blessing-agility"` to the modifier dropdown in the dungeon creation form
+4. Verify the new modifier appears in the dungeon creation UI, the kro graph panel shows the correct `effect` string, and the modifier-graph node inspector shows the CEL value
+
+**Acceptance criteria for your PR:**
+
+- [ ] `modifier-graph.yaml` has a `blessing-agility` branch in the `effect` CEL expression
+- [ ] The `effect` string reads: `"Blessing of Agility: 10% chance to dodge counter-attacks."`
+- [ ] The modifier appears in the dungeon creation form dropdown
+- [ ] The kro panel shows the modifier node with `state: blessing-agility`
+- [ ] All 4 test suites pass: `tests/run.sh`, `tests/guardrails.sh`, `tests/backend-api.sh`, `tests/e2e/smoke-test.js`
+
+---
+
+## Step 1 — Fork and clone (15 min)
+
+```bash
+# Fork the repo on GitHub, then:
+git clone https://github.com/<your-github-username>/krombat.git
+cd krombat
+git checkout -b workshop-day3-blessing-agility
+```
+
+---
+
+## Step 2 — Edit modifier-graph.yaml (20 min)
+
+Open `manifests/rgds/modifier-graph.yaml`. Find the `effect` CEL expression (line 37). Add a new branch before the final `'No modifier'` fallback:
+
+```yaml
+effect: >-
+  "${
+    schema.spec.modifierType == 'curse-fortitude' ? 'Curse of Fortitude: All monsters have 50% more HP, making them harder to kill.' :
+    schema.spec.modifierType == 'curse-fury' ? 'Curse of Fury: The boss deals double damage on counter-attacks. Be careful!' :
+    schema.spec.modifierType == 'curse-darkness' ? 'Curse of Darkness: Your attacks deal 25% less damage to all enemies.' :
+    schema.spec.modifierType == 'blessing-strength' ? 'Blessing of Strength: Your attacks deal 50% more damage to all enemies!' :
+    schema.spec.modifierType == 'blessing-resilience' ? 'Blessing of Resilience: All counter-attack damage against you is halved.' :
+    schema.spec.modifierType == 'blessing-fortune' ? 'Blessing of Fortune: 20% chance to land a critical hit for double damage!' :
+    schema.spec.modifierType == 'blessing-agility' ? 'Blessing of Agility: 10% chance to dodge counter-attacks.' :
+    'No modifier'
+  }"
+```
+
+**Verify the CEL expression in the Playground:** Open the CEL Playground at `https://learn-kro.eks.aws.dev` and paste:
+
+```
+schema.spec.modifierType == 'blessing-agility' ? 'Blessing of Agility: 10% chance to dodge counter-attacks.' : 'No modifier'
+```
+
+The output should be `"No modifier"` (because your current dungeon does not use `blessing-agility`). That is correct — the expression is valid.
+
+---
+
+## Step 3 — Add the game logic in handlers.go (30 min)
+
+Open `backend/internal/handlers/handlers.go`. Find the section that applies modifier effects to combat (search for `"blessing-fortune"` or `"blessing-resilience"`).
+
+Add the dodge logic for `blessing-agility`. When the modifier is `blessing-agility`, add 10 to the hero's dodge roll in the counter-attack resolution block. The backend is the game engine: all combat math lives here.
+
+> **Tip:** Study how `blessing-resilience` halves incoming counter-attack damage to understand the pattern. Your `blessing-agility` dodge logic should roll a random number and skip the counter-attack damage if the roll beats 90 (10% chance).
+
+---
+
+## Step 4 — Add to the frontend dropdown (15 min)
+
+Open `frontend/src/App.tsx`. Find the modifier dropdown in the dungeon creation form (search for `"blessing-fortune"`). Add `blessing-agility` as a new option:
+
+```tsx
+<option value="blessing-agility">Blessing of Agility (+10% dodge)</option>
+```
+
+---
+
+## Step 5 — Deploy via ArgoCD (30 min)
+
+If you have write access to the Krombat cluster:
+
+```bash
+# Commit your changes
+git add manifests/rgds/modifier-graph.yaml backend/internal/handlers/handlers.go frontend/src/App.tsx
+git commit -m "feat: add blessing-agility modifier (#workshop-day3)"
+
+# Push to your fork
+git push origin workshop-day3-blessing-agility
+
+# Open a PR to your fork's main branch (not the upstream)
+# ArgoCD will sync when you merge to your main branch
+
+# After merge, delete the old RGD to force schema regeneration:
+kubectl --context <your-context> delete rgd modifier-graph
+# ArgoCD recreates it from the new YAML within ~6 seconds
+```
+
+If you are deploying to your own cluster (not Krombat):
+
+```bash
+# Install kro first: https://kro.run/docs/getting-started/installation
+# Then apply the RGD:
+kubectl apply -f manifests/rgds/modifier-graph.yaml
+
+# Verify kro picked it up:
+kubectl get rgd modifier-graph -o yaml | grep -A5 "status:"
+```
+
+---
+
+## Step 6 — Verify in the game (20 min)
+
+1. Open `https://learn-kro.eks.aws.dev` (or your own deployment)
+2. Click **New Dungeon**
+3. Confirm `Blessing of Agility` appears in the modifier dropdown
+4. Create a dungeon with `blessing-agility`
+5. Open the kro panel — the Modifier node should show `state: blessing-agility`
+6. Click the Modifier node — the inspector should show `effect: Blessing of Agility: 10% chance to dodge counter-attacks.`
+7. Fight the boss — you should occasionally see "Dodge!" in the combat log when the counter-attack is negated
+
+---
+
+## Step 7 — Run the test suite (20 min)
+
+```bash
+# From the repo root:
+./tests/guardrails.sh
+./tests/backend-api.sh
+BASE_URL=https://learn-kro.eks.aws.dev node tests/e2e/smoke-test.js
+```
+
+All tests must pass before your PR can be considered complete.
+
+---
+
+## Day 3 exercises
+
+Complete the guided steps in [exercises/day-3-exercises.md](exercises/day-3-exercises.md).
+
+The reference solution is in [solutions/day-3-solution.yaml](solutions/day-3-solution.yaml). Only look at it after completing your own attempt.
+
+---
+
+## Day 3 summary
+
+You have now:
+- Written a real kro RGD CEL expression from scratch
+- Deployed it via ArgoCD (GitOps)
+- Verified the reconcile loop picked up the schema change and reflected it in the live game
+- Run the full test suite and confirmed all tests pass
+
+**You have completed the kro workshop.** You now have the foundation to author your own kro RGDs for real production use cases.
+
+---
+
+## Next steps
+
+- Read the [kro documentation](https://kro.run/docs) for the full feature set
+- Browse the other 8 RGDs in `manifests/rgds/` — each one demonstrates a different kro pattern
+- Join the [kro community](https://github.com/kubernetes-sigs/kro/discussions) and share what you built
+- Use the blog post generator (victory screen → **Tell the story of this run**) to share your Day 3 result

--- a/Docs/workshop/exercises/day-1-exercises.md
+++ b/Docs/workshop/exercises/day-1-exercises.md
@@ -1,0 +1,49 @@
+# Day 1 Exercises
+
+Answer these 5 questions using the live game at `https://learn-kro.eks.aws.dev`. No code reading required — all answers can be found by inspecting the game UI.
+
+---
+
+## Q1 — Resource count
+
+Create a dungeon with 3 monsters. Open the kro panel and count all nodes in the resource graph (including specPatch nodes).
+
+**How many resources did kro create from your single Dungeon CR?**
+
+*Hint: The root Dungeon CR is not counted — count only the resources kro created from it.*
+
+---
+
+## Q2 — monster-graph entityState
+
+Kill one of your three monsters. Open the kro panel and click the dead monster's node in the graph.
+
+**Which field changes in the monster's ConfigMap when the monster dies? What does it change from and to? Which RGD is responsible?**
+
+---
+
+## Q3 — combatResolve specPatch
+
+After attacking, open the K8s log tab and find the most recent attack entry. Expand the **[kro]** annotation block.
+
+**List 3 fields that the `combatResolve` specPatch node writes back to the Dungeon CR spec after a combat turn.**
+
+---
+
+## Q4 — readyWhen vs includeWhen
+
+Open the Reconcile Stream tab and watch it during an attack. Then open the kro concept glossary (kro panel footer) and look up both `readyWhen` and `includeWhen`.
+
+**In your own words: what is the difference between `readyWhen` and `includeWhen` in kro?**
+
+---
+
+## Q5 — CEL Playground: boss phase
+
+Open the CEL Playground and evaluate this expression (replace `400` with your boss's actual max HP if it differs):
+
+```
+schema.spec.bossHP * 100 / 400 > 50 ? "phase1" : schema.spec.bossHP * 100 / 400 > 25 ? "phase2" : "phase3"
+```
+
+**What phase is the boss in right now? At what HP threshold does it transition to phase2?**

--- a/Docs/workshop/exercises/day-2-exercises.md
+++ b/Docs/workshop/exercises/day-2-exercises.md
@@ -1,0 +1,53 @@
+# Day 2 Exercises
+
+Answer these 5 questions by reading the RGD YAML files in `manifests/rgds/` and using the CEL Playground at `https://learn-kro.eks.aws.dev`.
+
+---
+
+## Q1 — modifier-graph readyWhen
+
+Read `manifests/rgds/modifier-graph.yaml`.
+
+**What condition does `readyWhen` check? What happens to the Modifier CR status if this condition is not yet true?**
+
+---
+
+## Q2 — CEL ternary chain in modifier-graph
+
+Open the CEL Playground. Evaluate the following expression (it is the exact expression from modifier-graph.yaml, simplified):
+
+```
+"blessing-fortune" == "curse-fortitude" ? "Curse of Fortitude: All monsters have 50% more HP, making them harder to kill." :
+"blessing-fortune" == "curse-fury" ? "Curse of Fury: The boss deals double damage on counter-attacks. Be careful!" :
+"blessing-fortune" == "curse-darkness" ? "Curse of Darkness: Your attacks deal 25% less damage to all enemies." :
+"blessing-fortune" == "blessing-strength" ? "Blessing of Strength: Your attacks deal 50% more damage to all enemies!" :
+"blessing-fortune" == "blessing-resilience" ? "Blessing of Resilience: All counter-attack damage against you is halved." :
+"blessing-fortune" == "blessing-fortune" ? "Blessing of Fortune: 20% chance to land a critical hit for double damage!" :
+"No modifier"
+```
+
+**What does this expression return? Why is the CEL ternary chain evaluated left-to-right?**
+
+---
+
+## Q3 — boss-graph includeWhen
+
+Read `manifests/rgds/boss-graph.yaml`. Find the `lootCR` resource.
+
+**What `includeWhen` condition controls when the Loot CR is created? What happens to the Loot CR if the boss is alive (hp > 0)?**
+
+---
+
+## Q4 — dungeon-graph forEach
+
+Read the `monsterCRs` resource in `manifests/rgds/dungeon-graph.yaml`.
+
+**If `spec.monsterHP` is `[50, 50, 50]`, how many Monster CRs does kro create? What is the name of the second one (index 1)?**
+
+---
+
+## Q5 — specPatch concept
+
+Read the `combatResolve` specPatch resource in `manifests/rgds/dungeon-graph.yaml`.
+
+**In plain English: what is a `specPatch` resource in kro, and why is it used here instead of a ConfigMap?**

--- a/Docs/workshop/exercises/day-3-exercises.md
+++ b/Docs/workshop/exercises/day-3-exercises.md
@@ -1,0 +1,83 @@
+# Day 3 Exercises — Guided RGD Authoring
+
+Complete these steps in order. The goal is to add a `blessing-agility` modifier to `modifier-graph.yaml` that gives the hero a +10% dodge chance.
+
+Do not look at the solution in `solutions/day-3-solution.yaml` until you have completed your own attempt.
+
+---
+
+## Part A — Design the CEL expression (30 min)
+
+Before writing any code, design the CEL expression you will add to modifier-graph.yaml.
+
+**Exercise A1:** Write the new CEL branch that should be inserted into the `effect` ternary chain. The effect string must read exactly:
+
+```
+Blessing of Agility: 10% chance to dodge counter-attacks.
+```
+
+*Hint: look at the existing `blessing-fortune` branch for the pattern.*
+
+**Exercise A2:** In the CEL Playground at `https://learn-kro.eks.aws.dev`, evaluate this expression to verify your syntax is correct:
+
+```
+"blessing-agility" == "blessing-agility" ? "Blessing of Agility: 10% chance to dodge counter-attacks." : "No modifier"
+```
+
+Expected output: `"Blessing of Agility: 10% chance to dodge counter-attacks."`
+
+**Exercise A3:** Where exactly in the ternary chain should `blessing-agility` appear? Does the order matter? Why or why not?
+
+---
+
+## Part B — Edit the RGD (20 min)
+
+Edit `manifests/rgds/modifier-graph.yaml` and add the `blessing-agility` branch to the `effect` field.
+
+**Checkpoint:** After editing, the `effect` field should have 7 named modifier branches (6 existing + your new one) plus the `'No modifier'` fallback.
+
+**Exercise B1:** Count the lines in the `effect` expression before and after your change. How many lines did you add?
+
+**Exercise B2:** The `multiplier` field in the modifier-graph schema is a `string` with `default="1.0"`. For `blessing-agility`, the game logic uses a percentage roll (not a multiplier on damage). Should you update the `multiplier` field in the RGD for `blessing-agility`? Why or why not?
+
+---
+
+## Part C — Understand the kro/backend split (20 min)
+
+**Exercise C1:** The `effect` field in modifier-graph is a human-readable description string stored in a ConfigMap. The actual dodge roll happens in `backend/internal/handlers/handlers.go`. Why is the game logic in Go and not in CEL?
+
+*Hint: read the constraint in AGENTS.md: "Game features and game engine MUST be kro/CEL always." Then re-read the architecture section. Is the dodge roll a game feature or game engine?*
+
+**Exercise C2:** Is there anything in modifier-graph.yaml that the Go backend reads to decide how much dodge chance to apply? Or does the backend determine the dodge chance independently?
+
+---
+
+## Part D — Deploy and verify (30 min)
+
+Follow the deploy instructions in [day-3-extend.md](../day-3-extend.md), Step 5 and Step 6.
+
+**Exercise D1:** After deploying, create a dungeon with `blessing-agility`. Open the kro panel and click the Modifier node. Paste a screenshot or describe the `effect` value shown in the node inspector.
+
+**Exercise D2:** Fight until a counter-attack is negated by the dodge. Describe what appears in the combat log when the dodge fires.
+
+---
+
+## Part E — Test and submit (20 min)
+
+Run the full test suite:
+
+```bash
+./tests/guardrails.sh
+./tests/backend-api.sh
+BASE_URL=https://learn-kro.eks.aws.dev node tests/e2e/smoke-test.js
+```
+
+**Exercise E1:** Do all tests pass? If any test fails, what does the failure say and how would you fix it?
+
+**Exercise E2:** If you were to add a new guardrail test for `blessing-agility`, what would it check? Write the one-line `grep` check.
+
+---
+
+## Reference solution
+
+The reference solution for the modifier-graph.yaml change is in [solutions/day-3-solution.yaml](../solutions/day-3-solution.yaml).

--- a/Docs/workshop/solutions/day-3-solution.yaml
+++ b/Docs/workshop/solutions/day-3-solution.yaml
@@ -1,0 +1,37 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: modifier-graph
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Modifier
+    group: game.k8s.example
+    spec:
+      dungeonName: string | required=true
+      modifierType: string | default="none"
+      multiplier: string | default="1.0"
+    status:
+      effect: "${modifierState.data.effect}"
+      modifierType: "${modifierState.data.modifierType}"
+      multiplier: "${modifierState.data.multiplier}"
+
+  resources:
+    - id: modifierState
+      readyWhen:
+        - "${modifierState.data.modifierType != ''}"
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: "${schema.spec.dungeonName + '-modifier'}"
+          namespace: ${schema.metadata.namespace}
+          labels:
+            game.k8s.example/dungeon: ${schema.spec.dungeonName}
+            game.k8s.example/entity: modifier
+        data:
+          modifierType: ${schema.spec.modifierType}
+          multiplier: ${schema.spec.multiplier}
+          effect: "${schema.spec.modifierType == 'curse-fortitude' ? 'Curse of Fortitude: All monsters have 50% more HP, making them harder to kill.' : schema.spec.modifierType == 'curse-fury' ? 'Curse of Fury: The boss deals double damage on counter-attacks. Be careful!' : schema.spec.modifierType == 'curse-darkness' ? 'Curse of Darkness: Your attacks deal 25% less damage to all enemies.' : schema.spec.modifierType == 'blessing-strength' ? 'Blessing of Strength: Your attacks deal 50% more damage to all enemies!' : schema.spec.modifierType == 'blessing-resilience' ? 'Blessing of Resilience: All counter-attack damage against you is halved.' : schema.spec.modifierType == 'blessing-fortune' ? 'Blessing of Fortune: 20% chance to land a critical hit for double damage!' : schema.spec.modifierType == 'blessing-agility' ? 'Blessing of Agility: 10% chance to dodge counter-attacks.' : 'No modifier'}"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1953,6 +1953,21 @@ function HelpModal({ onClose, onCheat }: { onClose: () => void; onCheat: () => v
         <p><b>Copy Markdown</b> copies the post to your clipboard. <b>Open in GitHub Discussions</b> opens a new tab pre-filled in the kro repo's show-and-tell category.</p>
       </>
     )},
+    { title: 'Workshop Kit', content: (
+      <>
+        <p>A self-paced 3-day workshop that teaches kro using Krombat as the teaching environment is available in <code>docs/workshop/</code> in this repo.</p>
+        <table className="help-table">
+          <thead><tr><th>Day</th><th>Title</th><th>Goal</th></tr></thead>
+          <tbody>
+            <tr><td>1</td><td>Explore</td><td>Understand what kro is doing by playing the game</td></tr>
+            <tr><td>2</td><td>Read the RGDs</td><td>Read all 9 RGDs and understand every CEL expression</td></tr>
+            <tr><td>3</td><td>Extend</td><td>Write your first kro RGD — add a new modifier type</td></tr>
+          </tbody>
+        </table>
+        <p>No local cluster required for Day 1 or Day 2. Day 3 requires forking the repo and deploying via ArgoCD.</p>
+        <p>Find the workshop at: <code>github.com/pnz1990/krombat/tree/main/docs/workshop/</code></p>
+      </>
+    )},
   ]
   return (
     <div className="modal-overlay" onClick={onClose}>

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -1517,6 +1517,19 @@ CEL: size(schema.spec.monsterHP.filter(hp, hp > 0))
 
 Built with kro — https://github.com/kubernetes-sigs/kro`,
   },
+  {
+    title: 'Take the 3-Day kro Workshop',
+    body: "A self-paced workshop in docs/workshop/ teaches kro using this game as the environment. Day 1: play and observe the resource graph. Day 2: read all 9 production RGDs and understand every CEL expression. Day 3: fork the repo and add a new modifier type — your first real kro RGD. No local cluster needed for Day 1 or Day 2.",
+    snippet: `# docs/workshop/
+  README.md               ← overview and prerequisites
+  day-1-explore.md        ← play and observe the kro graph
+  day-2-read-the-rgds.md  ← read all 9 RGDs, CEL expressions
+  day-3-extend.md         ← write your first RGD (blessing-agility)
+  exercises/              ← 5 questions per day
+  solutions/              ← day-3-solution.yaml reference
+
+# github.com/pnz1990/krombat/tree/main/docs/workshop/`,
+  },
 ]
 
 export function KroOnboardingOverlay({ onDismiss, isAuthenticated }: { onDismiss: () => void; isAuthenticated: boolean }) {

--- a/tests/e2e/journeys/41-workshop-kit.js
+++ b/tests/e2e/journeys/41-workshop-kit.js
@@ -1,0 +1,244 @@
+// Journey 41: Workshop Kit (#461)
+// UI-ONLY: no kubectl, no direct fetch/api, no execSync
+// Tests:
+//   1.  docs/workshop/README.md exists in repo (fetch from GitHub raw)
+//   2.  docs/workshop/day-1-explore.md exists in repo
+//   3.  docs/workshop/day-2-read-the-rgds.md exists in repo
+//   4.  docs/workshop/day-3-extend.md exists in repo
+//   5.  docs/workshop/exercises/day-1-exercises.md exists
+//   6.  docs/workshop/exercises/day-2-exercises.md exists
+//   7.  docs/workshop/exercises/day-3-exercises.md exists
+//   8.  docs/workshop/solutions/day-3-solution.yaml exists
+//   9.  day-3-solution.yaml contains blessing-agility
+//   10. day-3-solution.yaml is a valid ResourceGraphDefinition
+//   11. workshop README references learn-kro.eks.aws.dev
+//   12. day-1-explore.md says no local cluster required
+//   13. day-2-read-the-rgds.md says no local cluster required
+//   14. day-3-extend.md references ArgoCD
+//   15. Help modal has "Workshop Kit" page
+//   16. Intro tour has "3-Day kro Workshop" slide
+//   17. No JS console errors
+const { chromium } = require('playwright');
+const { testLogin } = require('./helpers');
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const TIMEOUT = 25000;
+let passed = 0, failed = 0, warnings = 0;
+function ok(msg)   { console.log(`  ✅ ${msg}`); passed++; }
+function fail(msg) { console.log(`  ❌ ${msg}`); failed++; }
+function warn(msg) { console.log(`  ⚠️  ${msg}`); warnings++; }
+
+const RAW_BASE = 'https://raw.githubusercontent.com/pnz1990/krombat/main';
+
+async function run() {
+  console.log('Journey 41: Workshop Kit\n');
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const consoleErrors = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error'
+      && !msg.text().includes('WebSocket')
+      && !msg.text().includes('404')
+      && !msg.text().includes('net::ERR')
+      && !msg.text().includes('502')
+      && !msg.text().includes('504')
+      && !msg.text().includes('400')
+      && !msg.text().includes('429'))
+      consoleErrors.push(msg.text());
+  });
+
+  try {
+    // === Step 1: Verify workshop files exist in repo ===
+    console.log('=== Step 1: Workshop files in repo ===');
+
+    const files = [
+      { path: 'Docs/workshop/README.md', label: 'Docs/workshop/README.md' },
+      { path: 'Docs/workshop/day-1-explore.md', label: 'Docs/workshop/day-1-explore.md' },
+      { path: 'Docs/workshop/day-2-read-the-rgds.md', label: 'Docs/workshop/day-2-read-the-rgds.md' },
+      { path: 'Docs/workshop/day-3-extend.md', label: 'Docs/workshop/day-3-extend.md' },
+      { path: 'Docs/workshop/exercises/day-1-exercises.md', label: 'exercises/day-1-exercises.md' },
+      { path: 'Docs/workshop/exercises/day-2-exercises.md', label: 'exercises/day-2-exercises.md' },
+      { path: 'Docs/workshop/exercises/day-3-exercises.md', label: 'exercises/day-3-exercises.md' },
+      { path: 'Docs/workshop/solutions/day-3-solution.yaml', label: 'solutions/day-3-solution.yaml' },
+    ];
+
+    const fileContents = {};
+    for (const f of files) {
+      const result = await page.evaluate(async (url) => {
+        try {
+          const r = await fetch(url);
+          return { status: r.status, body: await r.text() };
+        } catch (e) { return { status: 0, body: '' }; }
+      }, `${RAW_BASE}/${f.path}`);
+      result.status === 200
+        ? ok(`${f.label} exists in repo`)
+        : fail(`${f.label} not found (status ${result.status})`);
+      fileContents[f.path] = result.body;
+    }
+
+    // === Step 2: Validate day-3-solution.yaml content ===
+    console.log('\n=== Step 2: day-3-solution.yaml content ===');
+
+    const solutionYaml = fileContents['Docs/workshop/solutions/day-3-solution.yaml'] || '';
+
+    solutionYaml.includes('blessing-agility')
+      ? ok('day-3-solution.yaml contains blessing-agility modifier')
+      : fail('day-3-solution.yaml missing blessing-agility modifier');
+
+    solutionYaml.includes('ResourceGraphDefinition')
+      ? ok('day-3-solution.yaml is a ResourceGraphDefinition')
+      : fail('day-3-solution.yaml missing ResourceGraphDefinition kind');
+
+    solutionYaml.includes('kind: Modifier') || solutionYaml.includes('kind: modifier')
+      ? ok('day-3-solution.yaml schema kind is Modifier')
+      : fail('day-3-solution.yaml schema missing kind: Modifier');
+
+    solutionYaml.includes('Blessing of Agility')
+      ? ok('day-3-solution.yaml has correct Blessing of Agility effect string')
+      : fail('day-3-solution.yaml missing Blessing of Agility effect string');
+
+    solutionYaml.includes('modifier-graph')
+      ? ok('day-3-solution.yaml references modifier-graph name')
+      : fail('day-3-solution.yaml missing modifier-graph name');
+
+    // === Step 3: Validate guide content ===
+    console.log('\n=== Step 3: Guide content checks ===');
+
+    const readme = fileContents['Docs/workshop/README.md'] || '';
+    readme.includes('learn-kro.eks.aws.dev')
+      ? ok('workshop README references learn-kro.eks.aws.dev')
+      : fail('workshop README missing learn-kro.eks.aws.dev reference');
+
+    readme.includes('day-1') || readme.includes('Day 1')
+      ? ok('workshop README references Day 1')
+      : fail('workshop README missing Day 1 reference');
+
+    readme.includes('day-3') || readme.includes('Day 3')
+      ? ok('workshop README references Day 3')
+      : fail('workshop README missing Day 3 reference');
+
+    const day1 = fileContents['Docs/workshop/day-1-explore.md'] || '';
+    day1.includes('No local cluster required')
+      ? ok('day-1-explore.md states no local cluster required')
+      : fail('day-1-explore.md missing "No local cluster required"');
+
+    const day2 = fileContents['Docs/workshop/day-2-read-the-rgds.md'] || '';
+    day2.includes('No local cluster required')
+      ? ok('day-2-read-the-rgds.md states no local cluster required')
+      : fail('day-2-read-the-rgds.md missing "No local cluster required"');
+
+    const day3 = fileContents['Docs/workshop/day-3-extend.md'] || '';
+    (day3.includes('ArgoCD') || day3.includes('Argo CD') || day3.includes('argocd'))
+      ? ok('day-3-extend.md references ArgoCD deployment')
+      : fail('day-3-extend.md missing ArgoCD deployment instructions');
+
+    day3.includes('blessing-agility')
+      ? ok('day-3-extend.md exercises reference blessing-agility')
+      : fail('day-3-extend.md missing blessing-agility exercise');
+
+    // === Step 4: Verify help modal has Workshop Kit page ===
+    console.log('\n=== Step 4: Help modal workshop page ===');
+
+    await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: TIMEOUT });
+    await testLogin(page);
+    await page.waitForTimeout(1500);
+
+    // Dismiss onboarding if shown
+    for (let i = 0; i < 15; i++) {
+      const btn = page.locator('button:has-text("Next →"), button:has-text("Start Playing"), button:has-text("Got it!")');
+      if (await btn.count() > 0) { await btn.first().click({ force: true }).catch(() => {}); await page.waitForTimeout(400); }
+      else break;
+    }
+
+    // Open help modal via ? button or keyboard
+    const helpBtn = page.locator('button[aria-label="Help"], .help-btn');
+    if (await helpBtn.count() > 0) {
+      await helpBtn.first().click({ force: true }).catch(() => {});
+    } else {
+      await page.keyboard.press('?');
+    }
+    await page.waitForTimeout(800);
+
+    const helpModal = page.locator('.help-modal, [aria-label*="Help:"]');
+    if (await helpModal.count() > 0) {
+      ok('Help modal opened successfully');
+
+      // Navigate to the Workshop Kit page (last page — navigate via Next button repeatedly)
+      let found = false;
+      for (let i = 0; i < 20 && !found; i++) {
+        const bodyText = await page.textContent('.help-modal, .modal.help-modal').catch(() => '');
+        if (bodyText.includes('Workshop Kit') || bodyText.includes('workshop kit') || bodyText.includes('docs/workshop')) {
+          found = true;
+          ok('Help modal has Workshop Kit page');
+          break;
+        }
+        const nextBtn = page.locator('.help-nav button:has-text("Next →")');
+        if (await nextBtn.count() > 0 && !(await nextBtn.isDisabled())) {
+          await nextBtn.click({ force: true }).catch(() => {});
+          await page.waitForTimeout(300);
+        } else {
+          break;
+        }
+      }
+      if (!found) fail('Help modal missing Workshop Kit page');
+
+      // Close help modal
+      const closeBtn = page.locator('.help-nav button:has-text("Close")');
+      if (await closeBtn.count() > 0) await closeBtn.click({ force: true }).catch(() => {});
+      await page.waitForTimeout(400);
+    } else {
+      warn('Help modal did not open — skipping workshop page check');
+    }
+
+    // === Step 5: Verify intro tour has workshop slide ===
+    console.log('\n=== Step 5: Intro tour workshop slide ===');
+
+    // Clear localStorage to force onboarding to show again
+    await page.evaluate(() => { localStorage.removeItem('kro-onboarding-dismissed'); });
+    await page.reload({ waitUntil: 'networkidle', timeout: TIMEOUT });
+    await page.waitForTimeout(1500);
+
+    // The onboarding overlay should now be showing
+    const onboarding = page.locator('.kro-onboarding-overlay, [class*="onboard"]');
+    if (await onboarding.count() > 0) {
+      ok('Onboarding overlay present after clearing dismissal');
+
+      // Navigate through all slides looking for workshop slide
+      let workshopFound = false;
+      for (let i = 0; i < 15 && !workshopFound; i++) {
+        const slideText = await page.textContent('.kro-onboarding-overlay, [class*="onboard"]').catch(() => '');
+        if (slideText.includes('Workshop') || slideText.includes('docs/workshop') || slideText.includes('3-Day')) {
+          workshopFound = true;
+          ok('Intro tour has workshop slide');
+        }
+        const nextBtn = page.locator('button:has-text("Next →")');
+        if (!workshopFound && await nextBtn.count() > 0) {
+          await nextBtn.first().click({ force: true }).catch(() => {});
+          await page.waitForTimeout(400);
+        } else if (!workshopFound) {
+          break;
+        }
+      }
+      if (!workshopFound) fail('Intro tour missing workshop slide');
+    } else {
+      warn('Onboarding overlay not shown after clearing dismissal — skipping workshop slide check');
+    }
+
+  } catch (err) {
+    fail(`Unexpected error: ${err.message}`);
+  } finally {
+    await browser.close();
+  }
+
+  // === Console errors check ===
+  console.log('\n=== Console errors ===');
+  consoleErrors.length === 0
+    ? ok('No unexpected JS console errors')
+    : fail(`${consoleErrors.length} unexpected console error(s): ${consoleErrors.slice(0,3).join('; ')}`);
+
+  // === Summary ===
+  console.log(`\nJourney 41 complete: ${passed} passed, ${failed} failed, ${warnings} warnings`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch(err => { console.error(err); process.exit(1); });

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -1001,6 +1001,104 @@ grep -q "30 days" frontend/src/App.tsx \
   && pass "#477: UI says dungeon data kept for 30 days" \
   || fail "#477: UI still says '4 hours' instead of '30 days' — update App.tsx retention string"
 
+# --- Workshop kit (#461) ---
+echo "=== Workshop kit (#461)"
+
+# Docs/workshop/README.md must exist
+[ -f "Docs/workshop/README.md" ] \
+  && pass "#461: Docs/workshop/README.md exists" \
+  || fail "#461: Docs/workshop/README.md missing"
+
+# Docs/workshop/day-1-explore.md must exist
+[ -f "Docs/workshop/day-1-explore.md" ] \
+  && pass "#461: Docs/workshop/day-1-explore.md exists" \
+  || fail "#461: Docs/workshop/day-1-explore.md missing"
+
+# Docs/workshop/day-2-read-the-rgds.md must exist
+[ -f "Docs/workshop/day-2-read-the-rgds.md" ] \
+  && pass "#461: Docs/workshop/day-2-read-the-rgds.md exists" \
+  || fail "#461: Docs/workshop/day-2-read-the-rgds.md missing"
+
+# Docs/workshop/day-3-extend.md must exist
+[ -f "Docs/workshop/day-3-extend.md" ] \
+  && pass "#461: Docs/workshop/day-3-extend.md exists" \
+  || fail "#461: Docs/workshop/day-3-extend.md missing"
+
+# exercises must exist
+[ -f "Docs/workshop/exercises/day-1-exercises.md" ] \
+  && pass "#461: Docs/workshop/exercises/day-1-exercises.md exists" \
+  || fail "#461: Docs/workshop/exercises/day-1-exercises.md missing"
+
+[ -f "Docs/workshop/exercises/day-2-exercises.md" ] \
+  && pass "#461: Docs/workshop/exercises/day-2-exercises.md exists" \
+  || fail "#461: Docs/workshop/exercises/day-2-exercises.md missing"
+
+[ -f "Docs/workshop/exercises/day-3-exercises.md" ] \
+  && pass "#461: Docs/workshop/exercises/day-3-exercises.md exists" \
+  || fail "#461: Docs/workshop/exercises/day-3-exercises.md missing"
+
+# solutions/day-3-solution.yaml must exist
+[ -f "Docs/workshop/solutions/day-3-solution.yaml" ] \
+  && pass "#461: Docs/workshop/solutions/day-3-solution.yaml exists" \
+  || fail "#461: Docs/workshop/solutions/day-3-solution.yaml missing"
+
+# day-3-solution.yaml must be a valid kro RGD (has required fields)
+grep -q "kind: ResourceGraphDefinition" Docs/workshop/solutions/day-3-solution.yaml \
+  && pass "#461: day-3-solution.yaml is a ResourceGraphDefinition" \
+  || fail "#461: day-3-solution.yaml missing kind: ResourceGraphDefinition"
+
+grep -q "kind: Modifier" Docs/workshop/solutions/day-3-solution.yaml \
+  && pass "#461: day-3-solution.yaml schema is kind: Modifier" \
+  || fail "#461: day-3-solution.yaml schema missing kind: Modifier"
+
+grep -q "modifier-graph" Docs/workshop/solutions/day-3-solution.yaml \
+  && pass "#461: day-3-solution.yaml references modifier-graph" \
+  || fail "#461: day-3-solution.yaml missing modifier-graph name"
+
+# day-3-solution.yaml must contain the blessing-agility branch
+grep -q "blessing-agility" Docs/workshop/solutions/day-3-solution.yaml \
+  && pass "#461: day-3-solution.yaml contains blessing-agility" \
+  || fail "#461: day-3-solution.yaml missing blessing-agility modifier"
+
+# day-3-solution.yaml must contain the correct effect string
+grep -q "Blessing of Agility" Docs/workshop/solutions/day-3-solution.yaml \
+  && pass "#461: day-3-solution.yaml has correct Blessing of Agility effect string" \
+  || fail "#461: day-3-solution.yaml missing 'Blessing of Agility' effect string"
+
+# Workshop README must reference learn-kro.eks.aws.dev
+grep -q "learn-kro.eks.aws.dev" Docs/workshop/README.md \
+  && pass "#461: workshop README references learn-kro.eks.aws.dev" \
+  || fail "#461: workshop README missing learn-kro.eks.aws.dev reference"
+
+# Workshop day guides must not require local cluster for Day 1 and Day 2
+grep -q "No local cluster required" Docs/workshop/day-1-explore.md \
+  && pass "#461: day-1-explore.md says no local cluster required" \
+  || fail "#461: day-1-explore.md missing 'No local cluster required' statement"
+
+grep -q "No local cluster required" Docs/workshop/day-2-read-the-rgds.md \
+  && pass "#461: day-2-read-the-rgds.md says no local cluster required" \
+  || fail "#461: day-2-read-the-rgds.md missing 'No local cluster required' statement"
+
+# Day 3 must reference ArgoCD (no direct kubectl apply)
+grep -q "ArgoCD\|Argo CD\|argocd" Docs/workshop/day-3-extend.md \
+  && pass "#461: day-3-extend.md references ArgoCD deployment" \
+  || fail "#461: day-3-extend.md missing ArgoCD deployment instructions"
+
+# Help modal must document Workshop Kit
+grep -q "Workshop Kit\|workshop kit\|docs/workshop" frontend/src/App.tsx \
+  && pass "#461: Help modal documents Workshop Kit" \
+  || fail "#461: Help modal missing Workshop Kit page"
+
+# Intro tour must have Take the 3-Day workshop slide
+grep -q "3-Day kro Workshop\|docs/workshop\|workshop" frontend/src/KroTeach.tsx \
+  && pass "#461: KroTeach.tsx intro tour has workshop slide" \
+  || fail "#461: KroTeach.tsx missing workshop intro slide"
+
+# Journey 41 must exist
+[ -f "tests/e2e/journeys/41-workshop-kit.js" ] \
+  && pass "#461: tests/e2e/journeys/41-workshop-kit.js exists" \
+  || fail "#461: tests/e2e/journeys/41-workshop-kit.js missing"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
Closes #461

## Summary

- Adds `Docs/workshop/` with a complete 3-day self-paced kro workshop using Krombat as the teaching environment
- Day 1: Play the game and observe the live resource graph (no local cluster required)
- Day 2: Read all 9 production RGDs and understand every CEL expression (no local cluster required)
- Day 3: Fork the repo and add a new `blessing-agility` modifier type — writing the first real kro RGD
- Reference solution in `Docs/workshop/solutions/day-3-solution.yaml` (valid `modifier-graph` RGD with `blessing-agility` branch)
- 5 exercises per day in `Docs/workshop/exercises/`
- Help modal: new "Workshop Kit" page (page 14)
- Intro onboarding: new 10th slide "Take the 3-Day kro Workshop"
- 20 guardrail tests added to `tests/guardrails.sh` verifying all required files, content, and UI references
- Journey 41 (`tests/e2e/journeys/41-workshop-kit.js`) verifies workshop files exist on GitHub raw, validates solution YAML content, and checks the help modal and intro tour UI