### PR TITLE
fork-reduction: remove CSV inventory compat layer — all data migrated (#583)

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -862,7 +862,7 @@ func (h *Handler) recordProfile(login string, spec map[string]interface{}, kroSt
 		profile.DungeonsWon++
 		// Carry inventory and equipment forward only on victory.
 		rawInv, _ := spec["inventory"].(string)
-		profile.Inventory = normalizeInventory(rawInv)
+		profile.Inventory = rawInv
 		profile.WeaponBonus = getInt(spec, "weaponBonus")
 		profile.WeaponUses = getInt(spec, "weaponUses")
 		profile.ArmorBonus = getInt(spec, "armorBonus")
@@ -2457,31 +2457,7 @@ func sanitizeK8sError(err error) string {
 	}
 }
 
-// normalizeInventory converts a legacy CSV inventory string to a JSON array
-// string. New dungeons store inventory as JSON (e.g. `["weapon-common"]`);
-// old live dungeons may still carry CSV format (e.g. `"weapon-common,armor-rare"`).
-// Always returns a valid JSON array string or "" for empty.
-func normalizeInventory(inv string) string {
-	if inv == "" {
-		return ""
-	}
-	if strings.HasPrefix(inv, "[") {
-		return inv // already JSON
-	}
-	// Legacy CSV — convert to JSON array
-	parts := strings.Split(inv, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if p != "" {
-			out = append(out, p)
-		}
-	}
-	b, _ := json.Marshal(out)
-	return string(b)
-}
-
 func inventoryContains(inventory, item string) bool {
-	inventory = normalizeInventory(inventory)
 	if inventory == "" {
 		return false
 	}
@@ -2499,7 +2475,6 @@ func inventoryContains(inventory, item string) bool {
 
 // inventoryCount returns the number of items in the inventory string.
 func inventoryCount(inventory string) int {
-	inventory = normalizeInventory(inventory)
 	if inventory == "" {
 		return 0
 	}
@@ -3103,7 +3078,6 @@ func (h *Handler) RunNarrative(w http.ResponseWriter, r *http.Request) {
 
 	// Event 6: Loot drop via loot-graph (if inventory non-empty)
 	inventory, _ := spec["inventory"].(string)
-	inventory = normalizeInventory(inventory)
 	if inventory != "" {
 		var invItems []string
 		json.Unmarshal([]byte(inventory), &invItems)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,16 +64,11 @@ function computeAchievements(spec: any, maxHeroHP: number) {
    ]
 }
 
-// parseInventory handles both JSON array format (new: '["weapon-common"]')
-// and legacy CSV format (old: 'weapon-common,armor-rare') gracefully.
+// parseInventory parses a JSON array inventory string.
 // Returns an empty array for null/empty/invalid input.
 function parseInventory(inv: string | undefined | null): string[] {
   if (!inv) return []
-  if (inv.startsWith('[')) {
-    try { return JSON.parse(inv) as string[] } catch { return [] }
-  }
-  // Legacy CSV fallback for live dungeons during migration window
-  return inv.split(',').filter(Boolean)
+  try { return JSON.parse(inv) as string[] } catch { return [] }
 }
 
 function AchievementBadges({ achievements }: { achievements: ReturnType<typeof computeAchievements> }) {
@@ -1054,11 +1049,6 @@ const FAQ_ITEMS: { q: string; a: () => ReactNode }[] = [
               <td><code>random.seededInt</code>, <code>random.seededString</code></td>
               <td>Deterministic pseudo-random CEL functions seeded by stable string identifiers. Required because kro reconciles continuously — a non-deterministic random call would recompute a different value on every reconcile cycle.</td>
               <td>Merged upstream as part of earlier contributions</td>
-            </tr>
-            <tr>
-              <td><code>csv.add</code>, <code>csv.remove</code>, <code>csv.contains</code></td>
-              <td>CEL functions for manipulating comma-separated value strings — previously used for the inventory system.</td>
-              <td><strong>Removed</strong> — migrated to <code>json.marshal</code>/<code>json.unmarshal</code> (upstream CEL). Inventory is now stored as a JSON array string in the Kubernetes spec field. (#583)</td>
             </tr>
           </tbody>
         </table>

--- a/tests/guardrails.sh
+++ b/tests/guardrails.sh
@@ -486,10 +486,6 @@ grep -q '"warrior"' backend/internal/handlers/handlers.go && grep -q '"mage"' ba
 ! grep -q "kro status unavailable.*derive from spec" backend/internal/handlers/handlers.go && pass "#402: no raw-HP fallback in leaderboard/profile when kro status absent" || fail "#402: raw-HP fallback still present in leaderboard/profile — remove it"
 # #403: dead inventory helper functions must not exist
 ! grep -q "func inventoryAdd\|func inventoryRemove" backend/internal/handlers/handlers.go && pass "#403: dead inventoryAdd/inventoryRemove functions removed" || fail "#403: inventoryAdd or inventoryRemove still exist — delete them"
-# #583: csv.* must not appear in RGDs (migrated to json.marshal/unmarshal)
-! grep -q 'csv\.' manifests/rgds/dungeon-graph.yaml && pass "#583: csv.* removed from dungeon-graph RGD (inventory uses json.marshal/unmarshal)" || fail "#583: csv.* still present in dungeon-graph RGD — migration incomplete"
-# #583: csv.* must not appear in KroTeach teaching layer
-! grep -q 'csv\.add\|csv\.remove\|csv\.contains' frontend/src/KroTeach.tsx && pass "#583: csv.* removed from KroTeach teaching layer" || fail "#583: csv.* still in KroTeach — update teaching layer"
 # #401: no hardcoded per-turn DoT damage in log string literals (comment references are ok)
 ! grep -q '"-5 HP/turn\|-8 HP/turn"' backend/internal/handlers/handlers.go && pass "#401: no hardcoded per-turn DoT amounts in log string literals" || fail "#401: hardcoded -5/-8 HP/turn still in log string literals — remove them"
 


### PR DESCRIPTION
## What

Removes all CSV inventory compatibility shims now that every live dungeon and profile has been migrated to JSON array format.

- **`backend/internal/handlers/handlers.go`** — delete `normalizeInventory()` function and its 4 call sites; `inventoryContains` and `inventoryCount` now read plain JSON directly
- **`frontend/src/App.tsx`** — simplify `parseInventory()` to pure `JSON.parse` (no CSV split fallback); remove stale `csv.add`/`csv.remove`/`csv.contains` FAQ table row
- **`tests/guardrails.sh`** — remove the two `#583` migration-window guardrails (no longer meaningful once CSV is fully gone)

All 8 live dungeons and 2 CSV-format profiles were patched to JSON before this PR was opened.

Closes #583