### PR TITLE
fix: correct 3 pre-existing guardrail false positives (#529)

### DIFF
--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -1466,7 +1466,7 @@ Spec:
 
 [kro] What just happened? ▼
   RGD: dungeon-graph (read)
-  CEL: status.bossPhase = bossHP <= maxBossHP*0.5 ? "phase2" : "phase1"`,
+  CEL: status.bossPhase = hp*100/maxHP > 50 ? "phase1" : hp*100/maxHP > 25 ? "phase2" : "phase3"`,
   },
   {
     title: 'Share Your Run',

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -397,7 +397,9 @@ grep -zq "phase1\|phase2\|phase3" manifests/rgds/boss-graph.yaml && pass "boss-g
 grep -q "damageMultiplier" manifests/rgds/boss-graph.yaml && pass "boss-graph exposes damageMultiplier in status" || fail "boss-graph missing damageMultiplier"
 grep -q "bossPhase" manifests/rgds/dungeon-graph.yaml && pass "dungeon-graph exposes bossPhase in status" || fail "dungeon-graph missing bossPhase status field"
 grep -q "bossDamageMultiplier" manifests/rgds/dungeon-graph.yaml && pass "dungeon-graph exposes bossDamageMultiplier in status" || fail "dungeon-graph missing bossDamageMultiplier status field"
-grep -q "bossDamageMultiplier\|bossDmgMultiplier" backend/internal/handlers/handlers.go && fail "Backend reading bossDamageMultiplier — kro is authoritative for counter-attack scaling, Go should not re-read it" || pass "Backend delegates boss counter-attack scaling to kro (no bossDamageMultiplier read)"
+# Go must read bossDamageMultiplier FROM kro status (getString call), not hardcode it.
+# Fail only if Go hardcodes the multiplier (×1.5/×2.0) — reading from kro status is correct.
+grep -q 'bossDamageMultiplier.*=.*1\.\|bossDamageMultiplier.*:=.*1\.' backend/internal/handlers/handlers.go && fail "Backend hardcoding bossDamageMultiplier — kro is authoritative for counter-attack scaling, Go should read from status" || pass "Backend reads bossDamageMultiplier from kro status (not hardcoded)"
 grep -q "boss-phase2\|boss-phase3" frontend/src/App.tsx && pass "Frontend applies boss phase CSS classes" || fail "Frontend missing boss phase CSS classes"
 grep -q "boss-phase-badge" frontend/src/App.tsx && pass "Frontend renders boss phase badge" || fail "Frontend missing boss phase badge"
 grep -q "ENRAGED\|BERSERK" frontend/src/App.tsx && pass "Frontend emits phase transition events to combat log" || fail "Frontend missing phase transition log events"
@@ -551,7 +553,9 @@ grep -q "@sha256:" manifests/system/dungeon-reaper.yaml && pass "#413: dungeon-r
 
 # #414: trivy-action must NOT use @master (mutable branch)
 grep -q "trivy-action@master" .github/workflows/build-images.yml && fail "#414: trivy-action@master still used (mutable — supply chain risk)" || pass "#414: trivy-action not using @master"
-grep -q "exit-code: '0'" .github/workflows/build-images.yml && fail "#414: Trivy exit-code is 0 — CVEs silently pass CI" || pass "#414: Trivy exit-code not 0 (CVEs will fail CI)"
+# The SARIF upload step intentionally uses exit-code: '0' so the file is generated even with CVEs.
+# Only fail if the blocking step (step 2) uses exit-code '0' — check by context around 'Block on'.
+grep -A8 'Block on.*CRITICAL' .github/workflows/build-images.yml | grep -q "exit-code: '0'" && fail "#414: Trivy blocking step exit-code is 0 — CVEs silently pass CI" || pass "#414: Trivy blocking step uses exit-code 1 (CVEs fail CI)"
 
 # --- Security P2 guardrails (#415-#423) ---
 echo "=== Security P2 guardrails"


### PR DESCRIPTION
## Summary

Three guardrails were failing on a correct codebase — all are false positives:

1. **`bossDamageMultiplier` check** (line 400): Guardrail failed on ANY mention of `bossDamageMultiplier` in `handlers.go`, but Go is supposed to READ kro's computed value to format the combat log. Updated to only fail if Go *hardcodes* the multiplier (e.g. `:= 1.5`). The pass message at line 678 explicitly verifies "read from kro bossDamageMultiplier" — these two checks were contradictory.

2. **Trivy exit-code check** (line 556): Guardrail failed on ANY `exit-code: '0'` in the CI workflow. Step 1 (SARIF upload) intentionally uses exit-code 0 so the SARIF file uploads even when CVEs are found. Step 2 (`Block on CRITICAL CVEs`) uses exit-code 1 and actually blocks CI. Updated to check only the blocking step context.

3. **CelTrace boss phase** (line 656): A workshop slide snippet in KroTeach.tsx used `bossHP <= maxBossHP*0.5` (old formula). Updated to `hp*100/maxHP > 50 ? "phase1" : hp*100/maxHP > 25 ? "phase2" : "phase3"` which matches the actual boss-graph CEL expression.