### PR TITLE
fix: journey 36 — close hamburger via backdrop click instead of Escape (#457)

### DIFF
--- a/tests/e2e/journeys/36-kubectl-terminal.js
+++ b/tests/e2e/journeys/36-kubectl-terminal.js
@@ -118,8 +118,14 @@ async function run() {
     await termBtn.count() > 0
       ? ok('"kubectl Terminal" button found in dungeon hamburger menu')
       : fail('"kubectl Terminal" button missing from dungeon hamburger menu');
-    await page.keyboard.press('Escape');
-    await page.waitForTimeout(600);
+    // Close the menu by clicking the backdrop (Escape does not close it — no keydown handler)
+    const backdrop = page.locator('.hamburger-backdrop');
+    if (await backdrop.count() > 0) {
+      await backdrop.click();
+    } else {
+      await hamBtn.click(); // toggle off
+    }
+    await page.waitForTimeout(400);
 
     // ── Open terminal ────────────────────────────────────────────────────────
     console.log('\n=== Open terminal panel ===');


### PR DESCRIPTION
## Summary

- The previous fix used `page.keyboard.press('Escape')` to close the hamburger menu, but the menu has no keydown escape handler — it only closes on backdrop click or button re-click
- Fix: click `.hamburger-backdrop` to close the menu; fallback to re-clicking the button if the backdrop isn't found
- This ensures `openTerminal()` finds the menu closed and can open it cleanly

Closes follow-up from #457