### PR TITLE
fix: gear starts in backpack on New Game+, not pre-equipped (#555)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -118,16 +118,9 @@ type CreateDungeonReq struct {
 	HeroClass  string `json:"heroClass"`
 	Namespace  string `json:"namespace"`
 	// New Game+ carry-over fields (optional, 0 = fresh start)
-	RunCount    int64 `json:"runCount"`
-	WeaponBonus int64 `json:"weaponBonus"`
-	WeaponUses  int64 `json:"weaponUses"`
-	ArmorBonus  int64 `json:"armorBonus"`
-	ShieldBonus int64 `json:"shieldBonus"`
-	HelmetBonus int64 `json:"helmetBonus"`
-	PantsBonus  int64 `json:"pantsBonus"`
-	BootsBonus  int64 `json:"bootsBonus"`
-	RingBonus   int64 `json:"ringBonus"`
-	AmuletBonus int64 `json:"amuletBonus"`
+	// NOTE: *Bonus fields are intentionally ignored — gear is carried in
+	// inventory only and the player re-equips each run to avoid double-dipping.
+	RunCount int64 `json:"runCount"`
 }
 
 func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
@@ -196,20 +189,15 @@ func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// #423: validate equipment bonus values have a reasonable upper bound.
-	// Prevents leaderboard cheating via inflated weapon/armor stats.
-	const maxEquipBonus = 50
-	if req.WeaponBonus > maxEquipBonus || req.ArmorBonus > maxEquipBonus ||
-		req.ShieldBonus > maxEquipBonus || req.HelmetBonus > maxEquipBonus ||
-		req.PantsBonus > maxEquipBonus || req.BootsBonus > maxEquipBonus ||
-		req.RingBonus > maxEquipBonus || req.AmuletBonus > maxEquipBonus {
-		writeError(w, fmt.Sprintf("equipment bonus values must not exceed %d", maxEquipBonus), http.StatusBadRequest)
-		return
-	}
+	// (Bonus fields are no longer accepted on dungeon creation — gear is
+	// carried in inventory only. This block is kept for safety against
+	// unexpected future field additions.)
 
-	// Load persistent profile to pre-populate inventory and equipment for returning players.
-	// Only applied when the request carries no explicit gear (i.e. not a manual New Game+).
+	// Load persistent profile to pre-populate inventory for returning players.
+	// Equipment bonuses are NOT carried over — items are in inventory and the
+	// player re-equips each run, preventing gear from being both equipped and
+	// in the backpack simultaneously (#555).
 	var profileInv string
-	var profileEquip map[string]int64
 	if sess != nil {
 		ctx0 := context.Background()
 		cmClient0 := h.client.Dynamic.Resource(leaderboardGVR).Namespace(leaderboardNamespace)
@@ -218,13 +206,6 @@ func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
 				p := profileFromData(d, sess.Login)
 				if p.HeroHP > 0 || p.Inventory != "" {
 					profileInv = p.Inventory
-					profileEquip = map[string]int64{
-						"weaponBonus": p.WeaponBonus, "weaponUses": p.WeaponUses,
-						"armorBonus": p.ArmorBonus, "shieldBonus": p.ShieldBonus,
-						"helmetBonus": p.HelmetBonus, "pantsBonus": p.PantsBonus,
-						"bootsBonus": p.BootsBonus, "ringBonus": p.RingBonus,
-						"amuletBonus": p.AmuletBonus,
-					}
 				}
 			}
 		}
@@ -239,42 +220,9 @@ func (h *Handler) CreateDungeon(w http.ResponseWriter, r *http.Request) {
 		"heroClass":  heroClass,
 		"runCount":   runCount,
 	}
-	// Carry over gear bonuses: explicit request values take priority,
-	// then fall back to persistent profile values for returning players.
-	applyBonus := func(field string, reqVal int64, profileVal int64) {
-		if reqVal > 0 {
-			dungeonSpec[field] = reqVal
-		} else if profileVal > 0 {
-			dungeonSpec[field] = profileVal
-		}
-	}
-	var profWeaponUses, profWeaponBonus, profArmorBonus, profShieldBonus int64
-	var profHelmetBonus, profPantsBonus, profBootsBonus, profRingBonus, profAmuletBonus int64
-	if profileEquip != nil {
-		profWeaponBonus = profileEquip["weaponBonus"]
-		profWeaponUses = profileEquip["weaponUses"]
-		profArmorBonus = profileEquip["armorBonus"]
-		profShieldBonus = profileEquip["shieldBonus"]
-		profHelmetBonus = profileEquip["helmetBonus"]
-		profPantsBonus = profileEquip["pantsBonus"]
-		profBootsBonus = profileEquip["bootsBonus"]
-		profRingBonus = profileEquip["ringBonus"]
-		profAmuletBonus = profileEquip["amuletBonus"]
-	}
-	applyBonus("weaponBonus", req.WeaponBonus, profWeaponBonus)
-	if req.WeaponUses > 0 {
-		dungeonSpec["weaponUses"] = req.WeaponUses
-	} else if profWeaponUses > 0 {
-		dungeonSpec["weaponUses"] = profWeaponUses
-	}
-	applyBonus("armorBonus", req.ArmorBonus, profArmorBonus)
-	applyBonus("shieldBonus", req.ShieldBonus, profShieldBonus)
-	applyBonus("helmetBonus", req.HelmetBonus, profHelmetBonus)
-	applyBonus("pantsBonus", req.PantsBonus, profPantsBonus)
-	applyBonus("bootsBonus", req.BootsBonus, profBootsBonus)
-	applyBonus("ringBonus", req.RingBonus, profRingBonus)
-	applyBonus("amuletBonus", req.AmuletBonus, profAmuletBonus)
-	// Carry persistent inventory if no explicit inventory was provided.
+	// Carry persistent inventory only — no *Bonus fields (#555).
+	// Items start in the backpack; the player equips them manually each run.
+	// kro actionResolve will set the bonus fields when the player equips.
 	if profileInv != "" {
 		dungeonSpec["inventory"] = profileInv
 	}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -783,15 +783,8 @@ export default function App() {
     try {
       await createNewGamePlus(newName, spec.monsters ?? 3, spec.difficulty ?? 'normal', spec.heroClass ?? 'warrior', {
         runCount,
-        weaponBonus: spec.weaponBonus,
-        weaponUses: spec.weaponUses,
-        armorBonus: spec.armorBonus,
-        shieldBonus: spec.shieldBonus,
-        helmetBonus: spec.helmetBonus,
-        pantsBonus: spec.pantsBonus,
-        bootsBonus: spec.bootsBonus,
-        ringBonus: spec.ringBonus,
-        amuletBonus: spec.amuletBonus,
+        // *Bonus fields intentionally omitted — gear starts in backpack (inventory),
+        // player re-equips each run (#555). Backend also ignores these fields now.
       }, ns)
       navigate(`/dungeon/${ns}/${newName}`)
       trackEvent('dungeon_created', { monsters: spec.monsters ?? 3, difficulty: spec.difficulty ?? 'normal', heroClass: spec.heroClass ?? 'warrior', runCount })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -95,8 +95,7 @@ export async function createDungeon(name: string, monsters: number, difficulty: 
 
 export interface NewGamePlusOptions {
   runCount: number
-  weaponBonus?: number; weaponUses?: number; armorBonus?: number; shieldBonus?: number
-  helmetBonus?: number; pantsBonus?: number; bootsBonus?: number; ringBonus?: number; amuletBonus?: number
+  // *Bonus fields removed — gear is carried in inventory only (#555)
 }
 
 export async function createNewGamePlus(

--- a/tests/backend-api.sh
+++ b/tests/backend-api.sh
@@ -299,10 +299,10 @@ sleep 15
 BASE_SPEC=$(curl -s "${AUTH_H[@]}" "$BASE/api/v1/dungeons/default/$BASE_DUNGEON")
 BASE_MONSTER_HP=$(echo "$BASE_SPEC" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['spec']['monsterHP'][0])" 2>/dev/null || echo "0")
 
-# Create New Game+ dungeon with runCount=1 and inherited gear
+# Create New Game+ dungeon with runCount=1 — bonus fields are ignored by backend (#555)
 NG_RESP=$(curl -s -w "\n%{http_code}" -X POST "$BASE/api/v1/dungeons" \
   -H "Content-Type: application/json" "${AUTH_H[@]}" \
-  -d "{\"name\":\"$NG_DUNGEON\",\"monsters\":2,\"difficulty\":\"easy\",\"heroClass\":\"warrior\",\"runCount\":1,\"weaponBonus\":5,\"weaponUses\":3,\"armorBonus\":15}")
+  -d "{\"name\":\"$NG_DUNGEON\",\"monsters\":2,\"difficulty\":\"easy\",\"heroClass\":\"warrior\",\"runCount\":1}")
 NG_CODE=$(echo "$NG_RESP" | tail -1)
 [ "$NG_CODE" = "201" ] && pass "POST /dungeons with runCount=1 -> 201" || fail "POST /dungeons NG+ -> $NG_CODE (expected 201)"
 
@@ -317,13 +317,15 @@ spec=d.get('spec',{})
 assert spec.get('runCount') == 1, f'runCount should be 1, got {spec.get(\"runCount\")}'
 print('runCount=1 OK')
 
-# weaponBonus must carry over
-assert spec.get('weaponBonus') == 5, f'weaponBonus should be 5, got {spec.get(\"weaponBonus\")}'
-print('weaponBonus=5 OK')
+# #555: weaponBonus must NOT be pre-set at dungeon creation (items in inventory, equip manually)
+wb = spec.get('weaponBonus', 0)
+assert wb == 0, f'weaponBonus should be 0 at NG+ creation (inventory-only model), got {wb}'
+print('weaponBonus=0 (inventory-only) OK')
 
-# armorBonus must carry over
-assert spec.get('armorBonus') == 15, f'armorBonus should be 15, got {spec.get(\"armorBonus\")}'
-print('armorBonus=15 OK')
+# #555: armorBonus must NOT be pre-set at dungeon creation
+ab = spec.get('armorBonus', 0)
+assert ab == 0, f'armorBonus should be 0 at NG+ creation (inventory-only model), got {ab}'
+print('armorBonus=0 (inventory-only) OK')
 
 # Hero HP must be boosted (110% of base for warrior=200)
 base_hp = 200
@@ -332,8 +334,8 @@ actual_hp = spec.get('heroHP', 0)
 assert actual_hp == expected_hp, f'heroHP should be {expected_hp} for NG+1 warrior, got {actual_hp}'
 print(f'heroHP={actual_hp} (expected {expected_hp}) OK')
 " 2>/dev/null \
-  && pass "NG+ spec fields correct (runCount, weaponBonus, armorBonus, heroHP scaled)" \
-  || fail "NG+ spec fields incorrect — check runCount/gear carry-over/HP scaling"
+  && pass "NG+ spec fields correct (runCount, no bonus pre-set, heroHP scaled) (#555)" \
+  || fail "NG+ spec fields incorrect — check runCount/inventory-only carry-over/HP scaling"
 
 # Monster HP must be scaled 125% vs base
 echo "$BASE_MONSTER_HP $NG_SPEC" | python3 -c "

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -452,19 +452,14 @@ echo "=== New Game+ guardrails"
 grep -q "runCount" backend/internal/handlers/handlers.go && pass "Backend handles runCount in CreateDungeon" || fail "Backend missing runCount handling"
 grep -q "runCount.*20\|20.*runCount" backend/internal/handlers/handlers.go && pass "Backend clamps runCount to max 20 (overflow guard)" || fail "Backend missing runCount overflow guard"
 grep -q "1\.25\|125\|scale.*125\|125.*scale" manifests/rgds/dungeon-graph.yaml && pass "kro dungeon-graph applies 1.25x HP scaling per NG+ run (CEL)" || fail "dungeon-graph missing 1.25x NG+ HP scaling"
+# NG+ carry-over: gear must be in inventory only — no *Bonus fields at creation (#555)
 grep -q "createNewGamePlus" frontend/src/api.ts && pass "Frontend api.ts exports createNewGamePlus" || fail "createNewGamePlus missing from api.ts"
 grep -q "onNewGamePlus\|handleNewGamePlus" frontend/src/App.tsx && pass "App.tsx wires New Game+ handler" || fail "App.tsx missing New Game+ handler"
 grep -q "ng-plus-badge" frontend/src/App.tsx && pass "App.tsx renders NG+ badge on dungeon tiles" || fail "App.tsx missing NG+ badge"
-# NG+ carry-over completeness: all 8 gear fields must be present in CreateDungeonReq and carry-over block
-grep -q "BootsBonus" backend/internal/handlers/handlers.go && pass "Backend CreateDungeonReq includes BootsBonus for NG+ carry-over" || fail "BootsBonus missing from CreateDungeonReq — boots not carried over on NG+"
-grep -q "bootsBonus.*req\.BootsBonus\|req\.BootsBonus.*bootsBonus" backend/internal/handlers/handlers.go && pass "Backend applies BootsBonus to dungeonSpec in CreateDungeon" || fail "BootsBonus not applied to dungeonSpec"
-grep -q "bootsBonus" frontend/src/App.tsx && pass "Frontend handleNewGamePlus sends bootsBonus" || fail "Frontend missing bootsBonus in handleNewGamePlus call"
-grep -q "RingBonus" backend/internal/handlers/handlers.go && pass "Backend CreateDungeonReq includes RingBonus for NG+ carry-over" || fail "RingBonus missing from CreateDungeonReq — ring not carried over on NG+"
-grep -q "ringBonus.*req\.RingBonus\|req\.RingBonus.*ringBonus" backend/internal/handlers/handlers.go && pass "Backend applies RingBonus to dungeonSpec in CreateDungeon" || fail "RingBonus not applied to dungeonSpec"
-grep -q "ringBonus" frontend/src/App.tsx && pass "Frontend handleNewGamePlus sends ringBonus" || fail "Frontend missing ringBonus in handleNewGamePlus call"
-grep -q "AmuletBonus" backend/internal/handlers/handlers.go && pass "Backend CreateDungeonReq includes AmuletBonus for NG+ carry-over" || fail "AmuletBonus missing from CreateDungeonReq — amulet not carried over on NG+"
-grep -q "amuletBonus.*req\.AmuletBonus\|req\.AmuletBonus.*amuletBonus" backend/internal/handlers/handlers.go && pass "Backend applies AmuletBonus to dungeonSpec in CreateDungeon" || fail "AmuletBonus not applied to dungeonSpec"
-grep -q "amuletBonus" frontend/src/App.tsx && pass "Frontend handleNewGamePlus sends amuletBonus" || fail "Frontend missing amuletBonus in handleNewGamePlus call"
+# Ensure bonus fields are NOT applied at dungeon creation (fix for double-equip bug #555)
+! grep -q "applyBonus\|req\.BootsBonus\|req\.RingBonus\|req\.AmuletBonus\|req\.WeaponBonus\|req\.ArmorBonus\|req\.ShieldBonus\|req\.HelmetBonus\|req\.PantsBonus" backend/internal/handlers/handlers.go && pass "#555: Backend CreateDungeon does NOT apply *Bonus fields (inventory-only carry-over)" || fail "#555: Backend CreateDungeon still applies *Bonus fields — gear double-equip bug not fixed"
+# Ensure frontend does NOT send bonus fields in New Game+ request
+! grep -q "weaponBonus: spec\|armorBonus: spec\|shieldBonus: spec\|helmetBonus: spec\|pantsBonus: spec\|bootsBonus: spec\|ringBonus: spec\|amuletBonus: spec" frontend/src/App.tsx && pass "#555: Frontend handleNewGamePlus does not send *Bonus fields" || fail "#555: Frontend handleNewGamePlus still sends *Bonus fields — update to inventory-only carry-over"
 
 # --- Boss loot invariants ---
 echo "=== Boss loot invariants"
@@ -599,8 +594,8 @@ grep -A10 "func requireDungeonOwner" backend/internal/handlers/handlers.go | gre
 [ -f manifests/system/admission-policy.yaml ] && pass "#422: ValidatingAdmissionPolicy manifest exists" || fail "#422: ValidatingAdmissionPolicy manifest missing"
 grep -q "krombat.io/owner" manifests/system/admission-policy.yaml && pass "#422: admission policy enforces krombat.io/owner label" || fail "#422: admission policy does not reference krombat.io/owner"
 
-# #423: equipment bonus upper bound must be enforced
-grep -q "maxEquipBonus\|equip.*50\|50.*equip" backend/internal/handlers/handlers.go && pass "#423: maxEquipBonus constant present in CreateDungeon" || fail "#423: maxEquipBonus missing from CreateDungeon"
+# #423/#555: equipment bonus fields must NOT be accepted at dungeon creation (inventory-only model)
+! grep -q "req\.WeaponBonus\|req\.ArmorBonus\|req\.ShieldBonus\|req\.HelmetBonus\|req\.PantsBonus\|req\.BootsBonus\|req\.RingBonus\|req\.AmuletBonus" backend/internal/handlers/handlers.go && pass "#423/#555: CreateDungeon ignores *Bonus request fields (inventory-only carry-over)" || fail "#423/#555: CreateDungeon still reads *Bonus fields from request"
 grep -q "maximum=50" manifests/rgds/dungeon-graph.yaml && pass "#423: dungeon-graph RGD has maximum=50 on bonus fields" || fail "#423: dungeon-graph RGD missing maximum=50 on bonus fields"
 
 # --- Security P3 guardrails (#424-#429) ---


### PR DESCRIPTION
## Summary

- Removes `*Bonus` fields from `CreateDungeonReq` and the `applyBonus` carry-over block in `CreateDungeon`
- Items in `inventory` are carried to the new dungeon; the player re-equips them manually each run
- kro `actionResolve` sets the bonus fields on equip as normal — no double-dipping
- Frontend `handleNewGamePlus` no longer sends `*Bonus` fields (they were ignored by backend anyway)
- `NewGamePlusOptions` interface in `api.ts` cleaned up
- Guardrails and backend-api tests updated to assert new inventory-only behaviour

Closes #555