### PR TITLE
refactor: use transformList for bulk HP scaling in enterRoom2Resolve (#577 #581)

### DIFF
--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -936,7 +936,7 @@ spec:
               mod.startsWith('blessing') ? r2m * 9 / 10
               : mod.startsWith('curse') ? r2m * 11 / 10
               : r2m,
-              lists.range(schema.spec.monsters).map(i, adj)
+              schema.spec.monsterHP.transformList(_, adj)
             )))))}
 
         bossHP: >-
@@ -958,7 +958,7 @@ spec:
               mod.startsWith('blessing') ? r2m * 9 / 10
               : mod.startsWith('curse') ? r2m * 11 / 10
               : r2m,
-              lists.range(schema.spec.monsters).map(i, adj)
+              schema.spec.monsterHP.transformList(_, adj)
             )))))}
 
         room2BossHP: >-


### PR DESCRIPTION
## Summary

- Closes #581
- Closes #577 (partial — the `lists.range().map(i, const)` → `transformList` pattern is the applicable simplification; the `json.unmarshal`-based config refactor from #577 is deferred to #583)

## Changes

**`manifests/rgds/dungeon-graph.yaml`** — `enterRoom2Resolve` specPatch node:

`monsterHP` and `room2MonsterHP` previously used `lists.range(schema.spec.monsters).map(i, adj)` to produce a new list of scaled HP values, where `adj` is a constant and `i` (the index) is unused. Replaced with `schema.spec.monsterHP.transformList(_, adj)` — the idiomatic form for mapping a list to a new list of the same length using `TwoVarComprehensions` (upstream kro PR #1148-equivalent, available in our running image).

Before:
```cel
lists.range(schema.spec.monsters).map(i, adj)
```

After:
```cel
schema.spec.monsterHP.transformList(_, adj)
```

This is cleaner because:
1. It operates directly on the existing `monsterHP` list rather than generating an integer range as a proxy for length
2. The `_` discard variable makes explicit that the element value is unused (only the list length matters)
3. `transformList` is the purpose-built operator for this pattern

## Testing

- `dungeon-graph` RGD applied and confirmed `Ready` on the live cluster
- Integration tests: 30/30 passed