### PR TITLE
docs: refresh kro PR #1148 merged status and rename lists.set* across teaching content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,7 +349,7 @@ Sign at: https://easycla.lfx.linuxfoundation.org
 - Any reference to the krombat game, game logic, or game-specific CEL patterns
 - The 3-arg `random.seededInt(min, max, seed)` signature changes — already upstream
 - `ext.Bindings()` / `cel.bind()` — **already merged upstream** (PR #1145)
-- `lists.setIndex`, `lists.insertAt`, `lists.removeAt` — **in review upstream** (PR #1148)
+- `lists.setAtIndex`, `lists.insertAtIndex`, `lists.removeAtIndex` — **already merged upstream** (PR #1148)
 
 ### Isolation check before opening a PR
 

--- a/backend/internal/handlers/cel_eval.go
+++ b/backend/internal/handlers/cel_eval.go
@@ -9,7 +9,7 @@ package handlers
 //   - library.Random() (random.seededInt, random.seededString)
 //   - library.Maps()  (maps.*)
 //   - library.JSON()  (json.*)
-//   - library.Lists() (lists.setIndex, lists.insertAt, lists.removeAt)
+//   - library.Lists() (lists.setAtIndex, lists.insertAtIndex, lists.removeAtIndex)
 //   - library.CSV()   (csv.add, csv.remove, csv.contains)
 //
 // Variable bindings follow the same schema as kro RGD expressions:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1034,9 +1034,9 @@ const FAQ_ITEMS: { q: string; a: () => ReactNode }[] = [
               <td><a href="https://github.com/kubernetes-sigs/kro/pull/1145" target="_blank" rel="noopener noreferrer" className="faq-link">Merged upstream (PR #1145)</a></td>
             </tr>
             <tr>
-              <td><code>lists.setIndex</code>, <code>lists.insertAt</code>, <code>lists.removeAt</code></td>
+              <td><code>lists.setAtIndex</code>, <code>lists.insertAtIndex</code>, <code>lists.removeAtIndex</code></td>
               <td>Index-mutation functions for CEL lists. CEL has no built-in way to return a new list with a single element replaced — these fill that gap and are essential for updating per-monster HP arrays.</td>
-              <td><a href="https://github.com/kubernetes-sigs/kro/pull/1148" target="_blank" rel="noopener noreferrer" className="faq-link">In review upstream (PR #1148)</a>, expected to merge soon</td>
+              <td><a href="https://github.com/kubernetes-sigs/kro/pull/1148" target="_blank" rel="noopener noreferrer" className="faq-link">Merged upstream (PR #1148)</a></td>
             </tr>
             <tr>
               <td><code>random.seededInt</code>, <code>random.seededString</code></td>
@@ -1050,7 +1050,7 @@ const FAQ_ITEMS: { q: string; a: () => ReactNode }[] = [
             </tr>
           </tbody>
         </table>
-        <p>The goal is to upstream <code>specPatch</code> and <code>stateWrite</code> once the design has been agreed with the kro maintainers. The CEL library additions (<code>cel.bind</code>, list mutations, seeded random) are already on their way — two are merged, one is in review.</p>
+        <p>The goal is to upstream <code>specPatch</code> and <code>stateWrite</code> once the design has been agreed with the kro maintainers. The CEL library additions (<code>cel.bind</code>, list mutations, seeded random) are all merged upstream.</p>
       </>
     ),
   },

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -174,7 +174,7 @@ The damage you just dealt was computed by CEL inside a specPatch node in dungeon
     # Dice roll seeded by lastAttackSeed for deterministic replay
     monsterHP: >-
       \${schema.spec.difficulty == 'easy'
-        ? lists.set(schema.spec.monsterHP, idx,
+        ? lists.setAtIndex(schema.spec.monsterHP, idx,
             schema.spec.monsterHP[idx] - (roll + 2))
         : ...}
     combatProcessedSeq: "\${schema.spec.attackSeq}"`,
@@ -574,7 +574,7 @@ This means every kro extension is available in the Playground:
 - \`cel.bind(x, schema.spec.heroHP, x * 2)\` — bind macro (same as dungeon-graph.yaml)
 - \`random.seededInt(0, 20, "seed")\` — deterministic random (same RNG kro uses)
 - \`csv.add(schema.spec.inventory, "sword", 5)\` — CSV item manipulation
-- \`lists.set([1, 2, 3], 0, 99)\` — list mutation
+- \`lists.setAtIndex([1, 2, 3], 0, 99)\` — list mutation
 - \`schema.spec.heroClass.startsWith("war")\` — string functions
 
 Try expressions that mirror real kro RGD patterns:
@@ -1726,7 +1726,7 @@ export function KroCelPlayground({ dungeonNs, dungeonName, onLearnConcept, onClo
           <div style={{ flex: 1 }} />
           <div className="kro-playground-supported">
             {/* #453: list all kro CEL extensions registered in BaseDeclarations() */}
-            Supported: field access · arithmetic · ternary · string() · int() · size() · has() · cel.bind() · random.seededInt/String() · lists.set/range/filter() · csv.add/remove() · maps.* · 500 char limit
+            Supported: field access · arithmetic · ternary · string() · int() · size() · has() · cel.bind() · random.seededInt/String() · lists.setAtIndex/insertAtIndex/removeAtIndex/range/filter() · csv.add/remove() · maps.* · 500 char limit
           </div>
         </div>
       </div>

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -673,7 +673,8 @@ grep -q "modExpr = .*'spec\.modifier\|modExpr = .*\"spec\.modifier" frontend/src
 
 # #448: InsightCards must not reference combatResult CM or processCombat
 grep -q "combatResult ConfigMap\|processCombat\|in a ConfigMap'" frontend/src/KroTeach.tsx && fail "#448: InsightCards still reference stale combatResult CM or processCombat" || pass "#448: InsightCards stale arch references removed"
-grep -q 'lists\.setIndex' frontend/src/KroTeach.tsx && fail "#448: lists.setIndex still used (should be lists.set)" || pass "#448: lists.setIndex replaced with lists.set"
+grep -q 'lists\.setIndex' frontend/src/KroTeach.tsx && fail "#448: lists.setIndex still used (should be lists.setAtIndex)" || pass "#448: lists.setIndex replaced with lists.setAtIndex"
+grep -q 'lists\.set[^A]' frontend/src/KroTeach.tsx && fail "#448: old lists.set() name still used in KroTeach (should be lists.setAtIndex)" || pass "#448: KroTeach uses lists.setAtIndex (upstream PR #1148 name)"
 grep -q 'int(name.*36\|base-36.*coercion' frontend/src/KroTeach.tsx && fail "#448: loot-drop-string-ops still mentions int(name, 36) / base-36" || pass "#448: loot-drop-string-ops headline updated"
 
 # #451: intro modal must be updated
@@ -1130,8 +1131,8 @@ grep -q 'kro/pull/1145\|PR #1145\|1145' frontend/src/App.tsx \
   || fail "FAQ: kro PR #1145 (cel.bind) missing from FAQ"
 
 grep -q 'kro/pull/1148\|PR #1148\|1148' frontend/src/App.tsx \
-  && pass "FAQ: kro PR #1148 (lists.setIndex) referenced in FAQ" \
-  || fail "FAQ: kro PR #1148 (lists.setIndex) missing from FAQ"
+  && pass "FAQ: kro PR #1148 (lists.setAtIndex) referenced in FAQ" \
+  || fail "FAQ: kro PR #1148 (lists.setAtIndex) missing from FAQ"
 
 grep -q 'specPatch\|stateWrite' frontend/src/App.tsx \
   && pass "FAQ: fork patches (specPatch/stateWrite) documented in FAQ" \


### PR DESCRIPTION
## Summary
kro PR #1148 (`lists.setAtIndex`, `lists.insertAtIndex`, `lists.removeAtIndex`) merged upstream. This PR updates all teaching content, FAQs, docs, and guardrails to reflect that.

**Changes:**
- `frontend/src/App.tsx` — FAQ table: `lists.setIndex/insertAt/removeAt` → `lists.setAtIndex/insertAtIndex/removeAtIndex`; status badge "In review (PR #1148)" → "Merged upstream (PR #1148)"; summary sentence updated to "all merged upstream"
- `frontend/src/KroTeach.tsx` — InsightCard combat snippet, CEL Playground example, and footer supported-functions label: `lists.set` → `lists.setAtIndex`; footer label now shows the full trio (`setAtIndex/insertAtIndex/removeAtIndex`)
- `AGENTS.md` — "What NOT to include in upstream PRs" section: updated status from "in review" to "already merged upstream", corrected function names
- `backend/internal/handlers/cel_eval.go` — Package-level comment: `lists.setIndex/insertAt/removeAt` → `lists.setAtIndex/insertAtIndex/removeAtIndex`
- `tests/guardrails.sh` — Updated guardrail that was asserting the old `lists.set` name; now enforces `lists.setAtIndex`; updated PR #1148 description label

Closes #569