### PR TITLE
fix: safe inventory parse — handle legacy CSV format during migration window (#583)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,7 +61,19 @@ function computeAchievements(spec: any, maxHeroHP: number) {
     { id: 'rogue-win', name: 'Shadow', icon: 'dagger', earned: heroClass === 'rogue', desc: 'Won as Rogue' },
     { id: 'hard-win', name: 'Nightmare', icon: 'skull', earned: difficulty === 'hard', desc: 'Won on Hard difficulty' },
     { id: 'collector', name: 'Hoarder', icon: 'chest', earned: equippedCount >= 5, desc: `Won with ${equippedCount}/5 items equipped` },
-  ]
+   ]
+}
+
+// parseInventory handles both JSON array format (new: '["weapon-common"]')
+// and legacy CSV format (old: 'weapon-common,armor-rare') gracefully.
+// Returns an empty array for null/empty/invalid input.
+function parseInventory(inv: string | undefined | null): string[] {
+  if (!inv) return []
+  if (inv.startsWith('[')) {
+    try { return JSON.parse(inv) as string[] } catch { return [] }
+  }
+  // Legacy CSV fallback for live dungeons during migration window
+  return inv.split(',').filter(Boolean)
 }
 
 function AchievementBadges({ achievements }: { achievements: ReturnType<typeof computeAchievements> }) {
@@ -1384,7 +1396,7 @@ function ProfilePanel({ profile, loading, authUser, onClose }: {
   const login = authUser?.login ?? 'anonymous'
   const avatarUrl = authUser?.avatarUrl ?? ''
   const earnedSet = new Set(profile?.earnedBadges ?? [])
-  const inventoryItems = profile?.inventory ? (JSON.parse(profile.inventory || '[]') as string[]) : []
+  const inventoryItems = parseInventory(profile?.inventory)
 
   return (
     <div className="leaderboard-overlay" role="dialog" aria-label="Player Profile">
@@ -2875,7 +2887,7 @@ function DungeonView({ cr, prevCr, onBack, onGameOverBack, onNewGamePlus, onAtta
           )}
 
           {(() => {
-            const items = JSON.parse(spec.inventory || '[]') as string[]
+            const items = parseInventory(spec.inventory)
             const wb = spec.weaponBonus || 0
             const wu = spec.weaponUses || 0
             const ab = spec.armorBonus || 0


### PR DESCRIPTION
## Summary

Production crash fix for the CSV→JSON inventory migration (#583).

`JSON.parse("boots-common,armor-rare")` throws `SyntaxError` because legacy live dungeons still carry CSV-format inventory strings. This crashed the React component tree, making the dungeon view unreachable.

**Fix**: Adds a `parseInventory()` helper that:
- Returns `[]` for null/empty
- Uses `JSON.parse` for strings starting with `[` (new JSON format)
- Falls back to `split(',')` for legacy CSV strings during the migration window
- Wraps JSON.parse in try/catch to be safe in all cases

Replaces both bare `JSON.parse` call sites in `App.tsx` with the helper.

Closes #583 migration window concern.