### PR TITLE
docs: pre-launch review — fix architecture claims, auth type, journey count, live URL

### DIFF
--- a/Docs/demo/DEMO.md
+++ b/Docs/demo/DEMO.md
@@ -10,7 +10,7 @@
 
 ## Pre-demo checklist (do this 5 min before going on stage)
 
-1. Open `https://learn-kro.eks.aws.dev` in a browser tab and sign in (Google OAuth).
+1. Open `https://learn-kro.eks.aws.dev` in a browser tab and sign in with GitHub.
 2. Delete any leftover dungeons from prior runs so the UI is clean.
 3. Have a dungeon open and the K8s Logs tab visible so the audience can see reconcile events immediately.
 4. Increase browser font size to 125–150% for projector visibility.
@@ -111,7 +111,7 @@ Open the **K8s Logs tab** in the event log panel. You can see the creation event
 
 ## Audience call to action
 
-1. **Scan / type:** `https://learn-kro.eks.aws.dev` — play now, no account required for the tour
+1. **Scan / type:** `https://learn-kro.eks.aws.dev` — sign in with GitHub and play (free, no setup required)
 2. **Star:** `github.com/kubernetes-sigs/kro`
 3. **Read:** `kro.run/docs` — 5-minute quickstart
 4. **Watch:** The kro panel as you play — every concept has a glossary entry

--- a/Docs/demo/speaker-notes.md
+++ b/Docs/demo/speaker-notes.md
@@ -38,9 +38,9 @@ Use this as a Q&A cheat sheet after the 5-minute demo. Each entry has a short an
 
 ## Q5: How does the game engine work without backend logic?
 
-**Short:** The Go backend computes combat math (dice rolls, damage) and patches the Dungeon CR spec. kro picks up the patch, runs CEL specPatch nodes, and writes derived state (boss phase, entity states, loot) back into spec.
+**Short:** The Go backend writes trigger fields to the Dungeon CR spec and polls until kro's `combatResolve` specPatch fires. kro CEL is the authoritative combat engine. The backend then reads the result and computes loot drops and log text.
 
-**Long:** The architecture has a clear split: the Go backend is the game engine (dice, damage calculation, HP mutations, loot drops, room transitions). It patches `spec.heroHP`, `spec.bossHP`, etc. via the Kubernetes API. kro then reconciles: it evaluates CEL specPatch nodes (`combatResolve`, `actionResolve`) that compute derived state — `bossPhase`, `entityState` for each monster, `treasureState` — and writes those back into spec. The frontend reads only from `spec` (not `status`) because status can be stale after room transitions. This is a real kro limitation you'd encounter in production too, and the game surfaces it explicitly in the InsightCards.
+**Long:** The architecture has a clean split: the backend writes trigger fields (`attackSeq`, `lastAttackTarget`, `lastAttackSeed`, etc.) to the Dungeon CR spec, then polls for the `combatResolve` specPatch result. kro evaluates CEL expressions that compute all game math — dice rolls, damage calculations (weapon/helmet/amulet/class multipliers, backstab), counter-attack chains (armor/shield/class defense/pants dodge/taunt reduction), status effect infliction (poison/burn/stun), ring regen, and HP mutations. The backend reads back kro's post-state diff (pre/post heroHP, monsterHP, bossHP) and generates log text. It never does the math itself. The frontend reads only from `spec` (not `status`) because status can be stale after room transitions — a real kro limitation the game surfaces explicitly in InsightCards.
 
 ---
 

--- a/Docs/design.txt
+++ b/Docs/design.txt
@@ -13,16 +13,17 @@ A turn-based dungeon RPG where the entire game state lives in Kubernetes, orches
 - **Treasure CR** → ConfigMap + Secret (opened/unopened state via CEL)
 - **Modifier CR** → ConfigMap (curse/blessing effects via CEL)
 - **Loot CR** → Secret (item data: type, rarity, stat via CEL)
-- **Attack CR** — CRD-only stub (attack-graph RGD); all combat logic in Go backend
+- **Attack CR** — CRD-only stub (attack-graph RGD); backend writes trigger fields, kro CEL computes all combat math via `combatResolve` specPatch
 - **Action CR** — CRD-only stub (action-graph RGD); all item/action logic in Go backend
 
 ### State Flow
 1. User creates Dungeon CR via backend API
 2. kro's dungeon-graph reconciles: creates Namespace, Hero, Monster, Boss, Treasure, Modifier CRs
 3. Each child RGD reconciles its CR into native K8s resources (ConfigMaps, Secrets)
-4. User submits Attack CR (combat) or Action CR (items) via backend API
-5. Go backend computes all game math and patches Dungeon CR spec directly
-6. Backend upserts Attack/Action CR (CRD-only stubs; no resources created by kro)
+    4. User submits Attack CR (combat) or Action CR (items) via backend API
+    5. Go backend writes trigger fields to Dungeon CR spec (`attackSeq`, `lastAttackTarget`, etc.) and polls until kro's `combatResolve` specPatch fires — kro CEL is the authoritative combat engine
+    6. Backend reads kro's result, computes loot drops and log text, writes `lastLootDrop` / `xpEarned`
+    7. Backend upserts Attack/Action CR (CRD-only stubs; no resources created by kro)
 7. kro re-reconciles child CRs based on updated Dungeon spec
 8. Frontend polls Dungeon CR for state changes
 
@@ -34,7 +35,7 @@ A turn-based dungeon RPG where the entire game state lives in Kubernetes, orches
 
 ### Combat System
 - D&D-style dice: Easy 1d20+3, Normal 2d12+6, Hard 3d20+8
-- All combat logic in Go backend (`handlers.go`)
+- All combat math computed by kro CEL (`combatResolve` specPatch in `dungeon-graph`)
 - attackSeq counter on Dungeon CR for reliable poll detection
 - Loot drops only on kill transition (OLD_HP > 0 && NEW_HP == 0)
 - Status effects: Poison (-5/turn), Burn (-8/turn), Stun (skip attack)
@@ -60,4 +61,4 @@ A turn-based dungeon RPG where the entire game state lives in Kubernetes, orches
 - EKS Auto Mode cluster (K8s 1.34) in us-west-2
 - kro self-installed via Helm (patched fork `cel-writeback-d`); Argo CD as EKS Managed Capability
 - CI: GitHub Actions builds images → ECR → rollout restart
-- Access: kubectl port-forward svc/rpg-frontend -n rpg-system 3000:3000
+- Access: https://learn-kro.eks.aws.dev (live, internet-facing ALB — no port-forward needed)

--- a/Docs/details.txt
+++ b/Docs/details.txt
@@ -17,6 +17,11 @@ Every game instance is a Dungeon custom resource. All mutable game state lives i
 - `weaponBonus` (int), `weaponUses` (int) — equipped weapon
 - `armorBonus` (int) — equipped armor defense %
 - `shieldBonus` (int) — equipped shield block %
+- `helmetBonus` (int) — equipped helmet crit chance %
+- `pantsBonus` (int) — equipped pants dodge chance %
+- `bootsBonus` (int) — equipped boots status resist %
+- `ringBonus` (int) — equipped ring HP regen per turn
+- `amuletBonus` (int) — equipped amulet damage boost %
 - `poisonTurns` (int), `burnTurns` (int), `stunTurns` (int) — status effects
 - `treasureOpened` (int) — 0/1
 - `doorUnlocked` (int) — 0/1
@@ -26,7 +31,17 @@ Every game instance is a Dungeon custom resource. All mutable game state lives i
 - `lastEnemyAction` (string) — last enemy action text
 - `lastCombatLog` (string) — JSON with full combat details
 - `lastLootDrop` (string) — item ID of last loot drop (empty if none)
-- `attackSeq` (int) — monotonic counter incremented by each attack
+- `attackSeq` (int) — monotonic counter incremented by each attack (combat trigger)
+- `actionSeq` (int) — monotonic counter incremented by each action (item/equip trigger)
+- `lastAttackTarget` (string) — combat trigger: target name
+- `lastAttackSeed` (string) — combat trigger: FNV-1a seed for dice
+- `lastAttackIndex` (int) — combat trigger: monster array index
+- `lastAttackIsBoss` (bool) — combat trigger: targeting boss
+- `lastAttackIsBackstab` (bool) — combat trigger: rogue backstab
+- `xpEarned` (int) — XP accumulated this run (kill XP written after each kill)
+- `runCount` (int) — New Game+ run number (0 = first run)
+- `monsterTypes` ([]string) — per-monster type override array
+- `initProcessedSeq` (int) — set to 1 by `dungeonInit` specPatch after initial HP values are written
 
 ## Nine ResourceGraphDefinitions
 
@@ -53,15 +68,16 @@ Modifier CR → ConfigMap. 6 modifier types with effects computed via CEL.
 Loot CR → Secret. Item data: type, rarity, stat, description via CEL.
 
 ### attack-graph (CRD-only stub)
-Defines the Attack CRD (`resources: []`). All combat logic (monster attacks, boss attacks, mage heal, warrior taunt, rogue backstab, attackSeq increment, dead-target rejection) is handled by the Go backend in `handlers.go`.
+Defines the Attack CRD (`resources: []`). The Go backend writes trigger fields (`attackSeq`, `lastAttackTarget`, `lastAttackSeed`, `lastAttackIndex`, `lastAttackIsBoss`, `lastAttackIsBackstab`) to the Dungeon CR spec, then polls until kro's `combatResolve` specPatch fires. kro CEL is authoritative for all combat math (dice, damage, HP mutations, status effects, counter-attacks). The backend only reads kro's result and computes loot drops, log text, and XP delta.
 
 ### action-graph (CRD-only stub)
-Defines the Action CRD (`resources: []`). All non-combat logic (equip weapon/armor/shield, use HP/mana potions, open treasure, unlock door, enter room 2) is handled by the Go backend. All action patches clear `lastLootDrop`. Enter-room-2 deletes stale Attack CRs.
+Defines the Action CRD (`resources: []`). Non-combat actions (equip weapon/armor/shield/helmet/pants/boots/ring/amulet, use HP/mana potions, open treasure, unlock door, enter room 2) are handled by the Go backend via `actionResolve` specPatch. All action patches clear `lastLootDrop`. Enter-room-2 deletes stale Attack CRs and triggers kro's `enterRoom2Resolve` specPatch for HP scaling.
 
-## Go Backend Combat Logic
-- Reads Dungeon CR, computes dice roll, applies modifiers/equipment/class bonuses
-- Patches Dungeon CR with merge patch (monsterHP/bossHP, heroHP, status effects, loot, attackSeq)
-- Loot drops only on kill transition: OLD_HP > 0 && NEW_HP == 0
+## Go Backend Role
+- Writes trigger fields to Dungeon CR spec, polls for kro's `combatResolve`/`actionResolve` specPatch results
+- Computes loot drops (kill-transition detection: OLD_HP > 0 && NEW_HP == 0), drop chance, rarity roll, item selection
+- Generates log text by reading kro's pre/post spec diff — no game math
+- Computes XP delta and writes `xpEarned`; records leaderboard and profile on dungeon deletion
 - Boss target matching: `-boss$` suffix regex (not just "boss" anywhere in name)
 - Already-dead targets: patches lastHeroAction but does NOT increment attackSeq
 - Game-over check: rejects combat when heroHP ≤ 0 or (bossHP ≤ 0 && all monsters dead)
@@ -82,8 +98,4 @@ Defines the Action CRD (`resources: []`). All non-combat logic (equip weapon/arm
 - Guardrails: 34 tests (RBAC, no game logic leaks, loot guards, animation guards, combat/action separation)
 - Backend API: 21 tests (CRUD, validation, rate limiting, metrics)
 - UI Smoke: 59 Playwright tests (page load, forms, classes, routing, modals)
-- Journey 1: 17 tests (warrior full UI playthrough)
-- Journey 4: 25 tests (items & equipment)
-- Journey 7: 21 tests (dungeon management)
-- Journey 8: 25 tests (edge cases)
-- Journey 10: 17 tests (visual & animation consistency)
+- Journey tests: 40 files (01–41, skipping 36) covering full UI gameplay sessions

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each dungeon instance gets its own Namespace for isolation and clean teardown.
 
 1. **Create a Dungeon** — specify a name, monster count (1–10), difficulty (easy/normal/hard), and hero class (warrior/mage/rogue)
 2. **kro reconciles** — dungeon-graph creates a Namespace, Hero CR, Monster CRs (one per monster, via forEach), Boss CR, Treasure CR, Modifier CR, and a `gameConfig` ConfigMap — all wired together via CEL expressions. Virtual `specPatch` and `stateWrite` nodes in dungeon-graph write computed state back to the Dungeon CR spec.
-3. **Attack monsters** — the frontend submits a POST to the backend; the backend runs all combat math in Go (FNV-1a seeded dice, class abilities, modifiers, status effects), patches the Dungeon CR spec directly (new HP values, `attackSeq`, `lastAttackTarget`, loot), and upserts an Attack CR as a signal
+3. **Attack monsters** — the frontend submits a POST to the backend; the backend writes trigger fields (`attackSeq`, `lastAttackTarget`, `lastAttackSeed`, `lastAttackIndex`, `lastAttackIsBoss`, `lastAttackIsBackstab`) to the Dungeon CR and polls until kro's `combatResolve` specPatch fires — kro CEL is the authoritative combat engine. The backend then reads the result, computes loot drops and log text, and writes `lastLootDrop` and `xpEarned`.
 4. **Use items** — same pattern via Action CR; the backend runs item/equip/room logic and patches the spec directly
 5. **Boss unlocks** — when all monster HP = 0, kro's CEL in `boss-graph` transitions `bossState` to `ready`; the Dungeon CR status aggregates this via `dungeon-graph` CEL
 6. **Defeat the boss** — boss has three phases driven by HP thresholds in `boss-graph` CEL (Phase 1 → Phase 2 ENRAGED → Phase 3 BERSERK), each with higher counter damage and special attack chance
@@ -61,7 +61,7 @@ Each dungeon instance gets its own Namespace for isolation and clean teardown.
 ```
 
 - **Frontend** — 8-bit pixel art React SPA. All game state read from Dungeon CR `spec` (not `status`, which can be stale after room transitions). Nginx reverse-proxies `/api/` to the backend. Includes a kro teaching layer: InsightCards, KroGlossary, CelTrace, live resource graph (KroGraph), Inspector panel, and an in-browser CEL Playground.
-- **Backend** — Stateless Go service. Only touches Dungeon, Attack, and Action CRs — never reads Pods, Secrets, or Jobs directly. Routes non-combat actions to Action CR, combat to Attack CR. Runs all game math in Go. Includes rate limiting (300 ms/dungeon), Prometheus metrics on `/metrics`, and a CEL eval endpoint.
+- **Backend** — Stateless Go service. Only touches Dungeon, Attack, and Action CRs — never reads Pods, Secrets, or Jobs directly. Writes trigger fields to the Dungeon CR spec and polls for kro's CEL specPatch results; computes loot drops, log text, XP, leaderboard entries, and room-transition triggers. Includes rate limiting (300 ms/dungeon), Prometheus metrics on `/metrics`, and a CEL eval endpoint.
 - **Kubernetes + kro** — Sole source of truth. Nine RGDs orchestrate the game via CR chaining. kro is self-installed via Helm (patched fork `cel-writeback-d`).
 - **Argo CD** — Runs as an [EKS Managed Capability](https://docs.aws.amazon.com/eks/latest/userguide/argocd.html). Continuously syncs all cluster manifests from this repo. GitHub webhook provides ~6 s sync latency.
 - **Observability** — CloudWatch Container Insights, structured JSON logs from the backend, CloudWatch dashboard and alarms. Prometheus metrics scraped from `/metrics`.
@@ -123,7 +123,7 @@ All nine ResourceGraphDefinitions live in `manifests/rgds/`:
 │   ├── backend-api.sh       # REST API tests (21 tests)
 │   └── e2e/
 │       ├── smoke-test.js    # Playwright smoke tests (59 assertions)
-│       └── journeys/        # 32 gameplay journey tests
+│       └── journeys/        # 40 gameplay journey tests
 ├── scripts/
 │   ├── ui-test.sh           # Deploy-and-test script (push → sync → smoke test)
 │   └── watch-dungeon.sh     # tmux dashboard for watching game state live
@@ -140,13 +140,19 @@ All nine ResourceGraphDefinitions live in `manifests/rgds/`:
 
 ### Access the UI
 
+The game is live at **https://learn-kro.eks.aws.dev** — sign in with GitHub, create a dungeon, fight monsters, defeat the boss.
+
+For local development against your own cluster:
+
 ```bash
 kubectl port-forward svc/rpg-frontend -n rpg-system 3000:3000
 ```
 
-Open http://localhost:3000 — create a dungeon, fight monsters, defeat the boss.
+Open http://localhost:3000
 
 ### Access the backend API directly
+
+For local development:
 
 ```bash
 kubectl port-forward svc/rpg-backend -n rpg-system 8080:8080
@@ -426,13 +432,13 @@ tests/run-all.sh
 tests/run.sh            # Integration: core lifecycle, abilities, features, infra
 tests/guardrails.sh     # Architecture guardrails (~34 assertions)
 tests/backend-api.sh    # REST API (21 tests)
-BASE_URL=http://localhost:3000 node tests/e2e/smoke-test.js   # UI smoke (59 assertions)
+BASE_URL=https://learn-kro.eks.aws.dev node tests/e2e/smoke-test.js   # UI smoke (59 assertions)
 
 # Run a specific journey
-BASE_URL=http://localhost:3000 node tests/e2e/journeys/20-leaderboard.js
+BASE_URL=https://learn-kro.eks.aws.dev node tests/e2e/journeys/20-leaderboard.js
 ```
 
-### Journey tests (32 total)
+### Journey tests (40 total)
 
 | # | Journey | Focus |
 |---|---|---|
@@ -468,6 +474,14 @@ BASE_URL=http://localhost:3000 node tests/e2e/journeys/20-leaderboard.js
 | 30 | Room 2 Boss Phases | Bat-boss ENRAGED/BERSERK |
 | 31 | Inspector: specPatch nodes | KroGraph Inspector for combatResolve/actionResolve |
 | 32 | CEL Playground Live Eval | Round-trip through CelEvalHandler |
+| 33 | User Profile | Stats, XP, badges after dungeon delete |
+| 34 | XP Levelling | XP accumulation, level-up thresholds |
+| 35 | Certificates | kro Expert Certificate unlock |
+| 37 | Social Run Card | Shareable SVG run card |
+| 38 | Conference Demo | End-to-end demo flow |
+| 39 | Reconcile Stream | Field-diff stream in kro tab |
+| 40 | Blog Post Generator | AI narrative generation panel |
+| 41 | Workshop Kit | Workshop helper UI |
 
 ## License
 


### PR DESCRIPTION
## Summary

Pre-launch doc audit across README.md, Docs/design.txt, Docs/details.txt, Docs/demo/DEMO.md, Docs/demo/speaker-notes.md.

### Incorrect architecture claims (kro vs Go backend)
- README "How It Works" step 3 and Architecture section claimed the Go backend "runs all combat math in Go" — **wrong since PR #542**. kro CEL (`combatResolve` specPatch) is the authoritative combat engine; the backend writes trigger fields and polls for the result.
- Same incorrect claim in Docs/design.txt (state flow step 5, combat system section) and Docs/details.txt (attack-graph description, "Go Backend Combat Logic" section).
- Docs/demo/speaker-notes.md Q5 long answer described Go as "the game engine" — corrected to accurately describe the trigger-field / CEL-poll split.

### Wrong auth provider
- Docs/demo/DEMO.md said "sign in (Google OAuth)" — it's **GitHub OAuth**.
- Same file also said "no account required for the tour" which contradicted the sign-in requirement on the same page — clarified to "sign in with GitHub (free, no setup required)".

### Stale journey test count
- README and project structure listed 32 journey tests — there are **40** (files 01–41, skipping 36).
- Added missing journeys 33–41 to the README journey table.
- Docs/details.txt listed only 5 representative journeys — replaced with a single accurate summary line.

### Port-forward references
- README "Running the Game" section led with port-forward — now leads with the live URL (`https://learn-kro.eks.aws.dev`) and moves port-forward to a local-dev note.
- Test commands used `BASE_URL=http://localhost:3000` — changed to `https://learn-kro.eks.aws.dev`.
- Docs/design.txt infrastructure section referenced port-forward — replaced with live URL.

### Missing spec fields
- Docs/details.txt spec field list was missing: `actionSeq`, all 5 new equipment slots (helmet/pants/boots/ring/amulet), and all 6 combat trigger fields (`lastAttackTarget`, `lastAttackSeed`, `lastAttackIndex`, `lastAttackIsBoss`, `lastAttackIsBackstab`, `initProcessedSeq`, `xpEarned`, `runCount`, `monsterTypes`) — all added.