### PR TITLE
fix: correct AGENTS.md architecture, remove CheatModal, fix taunt state docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,14 +26,21 @@ A turn-based dungeon RPG where game state lives in Kubernetes Custom Resources o
   - `attack-graph`: defines the Attack CRD (no resources — CRD only)
   - `action-graph`: defines the Action CRD (no resources — CRD only)
 - **Argo CD** (EKS Managed Capability) — GitOps from `manifests/`. GitHub webhook for ~6s sync
-- **Go Backend** — REST API + WebSocket in `rpg-system`. Creates/patches Dungeon CRs, creates Attack and Action CRs to trigger state changes. **The Go backend IS the game engine**: all combat math, damage, HP mutations, item effects, status effects, loot drops, and room transitions are computed in Go (`handlers.go`). The `combatResult` and `actionResult` ConfigMaps in dungeon-graph contain pre-computed CEL values (equip bonuses, HP-after-potion, Room 2 HP, etc.) but the backend currently re-derives all of these independently — those CEL blocks are scaffolding for a future migration, not active logic.
+- **Go Backend** — REST API + WebSocket in `rpg-system`. For combat, the backend writes trigger fields only (`attackSeq`, `lastAttackTarget`, `lastAttackSeed`, `lastAttackIndex`, `lastAttackIsBoss`, `lastAttackIsBackstab`) then polls until kro's `combatResolve` specPatch fires — kro CEL is the authoritative combat engine. For actions (equip, use-item, abilities), the backend writes trigger fields only (`actionSeq`, `lastAction`, `lastAbility`) and kro's `actionResolve`/`abilityResolve` specPatch nodes compute the result. The backend computes: loot drop chance/selection (writes `lastLootDrop`), log text (reads kro's post-state diff, no math), XP delta, leaderboard entries, and room transition triggers (writes `enterRoom2` trigger; kro's `enterRoom2Resolve` computes the new HP values).
 - **React Frontend** — 8-bit pixel art with circular dungeon arena, Tibia-style equipment panel, combat modal with dice rolling. All state from Dungeon CR `spec` (not `status` — status can be stale after room transitions)
 
-### What kro actually computes (active, not dead code)
+### What kro actually computes (authoritative — the game engine)
 
-| RGD | What kro CEL computes that matters |
+| RGD / specPatch | What kro CEL computes |
 |---|---|
-| `dungeon-graph` | Namespace, all child CRs, GameConfig CM (dice formula, HP/counter tables), Dungeon status fields |
+| `dungeon-graph` → `combatResolve` | All combat math: hero damage (dice, weapon, helmet, amulet, class multipliers, backstab), boss/monster counter-attack chains (armor, shield, class defense, pants dodge, taunt 60% reduction, one-shot floor), status effect infliction (poison/burn/stun), ring regen, monsterHP array mutation, heroHP mutation |
+| `dungeon-graph` → `abilityResolve` | Mage heal (heroHP clamp, mana cost), warrior taunt activation (tauntActive=1) |
+| `dungeon-graph` → `tickDoT` | DoT damage ticks: poison −5/turn, burn −8/turn, boots resist rolls |
+| `dungeon-graph` → `advanceTaunt` | Taunt counter lifecycle: 1 (queued) → 2 (active/protecting) → 0 (expired) |
+| `dungeon-graph` → `tickCooldown` | Backstab cooldown decrement |
+| `dungeon-graph` → `regenRing` | Ring HP regen per turn, capped at class max HP |
+| `dungeon-graph` → `actionResolve` | Item equip bonuses (weaponBonus, armorBonus, etc.), inventory updates |
+| `dungeon-graph` → `enterRoom2Resolve` | Room 2 HP scaling (monsters ×1.5, boss ×1.3), modifier adjustments, state resets |
 | `boss-graph` | `entityState` (pending/ready/defeated), `bossPhase` (phase1/2/3), `damageMultiplier` (1.0/1.3/1.6) |
 | `hero-graph` | `maxHP`, `maxMana`, `classNote` in status |
 | `monster-graph` | `entityState` (alive/dead) per monster |
@@ -41,15 +48,14 @@ A turn-based dungeon RPG where game state lives in Kubernetes Custom Resources o
 | `treasure-graph` | `state` (opened/unopened), loot key string |
 | `loot-graph` | Item `type`, `rarity`, `stat`, `description` |
 
-### What the Go backend computes (the actual game engine)
+### What the Go backend computes
 
-- All combat math: dice rolls (seeded by Attack CR UID), hero damage (class multipliers, backstab, weapon, helmet, amulet), boss counter-attack chain (armor, shield, warrior/rogue/pants defense, taunt reduction, one-shot floor), monster counter-attack + archer stun + shaman heal abilities
-- Status effects: DoT application (poison −5/turn, burn −8/turn, stun), infliction chances per boss/monster type, boots resist rolls
-- Mana lifecycle: consumption per attack, heal cost, regen on kill, mana restore on room entry
-- Loot drops: kill-transition detection, drop chance by difficulty, rarity roll, item type selection (seeded by dungeon name + index)
-- Item effects: all 27 equip cases (9 types × 3 rarities), potion healing (class-clamped), inventory add/remove/cap
-- Room transitions: Room 2 HP scaling (monsters ×1.5, boss ×1.3), modifier adjustments, monster type reassignment, state resets
+- Loot drops: kill-transition detection (OLD_HP>0 && NEW_HP==0), drop chance by difficulty, rarity roll, item type selection (seeded by dungeon name + index) — writes `lastLootDrop`
+- Log text: reads kro's post-state diff (pre/post heroHP, monsterHP, bossHP) and generates `lastHeroAction`/`lastEnemyAction` strings — no math, kro's results are authoritative
+- XP delta: kill/boss-kill/victory/defeat outcomes from post-spec, writes `xpEarned`
 - Leaderboard: outcome derivation, turn counting, ConfigMap storage (`krombat-leaderboard` in `rpg-system` — plain ConfigMap, no kro interface)
+- Room 2 trigger: writes `enterRoom2` trigger field; kro's `enterRoom2Resolve` specPatch computes all the HP scaling, modifier adjustments, and state resets
+- Dungeon creation: writes initial spec fields; kro's `dungeonInit` specPatch computes monster HP arrays and all derived initial values
 
 ### What the frontend computes (display + necessary spec re-derivation)
 
@@ -66,7 +72,7 @@ A turn-based dungeon RPG where game state lives in Kubernetes Custom Resources o
 |---|---|
 | `manifests/rgds/` | All 9 RGD YAML files (kro resource graph) |
 | `manifests/rbac/rbac.yaml` | ServiceAccounts, ClusterRoles, Bindings |
-| `backend/internal/handlers/handlers.go` | **The game engine**: combat math, item effects, loot, room transitions, leaderboard |
+| `backend/internal/handlers/handlers.go` | REST API handlers: writes trigger fields, polls for kro specPatch results, computes loot/log/XP/leaderboard |
 | `backend/internal/k8s/watchers.go` | GVR definitions (DungeonGVR, AttackGVR, ActionGVR) |
 | `frontend/src/App.tsx` | Main React app (~1000 lines) |
 | `frontend/src/Sprite.tsx` | Sprite components (hurt=6→1→6, dead=6 with 0.35 opacity) |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -123,7 +123,7 @@ export default function App() {
   const [roomLoading, setRoomLoading] = useState(false)
   const [showHelp, setShowHelp] = useState(false)
   const [showOnboarding, setShowOnboarding] = useState(() => !localStorage.getItem('kroOnboardingDone'))
-  const [showCheat, setShowCheat] = useState(false)
+
   const [deleting, setDeleting] = useState<Set<string>>(new Set())
   const [resumePrompt, setResumePrompt] = useState<{ ns: string; name: string } | null>(null)
   const resumeCheckedRef = useRef(false)
@@ -901,8 +901,6 @@ export default function App() {
           onCloseLoot={() => setShowLoot(false)}
           showHelp={showHelp}
           onToggleHelp={() => setShowHelp(h => !h)}
-          showCheat={showCheat}
-          onToggleCheat={() => setShowCheat(c => !c)}
           wsConnected={connected}
           apiError={apiError}
           kroUnlocked={unlocked}
@@ -954,7 +952,7 @@ export default function App() {
       )}
 
       {/* Help Modal — rendered globally so z-index is unaffected by DungeonView subtree (#495) */}
-      {showHelp && <HelpModal onClose={() => setShowHelp(false)} onCheat={() => { setShowHelp(false); setTimeout(() => setShowCheat(true), 100) }} />}
+      {showHelp && <HelpModal onClose={() => setShowHelp(false)} />}
 
       {/* kro Concept Modal */}
       {kroConceptModal && (
@@ -1625,84 +1623,6 @@ function EventLogTabs({ events, k8sLog, reconcileStream, kroUnlocked, onViewKroC
   )
 }
 
-function CheatModal({ onClose, onAction }: { onClose: () => void; onAction: (target: string) => void }) {
-  const sections = [
-    { title: 'Weapons', items: [
-      { id: 'equip-weapon-common', label: 'Common Sword', sprite: 'weapon-common' },
-      { id: 'equip-weapon-rare', label: 'Rare Sword', sprite: 'weapon-rare' },
-      { id: 'equip-weapon-epic', label: 'Epic Sword', sprite: 'weapon-epic' },
-    ]},
-    { title: 'Armor', items: [
-      { id: 'equip-armor-common', label: 'Common Armor', sprite: 'armor-common' },
-      { id: 'equip-armor-rare', label: 'Rare Armor', sprite: 'armor-rare' },
-      { id: 'equip-armor-epic', label: 'Epic Armor', sprite: 'armor-epic' },
-    ]},
-    { title: 'Shields', items: [
-      { id: 'equip-shield-common', label: 'Common Shield', sprite: 'shield-common' },
-      { id: 'equip-shield-rare', label: 'Rare Shield', sprite: 'shield-rare' },
-      { id: 'equip-shield-epic', label: 'Epic Shield', sprite: 'shield-epic' },
-    ]},
-    { title: 'Helmets', items: [
-      { id: 'equip-helmet-common', label: 'Common Helmet', sprite: 'helmet-common' },
-      { id: 'equip-helmet-rare', label: 'Rare Helmet', sprite: 'helmet-rare' },
-      { id: 'equip-helmet-epic', label: 'Epic Helmet', sprite: 'helmet-epic' },
-    ]},
-    { title: 'Pants', items: [
-      { id: 'equip-pants-common', label: 'Common Pants', sprite: 'pants-common' },
-      { id: 'equip-pants-rare', label: 'Rare Pants', sprite: 'pants-rare' },
-      { id: 'equip-pants-epic', label: 'Epic Pants', sprite: 'pants-epic' },
-    ]},
-    { title: 'Boots', items: [
-      { id: 'equip-boots-common', label: 'Common Boots', sprite: 'boots-common' },
-      { id: 'equip-boots-rare', label: 'Rare Boots', sprite: 'boots-rare' },
-      { id: 'equip-boots-epic', label: 'Epic Boots', sprite: 'boots-epic' },
-    ]},
-    { title: 'Rings', items: [
-      { id: 'equip-ring-common', label: 'Common Ring', sprite: 'ring-common' },
-      { id: 'equip-ring-rare', label: 'Rare Ring', sprite: 'ring-rare' },
-      { id: 'equip-ring-epic', label: 'Epic Ring', sprite: 'ring-epic' },
-    ]},
-    { title: 'Amulets', items: [
-      { id: 'equip-amulet-common', label: 'Common Amulet', sprite: 'amulet-common' },
-      { id: 'equip-amulet-rare', label: 'Rare Amulet', sprite: 'amulet-rare' },
-      { id: 'equip-amulet-epic', label: 'Epic Amulet', sprite: 'amulet-epic' },
-    ]},
-    { title: 'HP Potions', items: [
-      { id: 'use-hppotion-common', label: '+20 HP', sprite: 'hppotion-common' },
-      { id: 'use-hppotion-rare', label: '+40 HP', sprite: 'hppotion-rare' },
-      { id: 'use-hppotion-epic', label: 'Full HP', sprite: 'hppotion-epic' },
-    ]},
-    { title: 'Mana Potions', items: [
-      { id: 'use-manapotion-common', label: '+2 Mana', sprite: 'manapotion-common' },
-      { id: 'use-manapotion-rare', label: '+3 Mana', sprite: 'manapotion-rare' },
-      { id: 'use-manapotion-epic', label: '+8 Mana', sprite: 'manapotion-epic' },
-    ]},
-  ]
-  return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal help-modal" role="dialog" aria-modal="true" aria-label="Cheat mode" onClick={e => e.stopPropagation()} style={{ maxWidth: 500 }}>
-        <h2 style={{ color: '#e94560', fontSize: 12, marginBottom: 8 }}><PixelIcon name="damage" size={10} /> CHEAT MODE</h2>
-        <p style={{ fontSize: 7, color: '#666', marginBottom: 12 }}>Items are added to inventory then used/equipped via Attack CR pipeline.</p>
-        {sections.map(s => (
-          <div key={s.title} style={{ marginBottom: 8 }}>
-            <div style={{ fontSize: 8, color: '#888', marginBottom: 4 }}>{s.title}</div>
-            <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
-              {s.items.map(item => (
-                <button key={item.id} className="backpack-slot" style={{ borderColor: item.sprite.includes('epic') ? '#9b59b6' : item.sprite.includes('rare') ? '#5dade2' : '#aaa', width: 48, height: 48 }}
-                  title={item.label}
-                  onClick={() => { onAction(item.id); }}>
-                  <ItemSprite id={item.sprite} size={32} />
-                </button>
-              ))}
-            </div>
-          </div>
-        ))}
-        <button className="btn btn-gold" style={{ marginTop: 8 }} onClick={onClose}>Close</button>
-       </div>
-    </div>
-  )
-}
-
 // ── DungeonMiniMap ────────────────────────────────────────────────────────────
 // Shows a compact 2-room progress strip: Room 1 → Room 2
 // Room states: 'current' (gold) | 'cleared' (green) | 'locked' (gray) | 'active-boss' (red pulse)
@@ -1764,18 +1684,8 @@ function DungeonMiniMap({ spec }: { spec: any }) {
   )
 }
 
-function HelpModal({ onClose, onCheat }: { onClose: () => void; onCheat: () => void }) {
+function HelpModal({ onClose }: { onClose: () => void }) {
   const [page, setPage] = useState(0)
-  const bufRef = useRef('')
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      bufRef.current += e.key
-      if (bufRef.current.includes('999')) { bufRef.current = ''; onClose(); setTimeout(onCheat, 100) }
-      if (bufRef.current.length > 10) bufRef.current = bufRef.current.slice(-5)
-    }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [onClose, onCheat])
   const pages = [
     { title: 'Combat Basics', content: (
       <>
@@ -2024,13 +1934,12 @@ function getModifierArenaStyle(modifier: string | undefined): React.CSSPropertie
   }
 }
 
-function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sLog, reconcileStream, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, showCheat, onToggleCheat, floatingDmg, bossPhaseFlash, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError, kroUnlocked, onViewKroConcept, reconciling, onOpenLeaderboard, onCertTrigger, glossaryOpenCountRef, celTraceSeenRef }: {
+function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sLog, reconcileStream, showLoot, onOpenLoot, onCloseLoot, attackPhase, roomLoading, animPhase, attackTarget, showHelp, onToggleHelp, floatingDmg, bossPhaseFlash, combatModal, onDismissCombat, lootDrop, onDismissLoot, wsConnected, apiError, kroUnlocked, onViewKroConcept, reconciling, onOpenLeaderboard, onCertTrigger, glossaryOpenCountRef, celTraceSeenRef }: {
   cr: DungeonCR; prevCr?: DungeonCR | null; onBack: () => void; onNewGamePlus?: () => void; onAttack: (t: string, d: number) => void; events: WSEvent[]; k8sLog: { ts: string; cmd: string; res: string; yaml?: string }[]; reconcileStream: ReconcileDiffEvent[]
   showLoot: boolean; onOpenLoot: () => void; onCloseLoot: () => void
   attackPhase: string | null; roomLoading: boolean
   animPhase: string; attackTarget: string | null
   showHelp: boolean; onToggleHelp: () => void
-  showCheat: boolean; onToggleCheat: () => void
   floatingDmg: { target: string; amount: string; color: string } | null
   bossPhaseFlash: 'enraged' | 'berserk' | null
   combatModal: { phase: string; formula: string; heroAction: string; enemyAction: string; spec: any; oldHP: number } | null
@@ -2236,7 +2145,7 @@ function DungeonView({ cr, prevCr, onBack, onNewGamePlus, onAttack, events, k8sL
        {/* ── Mini-map ─────────────────────────────────────────────────── */}
        <DungeonMiniMap spec={spec} />
 
-      {showCheat && <CheatModal onClose={onToggleCheat} onAction={(target: string) => onAttack(target, 0)} />}
+
 
       {!wsConnected && (
         <div className="ws-reconnecting-banner">

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -701,24 +701,24 @@ stringData:
   'taunt-state-machine': {
     id: 'taunt-state-machine',
     title: 'specPatch Counter — Warrior Taunt Lifecycle',
-    tagline: 'CEL runs a 3-state counter in spec: 0 (idle) → 2 (queued) → 1 (active) → 0 (expired)',
-    body: `When you activate Taunt, the backend patches \`spec.tauntActive = 2\`. On every subsequent attack turn, the \`advanceTaunt\` specPatch node in dungeon-graph fires and decrements it:
+    tagline: 'CEL runs a 3-state counter in spec: 0 (idle) → 1 (queued) → 2 (active) → 0 (expired)',
+    body: `When you activate Taunt, \`abilityResolve\` sets \`spec.tauntActive = 1\`. On the next attack turn, the \`advanceTaunt\` specPatch node advances it to 2, and \`combatResolve\` applies the reduction. The turn after, \`advanceTaunt\` expires it back to 0:
 
-- **tauntActive = 2** — queued, damage reduction not yet applied
-- **tauntActive = 1** — active this combat turn (60% damage reduction applied in combatResolve)
+- **tauntActive = 1** — queued, set by abilityResolve, not yet protecting
+- **tauntActive = 2** — active this combat turn (60% damage reduction applied in combatResolve)
 - **tauntActive = 0** — expired, ability available again
 
 This is a **3-state CEL counter** implemented entirely in kro specPatch nodes. No backend code tracks the cooldown — kro reconciles it from spec on every attack. The Warrior's class identity is a state machine in YAML.`,
     snippet: `# dungeon-graph.yaml — advanceTaunt specPatch
-# Fires when tauntActive > 0, decrements counter each attack turn.
+# Fires when tauntActive > 0: advances 1→2 (active) or 2→0 (expired).
 - id: advanceTaunt
   type: specPatch
   includeWhen:
-    - "\${schema.spec.tauntActive > 0 && schema.spec.combatProcessedSeq > 0}"
+    - "\${schema.spec.tauntActive > 0 && schema.spec.attackSeq > schema.spec.tauntProcessedSeq}"
   patch:
-    tauntActive: "\${schema.spec.tauntActive - 1}"
-# combatResolve reads tauntActive == 1 to apply 50% damage reduction:
-# heroDmgTaken: "\${tauntActive == 1 ? int(baseDmg * 0.5) : int(baseDmg)}"`,
+    tauntActive: "\${schema.spec.tauntActive == 1 ? 2 : 0}"
+# combatResolve reads tauntActive == 2 to apply 60% damage reduction (2/5 of damage taken):
+# taunted: "\${tauntActive == 2 && pantsed > 0 ? pantsed * 2 / 5 : pantsed}"`,
     learnMore: 'manifests/rgds/dungeon-graph.yaml — advanceTaunt and combatResolve specPatch nodes',
   },
   'mana-lifecycle': {


### PR DESCRIPTION
## Summary

- Corrects AGENTS.md: the Go backend is NOT the game engine — kro CEL specPatch nodes are authoritative for all combat math, abilities, DoT, and room transitions. The backend writes trigger fields only and polls for kro to fire. The architecture table is now accurate.
- Removes the `CheatModal` component and all related state (`showCheat`, `onToggleCheat`, `onCheat`) from `App.tsx` — this was a dev shortcut that gave 999 HP and had no place in the production game.
- Fixes the `taunt-state-machine` concept in `KroTeach.tsx`: the state values `1` and `2` were swapped (docs said `2=queued, 1=active` but the RGD does `abilityResolve: 1`, `advanceTaunt: 1→2`, `combatResolve: tauntActive==2`). Also fixes the snippet comment which said 50% damage reduction when the actual CEL uses `2/5 = 60%`.