### PR TITLE
docs: update inventory format references from CSV to JSON (#583)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,7 +267,7 @@ git push origin main
 
 # 1. Create an isolated branch (one contribution per branch)
 git checkout -b <short-description>   # e.g. cel-bind-upstream
-# NO krombat-private files (lists.go, csv.go, specPatch, stateWrite, etc.)
+# NO krombat-private files (lists.go, specPatch, stateWrite, etc.)
 
 # 2. Make changes, run tests locally
 GOTOOLCHAIN=local go test ./pkg/cel/... 

--- a/Docs/details.txt
+++ b/Docs/details.txt
@@ -13,7 +13,7 @@ Every game instance is a Dungeon custom resource. All mutable game state lives i
 - `modifier` (string) — none/curse-fortitude/curse-fury/curse-darkness/blessing-strength/blessing-resilience/blessing-fortune
 - `tauntActive` (int) — warrior taunt state
 - `backstabCooldown` (int) — rogue backstab cooldown turns
-- `inventory` (string) — CSV of item IDs (e.g. "weapon-epic,hppotion-rare")
+- `inventory` (string) — JSON array of item IDs (e.g. '["weapon-epic","hppotion-rare"]')
 - `weaponBonus` (int), `weaponUses` (int) — equipped weapon
 - `armorBonus` (int) — equipped armor defense %
 - `shieldBonus` (int) — equipped shield block %

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -141,7 +141,7 @@ export interface UserProfile {
   totalBossKills: number
   favouriteClass: string
   favouriteDifficulty: string
-  inventory: string          // CSV
+  inventory: string          // JSON array string e.g. '["weapon-epic","hppotion-rare"]'
   weaponBonus: number; weaponUses: number; armorBonus: number; shieldBonus: number
   helmetBonus: number; pantsBonus: number; bootsBonus: number; ringBonus: number; amuletBonus: number
   heroHP: number


### PR DESCRIPTION
## What

Cleans up the last stale CSV inventory references in non-code files, following the data migration in #590.

- **`frontend/src/api.ts`** — `UserProfile.inventory` comment: `// CSV` → `// JSON array string`
- **`Docs/details.txt`** — spec field description: CSV example → JSON array example
- **`AGENTS.md`** — upstream branch comment: remove `csv.go` from the "do not include" list (file no longer exists in the fork)

Closes #583