### PR TITLE
fix: rename _ to hp in transformList to fix kro dep-graph error (#586)

### DIFF
--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -936,7 +936,7 @@ spec:
               mod.startsWith('blessing') ? r2m * 9 / 10
               : mod.startsWith('curse') ? r2m * 11 / 10
               : r2m,
-              schema.spec.monsterHP.transformList(_, adj)
+              schema.spec.monsterHP.transformList(hp, adj)
             )))))}
 
         bossHP: >-
@@ -958,7 +958,7 @@ spec:
               mod.startsWith('blessing') ? r2m * 9 / 10
               : mod.startsWith('curse') ? r2m * 11 / 10
               : r2m,
-              schema.spec.monsterHP.transformList(_, adj)
+              schema.spec.monsterHP.transformList(hp, adj)
             )))))}
 
         room2BossHP: >-


### PR DESCRIPTION
## Summary

Fixes continuous kro reconciler errors introduced by PR #585:

```
failed to build dependency graph: specPatch node "enterRoom2Resolve"
  field "room2MonsterHP": references unknown identifier "_"
failed to build dependency graph: specPatch node "enterRoom2Resolve"
  field "monsterHP": references unknown identifier "_"
```

kro's dependency graph builder does not recognize `_` as a discard variable — it treats it as an unresolved identifier and fails to build the dep graph. Renaming to `hp` (which is unused but a valid identifier) resolves the error.

## Change

**`manifests/rgds/dungeon-graph.yaml`** — `enterRoom2Resolve`, fields `monsterHP` and `room2MonsterHP`:

```cel
# before (broken)
schema.spec.monsterHP.transformList(_, adj)

# after (fixed)
schema.spec.monsterHP.transformList(hp, adj)
```

## Post-merge

After CI merges, run:
```
kubectl --context arn:aws:eks:us-west-2:319279230668:cluster/krombat delete rgd dungeon-graph
```
Argo CD will recreate it within ~6s with the fix applied.

## Root cause note

Added to AGENTS.md key lessons: kro's dep-graph builder does not handle `_` as a wildcard — always use a named variable even when the value is unused in `transformList`/`transformMap`.