### PR TITLE
fix: record leaderboard and profile immediately on victory, not just on delete

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -1697,6 +1697,27 @@ func (h *Handler) processCombat(ctx context.Context, r *http.Request, ns, name, 
 			"xpEarned":        newXPEarned,
 		},
 	}
+
+	// Record leaderboard + profile immediately on victory so the run appears
+	// in the leaderboard without requiring the player to delete the dungeon.
+	// recordLeaderboard uses dungeonName as the ConfigMap key, so a second
+	// write at delete-time is a harmless overwrite with identical data.
+	if combatOutcome == "victory" {
+		victoryLogin := "anonymous"
+		if sess := sessionFromCtx(r.Context()); sess != nil {
+			victoryLogin = sess.Login
+		}
+		// Build a merged spec that includes the final xpEarned value (not yet
+		// written to the CR) so the leaderboard entry reflects the full run XP.
+		victorySpec := make(map[string]interface{}, len(postSpec)+1)
+		for k, v := range postSpec {
+			victorySpec[k] = v
+		}
+		victorySpec["xpEarned"] = newXPEarned
+		go h.recordLeaderboard(victorySpec, postStatus, name, victoryLogin)
+		go h.recordProfile(victoryLogin, victorySpec, postStatus)
+	}
+
 	return h.patchAndRespond(ctx, ns, name, logPatch, w)
 }
 


### PR DESCRIPTION
## Problem

The leaderboard and player profile are only written when a dungeon is deleted (via `DeleteDungeon` → `go recordLeaderboard` / `go recordProfile`). Players who win and immediately start a New Game+ — or who just leave the browser — never appear on the leaderboard until the Dungeon Reaper cleans up their dungeon up to 4 hours later.

Observed live: @AnuragAnalog completed a full Room 2 victory but did not appear on the leaderboard because they started a New Game+ instead of deleting the dungeon.

## Fix

In `processCombat`, when `combatOutcome == "victory"`, immediately fire `go recordLeaderboard` and `go recordProfile` before returning the response. The victory spec snapshot includes the final `xpEarned` value (which hasn't been written to the CR yet at that point) so the leaderboard entry reflects the full run.

`recordLeaderboard` uses the dungeon name as the ConfigMap key, so the subsequent write at delete-time is a harmless idempotent overwrite — no dedup logic needed.

No dungeons are deleted as part of this fix.