### PR TITLE
feat: show kro tour automatically on pre-login homepage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -806,6 +806,9 @@ export default function App() {
             Login with GitHub
           </a>
         </div>
+        {showOnboarding && (
+          <KroOnboardingOverlay onDismiss={() => setShowOnboarding(false)} isAuthenticated={false} />
+        )}
       </div>
     )
   }


### PR DESCRIPTION
## Summary

Unauthenticated visitors now see the kro intro tour automatically when they land on the homepage.

**Before:** The login page showed a static tagline card and nothing else. The tour was only reachable via the hamburger "About kro" button after logging in.

**After:** `KroOnboardingOverlay` is rendered in the `authUser === false` branch. The modal appears immediately on page load. "Skip intro" or "Start Playing" dismisses it for the session, but the next visit shows it again (no localStorage persistence for unauthenticated users — this was already the behaviour, enforced in `KroTeach.tsx`).

## What changed

- `App.tsx`: 3 lines added — `{showOnboarding && <KroOnboardingOverlay ... isAuthenticated={false} />}` inside the pre-login return branch.

No new state, no new logic. The existing `setShowOnboarding(true)` call in the `getMe()` effect (line 143) and the `isAuthenticated=false` skip-persist in `KroOnboardingOverlay.handleDismiss` already handle everything correctly.