### PR TITLE
fork-reduction: migrate inventory from CSV to json.marshal/unmarshal (#583)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ A turn-based dungeon RPG where game state lives in Kubernetes Custom Resources o
 
 ## Dungeon CR Spec Fields
 
-`monsters`, `difficulty`, `heroClass`, `heroHP`, `heroMana`, `monsterHP` ([]int), `bossHP`, `modifier`, `tauntActive`, `backstabCooldown`, `inventory` (CSV), `weaponBonus`, `weaponUses`, `armorBonus`, `shieldBonus`, `helmetBonus`, `pantsBonus`, `bootsBonus`, `ringBonus`, `amuletBonus`, `poisonTurns`, `burnTurns`, `stunTurns`, `treasureOpened`, `currentRoom`, `doorUnlocked`, `room2MonsterHP`, `room2BossHP`, `lastHeroAction`, `lastEnemyAction`, `lastLootDrop`
+`monsters`, `difficulty`, `heroClass`, `heroHP`, `heroMana`, `monsterHP` ([]int), `bossHP`, `modifier`, `tauntActive`, `backstabCooldown`, `inventory` (JSON array string), `weaponBonus`, `weaponUses`, `armorBonus`, `shieldBonus`, `helmetBonus`, `pantsBonus`, `bootsBonus`, `ringBonus`, `amuletBonus`, `poisonTurns`, `burnTurns`, `stunTurns`, `treasureOpened`, `currentRoom`, `doorUnlocked`, `room2MonsterHP`, `room2BossHP`, `lastHeroAction`, `lastEnemyAction`, `lastLootDrop`
 
 ---
 
@@ -215,8 +215,8 @@ BASE_URL=https://learn-kro.eks.aws.dev node tests/e2e/run-journeys.js 25,26,27,2
 ## Current Priority: UPSTREAM ADOPTION + FORK REDUCTION
 
 All journey tests pass. Stabilization is complete. Current focus:
-- Issues #570–#573, #579–#580: teaching layer refresh for new upstream CEL features
-- Issue #583: migrate inventory from CSV to JSON to eliminate `csv.go` fork patch
+- Issues #570–#573, #579–#580: teaching layer refresh for new upstream CEL features ✅ done
+- Issue #583: migrate inventory from CSV to JSON to eliminate `csv.go` fork patch ✅ done
 - Issue #578: open upstream kro KREP for `specPatch` / CEL write-back
 - Issue #575: investigate replacing `specPatch` with upstream-compatible patterns
 
@@ -350,7 +350,6 @@ Sign at: https://easycla.lfx.linuxfoundation.org
 
 ### What NOT to include in upstream PRs
 
-- `pkg/cel/library/csv.go` — krombat-private CSV library (planned removal via #583)
 - `specPatch` / `stateWrite` dispatch in `builder.go` — pending maintainer discussion (#578)
 - Any reference to the krombat game, game logic, or game-specific CEL patterns
 - The 3-arg `random.seededInt(min, max, seed)` signature changes — already upstream
@@ -360,9 +359,6 @@ Sign at: https://easycla.lfx.linuxfoundation.org
 The current fork diff is exactly these files — run `git diff cel-writeback-d upstream/main --name-only` in `/Users/rrroizma/Projects/kro-fork` to verify the isolation boundary before opening any upstream PR:
 
 ```
-pkg/cel/library/csv.go              ← krombat-private (removal planned)
-pkg/cel/library/csv_test.go         ← same
-pkg/cel/environment.go              ← one line: library.CSV()
 pkg/graph/builder.go                ← specPatch/stateWrite dispatch
 pkg/graph/node.go                   ← NodeTypeSpecPatch, NodeTypeStateWrite
 pkg/graph/crd/crd.go                ← InjectKstateField

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -551,7 +551,7 @@ type UserProfile struct {
 	TotalBossKills    int            `json:"totalBossKills"`
 	FavouriteClass    string         `json:"favouriteClass"`
 	FavouriteDiff     string         `json:"favouriteDifficulty"`
-	Inventory         string         `json:"inventory"` // CSV, same format as spec.inventory
+	Inventory         string         `json:"inventory"` // JSON array string, same format as spec.inventory
 	WeaponBonus       int64          `json:"weaponBonus"`
 	WeaponUses        int64          `json:"weaponUses"`
 	ArmorBonus        int64          `json:"armorBonus"`
@@ -861,7 +861,8 @@ func (h *Handler) recordProfile(login string, spec map[string]interface{}, kroSt
 	if outcome == "victory" {
 		profile.DungeonsWon++
 		// Carry inventory and equipment forward only on victory.
-		profile.Inventory, _ = spec["inventory"].(string)
+		rawInv, _ := spec["inventory"].(string)
+		profile.Inventory = normalizeInventory(rawInv)
 		profile.WeaponBonus = getInt(spec, "weaponBonus")
 		profile.WeaponUses = getInt(spec, "weaponUses")
 		profile.ArmorBonus = getInt(spec, "armorBonus")
@@ -2456,8 +2457,39 @@ func sanitizeK8sError(err error) string {
 	}
 }
 
+// normalizeInventory converts a legacy CSV inventory string to a JSON array
+// string. New dungeons store inventory as JSON (e.g. `["weapon-common"]`);
+// old live dungeons may still carry CSV format (e.g. `"weapon-common,armor-rare"`).
+// Always returns a valid JSON array string or "" for empty.
+func normalizeInventory(inv string) string {
+	if inv == "" {
+		return ""
+	}
+	if strings.HasPrefix(inv, "[") {
+		return inv // already JSON
+	}
+	// Legacy CSV — convert to JSON array
+	parts := strings.Split(inv, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	b, _ := json.Marshal(out)
+	return string(b)
+}
+
 func inventoryContains(inventory, item string) bool {
-	for _, v := range strings.Split(inventory, ",") {
+	inventory = normalizeInventory(inventory)
+	if inventory == "" {
+		return false
+	}
+	var items []string
+	if err := json.Unmarshal([]byte(inventory), &items); err != nil {
+		return false
+	}
+	for _, v := range items {
 		if v == item {
 			return true
 		}
@@ -2465,18 +2497,17 @@ func inventoryContains(inventory, item string) bool {
 	return false
 }
 
-// inventoryCount returns the number of items in the inventory CSV string.
+// inventoryCount returns the number of items in the inventory string.
 func inventoryCount(inventory string) int {
+	inventory = normalizeInventory(inventory)
 	if inventory == "" {
 		return 0
 	}
-	count := 0
-	for _, v := range strings.Split(inventory, ",") {
-		if v != "" {
-			count++
-		}
+	var items []string
+	if err := json.Unmarshal([]byte(inventory), &items); err != nil {
+		return 0
 	}
-	return count
+	return len(items)
 }
 
 func getMap(obj map[string]interface{}, key string) map[string]interface{} {
@@ -3072,11 +3103,12 @@ func (h *Handler) RunNarrative(w http.ResponseWriter, r *http.Request) {
 
 	// Event 6: Loot drop via loot-graph (if inventory non-empty)
 	inventory, _ := spec["inventory"].(string)
+	inventory = normalizeInventory(inventory)
 	if inventory != "" {
-		items := strings.Split(inventory, ",")
+		var invItems []string
+		json.Unmarshal([]byte(inventory), &invItems)
 		firstItem := ""
-		for _, it := range items {
-			it = strings.TrimSpace(it)
+		for _, it := range invItems {
 			if it != "" {
 				firstItem = it
 				break

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1045,8 +1045,8 @@ const FAQ_ITEMS: { q: string; a: () => ReactNode }[] = [
             </tr>
             <tr>
               <td><code>csv.add</code>, <code>csv.remove</code>, <code>csv.contains</code></td>
-              <td>CEL functions for manipulating comma-separated value strings — used for the inventory system, which stores item names as a CSV in a single Kubernetes string field.</td>
-              <td>Krombat-private — planned migration to <code>json.marshal</code>/<code>json.unmarshal</code> (upstream) which will eliminate this patch entirely (#583)</td>
+              <td>CEL functions for manipulating comma-separated value strings — previously used for the inventory system.</td>
+              <td><strong>Removed</strong> — migrated to <code>json.marshal</code>/<code>json.unmarshal</code> (upstream CEL). Inventory is now stored as a JSON array string in the Kubernetes spec field. (#583)</td>
             </tr>
           </tbody>
         </table>
@@ -1384,7 +1384,7 @@ function ProfilePanel({ profile, loading, authUser, onClose }: {
   const login = authUser?.login ?? 'anonymous'
   const avatarUrl = authUser?.avatarUrl ?? ''
   const earnedSet = new Set(profile?.earnedBadges ?? [])
-  const inventoryItems = profile?.inventory ? profile.inventory.split(',').filter(Boolean) : []
+  const inventoryItems = profile?.inventory ? (JSON.parse(profile.inventory || '[]') as string[]) : []
 
   return (
     <div className="leaderboard-overlay" role="dialog" aria-label="Player Profile">
@@ -2875,7 +2875,7 @@ function DungeonView({ cr, prevCr, onBack, onGameOverBack, onNewGamePlus, onAtta
           )}
 
           {(() => {
-            const items = (spec.inventory || '').split(',').filter(Boolean)
+            const items = JSON.parse(spec.inventory || '[]') as string[]
             const wb = spec.weaponBonus || 0
             const wu = spec.weaponUses || 0
             const ab = spec.armorBonus || 0

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -607,7 +607,7 @@ Under the hood: \`POST /api/v1/dungeons/{ns}/{name}/cel-eval\` with \`{"expr":".
 This means every kro extension is available in the Playground:
 - \`cel.bind(x, schema.spec.heroHP, x * 2)\` — bind macro (same as dungeon-graph.yaml)
 - \`random.seededInt(0, 20, "seed")\` — deterministic random (same RNG kro uses)
-- \`csv.add(schema.spec.inventory, "sword", 5)\` — CSV item manipulation
+- \`json.marshal(json.unmarshal(schema.spec.inventory == '' ? '[]' : schema.spec.inventory) + ["sword"])\` — add item to JSON inventory
 - \`lists.setAtIndex([1, 2, 3], 0, 99)\` — list mutation
 - \`json.unmarshal('{"name":"goblin","hp":30}').name\` — parse JSON string into a map
 - \`json.marshal({"class": schema.spec.heroClass, "hp": schema.spec.heroHP})\` — serialize a map to JSON
@@ -1767,7 +1767,7 @@ export function KroCelPlayground({ dungeonNs, dungeonName, onLearnConcept, onClo
           <div style={{ flex: 1 }} />
           <div className="kro-playground-supported">
             {/* #453: list all kro CEL extensions registered in BaseDeclarations() */}
-            Supported: field access · arithmetic · ternary · string() · int() · size() · has() · cel.bind() · random.seededInt/String() · lists.setAtIndex/insertAtIndex/removeAtIndex/range/filter() · csv.add/remove() · maps.* · json.marshal/unmarshal() · transformList/transformMap() · 500 char limit
+            Supported: field access · arithmetic · ternary · string() · int() · size() · has() · cel.bind() · random.seededInt/String() · lists.setAtIndex/insertAtIndex/removeAtIndex/range/filter() · maps.* · json.marshal/unmarshal() · transformList/transformMap() · 500 char limit
           </div>
         </div>
       </div>

--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -774,7 +774,11 @@ spec:
                 : ''
               )))
             : '',
-            lootItem != '' ? csv.add(schema.spec.inventory, lootItem, 8) : schema.spec.inventory
+            lootItem != '' ?
+              cel.bind(invItems, json.unmarshal(schema.spec.inventory == '' ? '[]' : schema.spec.inventory),
+                size(invItems) < 8 ? json.marshal(invItems + [lootItem]) : schema.spec.inventory
+              )
+            : schema.spec.inventory
           ))))))))))))))))))}
 
         # --- Clear attack context so specPatch doesn't re-fire ---
@@ -796,7 +800,9 @@ spec:
           ${cel.bind(a, schema.spec.lastAction,
           cel.bind(inv, schema.spec.inventory,
             a.startsWith('use-') || a.startsWith('equip-') ?
-              csv.remove(inv, a.startsWith('use-') ? a.substring(4) : a.substring(6))
+              cel.bind(item, a.startsWith('use-') ? a.substring(4) : a.substring(6),
+                json.marshal(json.unmarshal(inv == '' ? '[]' : inv).filter(x, x != item))
+              )
             : inv
           ))}
 

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -486,6 +486,10 @@ grep -q '"warrior"' backend/internal/handlers/handlers.go && grep -q '"mage"' ba
 ! grep -q "kro status unavailable.*derive from spec" backend/internal/handlers/handlers.go && pass "#402: no raw-HP fallback in leaderboard/profile when kro status absent" || fail "#402: raw-HP fallback still present in leaderboard/profile — remove it"
 # #403: dead inventory helper functions must not exist
 ! grep -q "func inventoryAdd\|func inventoryRemove" backend/internal/handlers/handlers.go && pass "#403: dead inventoryAdd/inventoryRemove functions removed" || fail "#403: inventoryAdd or inventoryRemove still exist — delete them"
+# #583: csv.* must not appear in RGDs (migrated to json.marshal/unmarshal)
+! grep -q 'csv\.' manifests/rgds/dungeon-graph.yaml && pass "#583: csv.* removed from dungeon-graph RGD (inventory uses json.marshal/unmarshal)" || fail "#583: csv.* still present in dungeon-graph RGD — migration incomplete"
+# #583: csv.* must not appear in KroTeach teaching layer
+! grep -q 'csv\.add\|csv\.remove\|csv\.contains' frontend/src/KroTeach.tsx && pass "#583: csv.* removed from KroTeach teaching layer" || fail "#583: csv.* still in KroTeach — update teaching layer"
 # #401: no hardcoded per-turn DoT damage in log string literals (comment references are ok)
 ! grep -q '"-5 HP/turn\|-8 HP/turn"' backend/internal/handlers/handlers.go && pass "#401: no hardcoded per-turn DoT amounts in log string literals" || fail "#401: hardcoded -5/-8 HP/turn still in log string literals — remove them"
 


### PR DESCRIPTION
## Summary

- Removes `csv.go`, `csv_test.go`, and `library.CSV()` from the kro fork (`cel-writeback-d` branch, commits `4cb48f9` + `bad6490`) — reduces fork divergence from 16 → 13 files
- Migrates both `spec.inventory` call sites in `dungeon-graph.yaml` to `json.marshal`/`json.unmarshal` (upstream CEL)
- Adds `normalizeInventory()` shim in the Go backend to handle legacy CSV-format inventory on live dungeons during the transition window
- Updates `inventoryContains` and `inventoryCount` to use `json.Unmarshal`
- Updates frontend (`App.tsx`) to use `JSON.parse` in both the profile panel and the backpack panel
- Updates teaching layer: FAQ row status changed to "Removed", Playground example updated, Playground footer `csv.add/remove()` entry removed
- Adds two new guardrail checks: `csv.*` must not appear in dungeon-graph RGD or KroTeach

## Deploy steps after merge

1. Refresh AWS credentials
2. Build and push new kro image from `cel-writeback-d` branch (commit `bad6490`):
   ```bash
   cd /Users/rrroizma/Projects/kro-fork
   GOTOOLCHAIN=local go build -o bin/controller ./cmd/controller/main.go
   # Then docker build + push to ECR as cel-writeback-d-bad6490
   # Then helm upgrade kro in the cluster to new image tag
   ```
3. Wait for Argo CD to sync the new `dungeon-graph.yaml` (~6s after merge)
4. `kubectl delete rgd dungeon-graph --context arn:aws:eks:us-west-2:319279230668:cluster/krombat` to force CRD regeneration
5. Run journey tests:
   ```bash
   _TEST_USER=$(kubectl --context arn:aws:eks:us-west-2:319279230668:cluster/krombat get secret krombat-test-auth -n rpg-system -o jsonpath='{.data.KROMBAT_TEST_USER}' | base64 -d)
   kubectl --context arn:aws:eks:us-west-2:319279230668:cluster/krombat delete dungeons -l "krombat.io/owner=${_TEST_USER}" -A --ignore-not-found --wait=false
   BASE_URL=https://learn-kro.eks.aws.dev node tests/e2e/run-journeys.js 01,02,03,04,05,06,07,08
   ```

Closes #583