### PR TITLE
fix: add minDomains: 3 to topology spread — force 3-AZ node provisioning (#471)

### DIFF
--- a/manifests/system/backend.yaml
+++ b/manifests/system/backend.yaml
@@ -15,8 +15,11 @@ spec:
     spec:
       serviceAccountName: rpg-backend-sa
       topologySpreadConstraints:
-        # #471: enforce AZ spread — backend pods must not stack on same zone
+        # #471: enforce AZ spread — one pod per AZ across all 3 AZs
+        # minDomains: 3 forces Karpenter to provision a node in the 3rd AZ
+        # rather than consolidating onto 2 nodes (which satisfies maxSkew:1 with [2,1])
         - maxSkew: 1
+          minDomains: 3
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: DoNotSchedule
           labelSelector:

--- a/manifests/system/frontend.yaml
+++ b/manifests/system/frontend.yaml
@@ -14,8 +14,11 @@ spec:
         app: rpg-frontend
     spec:
       topologySpreadConstraints:
-        # #471: enforce AZ spread — frontend pods must not stack on same zone
+        # #471: enforce AZ spread — one pod per AZ across all 3 AZs
+        # minDomains: 3 forces Karpenter to provision a node in the 3rd AZ
+        # rather than consolidating onto 2 nodes (which satisfies maxSkew:1 with [2,1])
         - maxSkew: 1
+          minDomains: 3
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: DoNotSchedule
           labelSelector:


### PR DESCRIPTION
## Summary

- `maxSkew: 1` with 3 replicas across 2 AZs is valid ([2,1] distribution satisfies the constraint), so Karpenter was consolidating onto 2 nodes and never provisioning the 3rd AZ
- `minDomains: 3` tells the scheduler that 3 distinct topology domains are required; until Karpenter provisions a node in the 3rd AZ, pods in the `DoNotSchedule` constraint will remain pending — triggering provisioning
- Applied to both `rpg-backend` and `rpg-frontend` deployments
- Expected result after rollout: 4 nodes total — 1 per AZ for app workloads (3×) + 1 dedicated kro node