### PR TITLE
security: enforce TLS 1.2+ on public ALB (#556)

### DIFF
--- a/manifests/system/ingress.yaml
+++ b/manifests/system/ingress.yaml
@@ -38,6 +38,7 @@ metadata:
     # HTTP/2 does not support the Upgrade header, so WS connections fail with 400
     # when the ALB negotiates HTTP/2 with the backend.
     alb.ingress.kubernetes.io/backend-protocol-version: HTTP1
+    alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
 spec:
   ingressClassName: krombat
   rules:


### PR DESCRIPTION
## Summary

- Adds `alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"` to the `Ingress` in `manifests/system/ingress.yaml`
- Drops TLS 1.0 and TLS 1.1 support; enforces TLS 1.2+ (both TLS 1.2 and TLS 1.3 are allowed)
- Argo CD syncs within ~6s of merge — no Terraform or manual ALB change required

Closes #556