### PR TITLE
fix: maxSkew:1 with 4 replicas — steady-state [2,2] across us-west-2a/2b (#471)

### DIFF
--- a/manifests/system/backend.yaml
+++ b/manifests/system/backend.yaml
@@ -15,8 +15,9 @@ spec:
     spec:
       serviceAccountName: rpg-backend-sa
       topologySpreadConstraints:
-        # #471: 4 replicas across 2 AZs — maxSkew:0 enforces exactly 2 pods per AZ
-        - maxSkew: 0
+        # #471: 4 replicas, maxSkew:1 across 2 AZs — steady state is [2,2]
+        # maxSkew:0 causes pending pods during rolling update (scheduler sees 3 zones)
+        - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: DoNotSchedule
           labelSelector:

--- a/manifests/system/frontend.yaml
+++ b/manifests/system/frontend.yaml
@@ -14,8 +14,9 @@ spec:
         app: rpg-frontend
     spec:
       topologySpreadConstraints:
-        # #471: 4 replicas across 2 AZs — maxSkew:0 enforces exactly 2 pods per AZ
-        - maxSkew: 0
+        # #471: 4 replicas, maxSkew:1 across 2 AZs — steady state is [2,2]
+        # maxSkew:0 causes pending pods during rolling update (scheduler sees 3 zones)
+        - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: DoNotSchedule
           labelSelector:


### PR DESCRIPTION
## Summary

- `maxSkew:0` caused permanent pending pods: during rolling update the scheduler tracks 3 topology domains (including the empty `us-west-2c` from prior attempts), forcing pods toward a zone with no NodeClass subnet
- `maxSkew:1` with 4 replicas is the correct approach: the only stable distribution across 2 AZs is `[2,2]` — any `[3,1]` split violates `maxSkew:1` and Karpenter will rebalance; `DoNotSchedule` blocks `[4,0]` entirely
- Replicas remain at 4 (unchanged from previous PR)

Closes #471