### PR TITLE
fix: journey 36 — exclude 404 console errors from terminal resource fetches (#457)

### DIFF
--- a/tests/e2e/journeys/36-kubectl-terminal.js
+++ b/tests/e2e/journeys/36-kubectl-terminal.js
@@ -70,7 +70,8 @@ async function run() {
       && !msg.text().includes('net::ERR')
       && !msg.text().includes('WebSocket')
       && !msg.text().includes('429')
-      && !msg.text().includes('401'))
+      && !msg.text().includes('401')
+      && !msg.text().includes('404'))  // terminal fetch-by-name returns 404 when resource absent (e.g. modifier=none) — expected
       consoleErrors.push(msg.text());
   });
 


### PR DESCRIPTION
## Summary

- The terminal's `get modifier`, `get loot`, etc. legitimately return 404 when the resource doesn't exist for the current dungeon (e.g. modifier=none, loot not yet dropped)
- These 404 browser console errors were being caught by the error filter and failing the JS error check
- Fix: add `!msg.text().includes('404')` to the console error filter, with a comment explaining why

Closes follow-up from #457