### PR TITLE
fix: suppress onboarding modal in journey tests via addInitScript (#534)

### DIFF
--- a/tests/e2e/journeys/helpers.js
+++ b/tests/e2e/journeys/helpers.js
@@ -201,6 +201,13 @@ async function testLogin(page, baseUrl) {
     // No token available — skip; test will fail if login screen is shown
     return;
   }
+  // Suppress the onboarding overlay for every page load in this context.
+  // The overlay blocks pointer events until dismissed; commit 51191c4 made it
+  // appear on every fresh browser context (#534).
+  await page.addInitScript(() => {
+    localStorage.setItem('kroOnboardingDone', 'true');
+  });
+
   const loginUrl = `${baseUrl}/api/v1/auth/test-login?token=${encodeURIComponent(token)}`;
   await page.goto(loginUrl, { timeout: 15000 });
   // The endpoint redirects to '/' — wait for the main app to load


### PR DESCRIPTION
## Summary
- Uses `page.addInitScript()` in `testLogin` to set `localStorage.kroOnboardingDone = 'true'` before any page script runs
- This prevents the onboarding modal (added in commit `51191c4`) from rendering in fresh Playwright browser contexts
- The modal was blocking pointer events on the dungeon name input, causing `page.fill` to time out

Closes #534