### PR TITLE
fix: 4 replicas with maxSkew:0 — enforce exactly 2 pods per AZ (#471)

### DIFF
--- a/manifests/system/backend.yaml
+++ b/manifests/system/backend.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rpg-backend
   namespace: rpg-system
 spec:
-  replicas: 3
+  replicas: 4
   selector:
     matchLabels:
       app: rpg-backend
@@ -15,11 +15,8 @@ spec:
     spec:
       serviceAccountName: rpg-backend-sa
       topologySpreadConstraints:
-        # #471: enforce AZ spread — one pod per AZ across all 3 AZs
-        # minDomains: 3 forces Karpenter to provision a node in the 3rd AZ
-        # rather than consolidating onto 2 nodes (which satisfies maxSkew:1 with [2,1])
-        - maxSkew: 1
-          minDomains: 3
+        # #471: 4 replicas across 2 AZs — maxSkew:0 enforces exactly 2 pods per AZ
+        - maxSkew: 0
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: DoNotSchedule
           labelSelector:

--- a/manifests/system/frontend.yaml
+++ b/manifests/system/frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rpg-frontend
   namespace: rpg-system
 spec:
-  replicas: 3
+  replicas: 4
   selector:
     matchLabels:
       app: rpg-frontend
@@ -14,11 +14,8 @@ spec:
         app: rpg-frontend
     spec:
       topologySpreadConstraints:
-        # #471: enforce AZ spread — one pod per AZ across all 3 AZs
-        # minDomains: 3 forces Karpenter to provision a node in the 3rd AZ
-        # rather than consolidating onto 2 nodes (which satisfies maxSkew:1 with [2,1])
-        - maxSkew: 1
-          minDomains: 3
+        # #471: 4 replicas across 2 AZs — maxSkew:0 enforces exactly 2 pods per AZ
+        - maxSkew: 0
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: DoNotSchedule
           labelSelector:


### PR DESCRIPTION
## Summary

- Reverts `minDomains: 3` (required a 3rd AZ subnet — EKS cluster was created with only 2 AZs and cannot be extended without recreation)
- Changes replicas from 3 → 4 on both `rpg-backend` and `rpg-frontend`
- Changes `maxSkew` from 1 → 0: with 4 pods across 2 AZs, `maxSkew: 0` enforces exactly 2 pods per AZ at all times — Karpenter must keep one node per AZ to satisfy `DoNotSchedule`
- PDB `minAvailable: 2` unchanged — appropriate for 4 replicas

Expected topology after rollout:
- `us-west-2a`: 2× backend + 2× frontend on 1 node
- `us-west-2b`: 2× backend + 2× frontend on 1 node  
- `us-west-2b`: kro on dedicated m7i.2xlarge node
- Total: 3 nodes