### PR TITLE
fix: revert transformList to lists.range().map() in enterRoom2Resolve (#586)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,7 @@ Open feature requests (lower priority):
 - Avoid `${}` in RGD YAML — kro parses it as CEL; use `$()` for bash variable expansion
 - `readyWhen` expressions in RGDs must use `${}` wrapper AND the resource's own ID (not `self`) — kro enforces both
 - When adding new fields to the Dungeon CR spec in `dungeon-graph.yaml`, always `kubectl delete rgd dungeon-graph` after merge so kro regenerates the CRD schema — Argo CD sync alone does NOT update the CRD field list
+- **Do NOT use `transformList` or `transformMap` in `specPatch` nodes** — kro's dep-graph builder does not recognize the comprehension variable as a local binding and reports it as an unknown identifier. Use `lists.range(n).map(i, expr)` instead, which the dep-graph builder handles correctly.
 
 ---
 

--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -936,7 +936,7 @@ spec:
               mod.startsWith('blessing') ? r2m * 9 / 10
               : mod.startsWith('curse') ? r2m * 11 / 10
               : r2m,
-              schema.spec.monsterHP.transformList(hp, adj)
+              lists.range(schema.spec.monsters).map(i, adj)
             )))))}
 
         bossHP: >-
@@ -958,7 +958,7 @@ spec:
               mod.startsWith('blessing') ? r2m * 9 / 10
               : mod.startsWith('curse') ? r2m * 11 / 10
               : r2m,
-              schema.spec.monsterHP.transformList(hp, adj)
+              lists.range(schema.spec.monsters).map(i, adj)
             )))))}
 
         room2BossHP: >-


### PR DESCRIPTION
## Summary

Follows up on PR #586 (which renamed `_` to `hp` in `transformList`). That fix was insufficient — kro's dep-graph builder rejects **any** comprehension variable name in `transformList`/`transformMap` inside `specPatch` nodes, not just `_`. The variable is reported as an unknown identifier regardless of name.

Root cause: kro's dep-graph builder does not recognize the iteration variable of a `transformList` comprehension as a local binding. It treats it as an unresolved field reference.

## Change

**`manifests/rgds/dungeon-graph.yaml`** — `enterRoom2Resolve` `monsterHP` and `room2MonsterHP`:

```cel
# broken (both _ and hp rejected by dep-graph builder)
schema.spec.monsterHP.transformList(hp, adj)

# fixed — lists.range().map() is handled correctly by kro dep-graph builder
lists.range(schema.spec.monsters).map(i, adj)
```

**`AGENTS.md`** — added key lesson:
> Do NOT use `transformList` or `transformMap` in `specPatch` nodes — kro's dep-graph builder does not recognize the comprehension variable as a local binding. Use `lists.range(n).map(i, expr)` instead.

## Post-merge

```
kubectl --context arn:aws:eks:us-west-2:319279230668:cluster/krombat delete rgd dungeon-graph
```
Argo CD recreates it within ~6s.

Closes #586