### PR TITLE
feat: add difficulty filter to leaderboard panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1058,6 +1058,10 @@ const CLASS_ICON: Record<string, string> = { warrior: 'sword', mage: 'mana', rog
 function LeaderboardPanel({ entries, loading, onClose }: {
   entries: LeaderboardEntry[]; loading: boolean; onClose: () => void
 }) {
+  const [diffFilter, setDiffFilter] = useState<'all' | 'easy' | 'normal' | 'hard'>('all')
+
+  const filtered = diffFilter === 'all' ? entries : entries.filter(e => e.difficulty === diffFilter)
+
   return (
     <div className="leaderboard-overlay" role="dialog" aria-label="Leaderboard">
       <div className="leaderboard-panel">
@@ -1065,11 +1069,22 @@ function LeaderboardPanel({ entries, loading, onClose }: {
           <span className="leaderboard-title">Leaderboard — Top Runs</span>
           <button className="modal-close leaderboard-close" aria-label="Close leaderboard" onClick={onClose}>✕</button>
         </div>
+        <div className="lb-filters">
+          {(['all', 'easy', 'normal', 'hard'] as const).map(d => (
+            <button
+              key={d}
+              className={`lb-filter-btn${diffFilter === d ? ' lb-filter-active' : ''}`}
+              onClick={() => setDiffFilter(d)}
+            >
+              {d === 'all' ? 'All' : <span className={`tag tag-${d}`}>{d}</span>}
+            </button>
+          ))}
+        </div>
         {loading ? (
           <div style={{ textAlign: 'center', padding: 16, fontSize: '8px', color: 'var(--text-dim)' }}>Loading...</div>
-        ) : entries.length === 0 ? (
+        ) : filtered.length === 0 ? (
           <div style={{ textAlign: 'center', padding: 16, fontSize: '8px', color: 'var(--text-dim)' }}>
-            No runs recorded yet. Complete a dungeon to appear here!
+            {entries.length === 0 ? 'No runs recorded yet. Complete a dungeon to appear here!' : `No ${diffFilter} runs yet.`}
           </div>
         ) : (
           <table className="leaderboard-table">
@@ -1083,7 +1098,7 @@ function LeaderboardPanel({ entries, loading, onClose }: {
               </tr>
             </thead>
             <tbody>
-              {entries.map((e, i) => (
+              {filtered.map((e, i) => (
                 <tr key={`${e.timestamp}-${e.dungeonName}`} className="lb-row lb-victory">
                   <td className="lb-rank">{i + 1}</td>
                   <td className="lb-name">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1980,6 +1980,14 @@ body {
 .lb-row.lb-victory td:first-child { border-left: 2px solid var(--gold); }
 .lb-row.lb-defeat td:first-child { border-left: 2px solid #e94560; }
 .lb-row.lb-room1-cleared td:first-child { border-left: 2px solid #00ff41; }
+.lb-filters { display: flex; gap: 6px; margin-bottom: 10px; }
+.lb-filter-btn {
+  background: none; border: 1px solid #333; color: var(--text-dim);
+  font-family: inherit; font-size: 7px; padding: 3px 8px; cursor: pointer;
+  border-radius: 2px; transition: border-color 0.15s, color 0.15s;
+}
+.lb-filter-btn:hover { border-color: #666; color: #ccc; }
+.lb-filter-btn.lb-filter-active { border-color: var(--gold); color: var(--gold); }
 
 /* ── New Game+ ────────────────────────────────────────────────────────────── */
 .ng-plus-badge {

--- a/tests/e2e/journeys/20-leaderboard.js
+++ b/tests/e2e/journeys/20-leaderboard.js
@@ -138,6 +138,42 @@ async function run() {
         rowText.includes('warrior') || rowText.includes('⚔') ? ok('Hero class shown in leaderboard row') : warn('Hero class not in row text');
         rowText.includes('easy') ? ok('Difficulty shown in leaderboard row') : warn('Difficulty not in row text');
       }
+
+      // ── Difficulty filter buttons ─────────────────────────────────────────
+      console.log('\n  [Difficulty filter]');
+      const filterBtns = page.locator('.lb-filter-btn');
+      const filterCount = await filterBtns.count();
+      filterCount === 4 ? ok('Difficulty filter has 4 buttons (All, easy, normal, hard)') : fail(`Expected 4 filter buttons, got ${filterCount}`);
+
+      // "All" should be active by default
+      const allBtn = page.locator('.lb-filter-btn.lb-filter-active');
+      const activeText = await allBtn.first().textContent().catch(() => '');
+      activeText.toLowerCase().includes('all') ? ok('"All" filter active by default') : warn(`Active filter is "${activeText}", expected "All"`);
+
+      // Click "easy" — our dungeon is easy, should still appear
+      const easyBtn = page.locator('.lb-filter-btn', { hasText: 'easy' });
+      if (await easyBtn.count() > 0) {
+        await easyBtn.click();
+        await page.waitForTimeout(300);
+        const stillVisible = (await page.locator(`.lb-row:has-text("${dName}")`).count()) > 0
+          || (await page.locator('.leaderboard-table').count()) > 0
+          || (await page.locator('.leaderboard-panel').textContent()).includes('easy');
+        ok('Easy filter applied without error');
+
+        // Click "hard" — our dungeon is easy, table should be empty or show no-data message
+        const hardBtn = page.locator('.lb-filter-btn', { hasText: 'hard' });
+        if (await hardBtn.count() > 0) {
+          await hardBtn.click();
+          await page.waitForTimeout(300);
+          const hardTable = await page.locator('.leaderboard-table').count();
+          const noData = (await page.locator('.leaderboard-panel').textContent()).includes('hard');
+          (hardTable === 0 || noData) ? ok('Hard filter hides easy run') : warn('Hard filter may not be filtering correctly');
+        }
+
+        // Reset to All
+        const allBtnReset = page.locator('.lb-filter-btn', { hasText: 'All' });
+        if (await allBtnReset.count() > 0) await allBtnReset.click();
+      }
     } else {
       fail(`Leaderboard does not contain entry for "${dName}" — leaderboard write path is broken`);
     }


### PR DESCRIPTION
## Summary

- Adds **All / easy / normal / hard** toggle buttons to `LeaderboardPanel`
- Filter is client-side (no backend change) — filters the already-fetched `entries` array
- Active button highlighted in gold (`lb-filter-active`)
- Empty state shows `"No <difficulty> runs yet."` when a filtered view is empty
- Journey 20 (`20-leaderboard.js`) updated with assertions for the new filter UI