### PR TITLE
fix: add 409 Conflict to journey test console error filters (#593)

### DIFF
--- a/tests/e2e/journeys/01-warrior-easy.js
+++ b/tests/e2e/journeys/01-warrior-easy.js
@@ -27,7 +27,7 @@ async function run() {
   const dName = `j1-${Date.now()}`;
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('429') && !msg.text().includes('504'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504'))
       consoleErrors.push(msg.text());
   });
 

--- a/tests/e2e/journeys/02-mage-normal.js
+++ b/tests/e2e/journeys/02-mage-normal.js
@@ -57,7 +57,7 @@ async function run() {
   const dName = `j2-${Date.now()}`;
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('429') && !msg.text().includes('504'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/03-rogue-hard.js
+++ b/tests/e2e/journeys/03-rogue-hard.js
@@ -73,7 +73,7 @@ async function run() {
   const dName = `j3-${Date.now()}`;
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('429') && !msg.text().includes('504'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/04-items-equipment.js
+++ b/tests/e2e/journeys/04-items-equipment.js
@@ -65,7 +65,7 @@ async function run() {
         !msg.text().includes('WebSocket') &&
         !msg.text().includes('404') &&
         !msg.text().includes('400') &&
-        !msg.text().includes('429') &&
+        !msg.text().includes('409') && !msg.text().includes('429') &&
         !msg.text().includes('504'))
       consoleErrors.push(msg.text());
   });

--- a/tests/e2e/journeys/05-status-effects.js
+++ b/tests/e2e/journeys/05-status-effects.js
@@ -98,7 +98,7 @@ async function run() {
 
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('429') && !msg.text().includes('504'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/06-dungeon-modifiers.js
+++ b/tests/e2e/journeys/06-dungeon-modifiers.js
@@ -75,7 +75,7 @@ async function run() {
 
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('429') && !msg.text().includes('504'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/08-edge-cases.js
+++ b/tests/e2e/journeys/08-edge-cases.js
@@ -42,7 +42,7 @@ async function run() {
 
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('500') && !msg.text().includes('400'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('500') && !msg.text().includes('400'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/09-k8s-logs.js
+++ b/tests/e2e/journeys/09-k8s-logs.js
@@ -58,7 +58,7 @@ async function run() {
 
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('429') && !msg.text().includes('504'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/10-animations.js
+++ b/tests/e2e/journeys/10-animations.js
@@ -41,7 +41,7 @@ async function run() {
 
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('429') && !msg.text().includes('504'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/11-room2-victory.js
+++ b/tests/e2e/journeys/11-room2-victory.js
@@ -33,7 +33,7 @@ async function run() {
   const dName = `j11-${Date.now()}`;
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('429') && !msg.text().includes('504'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504'))
       consoleErrors.push(msg.text());
   });
 

--- a/tests/e2e/journeys/12-kro-teaching.js
+++ b/tests/e2e/journeys/12-kro-teaching.js
@@ -27,7 +27,7 @@ async function run() {
   const dName = `j12-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);
@@ -338,7 +338,7 @@ async function run() {
 
     // ── Console errors ────────────────────────────────────────────────────────
     const relevantErrors = consoleErrors.filter(e =>
-      !e.includes('favicon') && !e.includes('WebSocket') && !e.includes('net::ERR') && !e.includes('429') && !e.includes('504')
+      !e.includes('favicon') && !e.includes('WebSocket') && !e.includes('net::ERR') && !e.includes('409') && !e.includes('429') && !e.includes('504')
     );
     relevantErrors.length === 0 ? ok('No console errors') : fail(`Console errors: ${relevantErrors.join('; ')}`);
 

--- a/tests/e2e/journeys/14-kro-inspector.js
+++ b/tests/e2e/journeys/14-kro-inspector.js
@@ -44,7 +44,7 @@ async function run() {
   const dName = `j14-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/15-ownerref-and-glossary.js
+++ b/tests/e2e/journeys/15-ownerref-and-glossary.js
@@ -32,7 +32,7 @@ async function run() {
   const dNameMain   = `j15-main-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     // Ensure onboarding is already done so it doesn't block the test
@@ -293,7 +293,7 @@ async function run() {
 
     // ── Console errors ────────────────────────────────────────────────────────
     const relevantErrors = consoleErrors.filter(e =>
-      !e.includes('favicon') && !e.includes('WebSocket') && !e.includes('net::ERR') && !e.includes('429') && !e.includes('504')
+      !e.includes('favicon') && !e.includes('WebSocket') && !e.includes('net::ERR') && !e.includes('409') && !e.includes('429') && !e.includes('504')
     );
     relevantErrors.length === 0
       ? ok('No console errors during journey')

--- a/tests/e2e/journeys/16-ring-amulet-loot.js
+++ b/tests/e2e/journeys/16-ring-amulet-loot.js
@@ -123,7 +123,7 @@ async function run() {
 
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('400') && !msg.text().includes('net::ERR') && !msg.text().includes('429') && !msg.text().includes('504'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('400') && !msg.text().includes('net::ERR') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504'))
       consoleErrors.push(msg.text());
   });
   page.on('dialog', dialog => dialog.accept());

--- a/tests/e2e/journeys/17-cel-playground.js
+++ b/tests/e2e/journeys/17-cel-playground.js
@@ -28,7 +28,7 @@ async function run() {
   const dName = `j17-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/18-achievements.js
+++ b/tests/e2e/journeys/18-achievements.js
@@ -19,7 +19,7 @@ async function run() {
   const dName = `j18-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/19-enemy-variety.js
+++ b/tests/e2e/journeys/19-enemy-variety.js
@@ -20,7 +20,7 @@ async function run() {
   const dName = `j19-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/20-leaderboard.js
+++ b/tests/e2e/journeys/20-leaderboard.js
@@ -32,7 +32,7 @@ async function run() {
   const dName = `j20-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/21-new-game-plus.js
+++ b/tests/e2e/journeys/21-new-game-plus.js
@@ -26,7 +26,7 @@ async function run() {
   const ngName = `${dName}-ng1`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/22-minimap.js
+++ b/tests/e2e/journeys/22-minimap.js
@@ -20,7 +20,7 @@ async function run() {
   const dName = `j22-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/23-taunt-and-boss-phases.js
+++ b/tests/e2e/journeys/23-taunt-and-boss-phases.js
@@ -21,7 +21,7 @@ async function run() {
   const dName = `j23-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/24-potions-inventory-cap-helmet-pants.js
+++ b/tests/e2e/journeys/24-potions-inventory-cap-helmet-pants.js
@@ -20,7 +20,7 @@ async function run() {
   const dName = `j24-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/25-mage-room2-mana-restore-room2-scaling.js
+++ b/tests/e2e/journeys/25-mage-room2-mana-restore-room2-scaling.js
@@ -21,7 +21,7 @@ async function run() {
   const dName = `j25-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/26-kro-certificate-and-mid-game-insights.js
+++ b/tests/e2e/journeys/26-kro-certificate-and-mid-game-insights.js
@@ -20,7 +20,7 @@ async function run() {
   const dName = `j26-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/27-regression-loot-drop-item-clear-boss-name.js
+++ b/tests/e2e/journeys/27-regression-loot-drop-item-clear-boss-name.js
@@ -30,7 +30,7 @@ async function run() {
   const dNameNormal = `j27-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/28-resume-prompt-validation-room1-cleared-last-played.js
+++ b/tests/e2e/journeys/28-resume-prompt-validation-room1-cleared-last-played.js
@@ -21,7 +21,7 @@ async function run() {
   const dName = `j28-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/29-ring-regen-amulet-combat.js
+++ b/tests/e2e/journeys/29-ring-regen-amulet-combat.js
@@ -40,7 +40,7 @@ async function run() {
   const dName = `j29-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/30-room2-boss-phases.js
+++ b/tests/e2e/journeys/30-room2-boss-phases.js
@@ -22,7 +22,7 @@ async function run() {
   const dName = `j30-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/31-kro-inspector-combat-modifier-cm.js
+++ b/tests/e2e/journeys/31-kro-inspector-combat-modifier-cm.js
@@ -89,7 +89,7 @@ async function run() {
   const dName = `j31-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/32-cel-playground-live-eval.js
+++ b/tests/e2e/journeys/32-cel-playground-live-eval.js
@@ -75,7 +75,7 @@ async function run() {
   const dName = `j32-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/33-user-profile.js
+++ b/tests/e2e/journeys/33-user-profile.js
@@ -33,7 +33,7 @@ async function run() {
   const dName = `j33-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/34-xp-levelling.js
+++ b/tests/e2e/journeys/34-xp-levelling.js
@@ -38,7 +38,7 @@ async function run() {
   const dName = `j34-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/35-certificates.js
+++ b/tests/e2e/journeys/35-certificates.js
@@ -45,7 +45,7 @@ async function run() {
   const dName = `j35-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);

--- a/tests/e2e/journeys/37-social-run-card.js
+++ b/tests/e2e/journeys/37-social-run-card.js
@@ -64,7 +64,7 @@ async function run() {
   const dName = `j37-${Date.now()}`;
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('429') && !msg.text().includes('504'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504'))
       consoleErrors.push(msg.text());
   });
 

--- a/tests/e2e/journeys/38-conference-demo.js
+++ b/tests/e2e/journeys/38-conference-demo.js
@@ -25,7 +25,7 @@ async function run() {
   const page = await browser.newPage();
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('429') && !msg.text().includes('504'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504'))
       consoleErrors.push(msg.text());
   });
 

--- a/tests/e2e/journeys/39-reconcile-stream.js
+++ b/tests/e2e/journeys/39-reconcile-stream.js
@@ -48,7 +48,7 @@ async function run() {
   const dName = `j39-${Date.now()}`;
 
   const consoleErrors = [];
-  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
+  page.on('console', msg => { if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('504') && !msg.text().includes('net::ERR')) consoleErrors.push(msg.text()); });
 
   try {
     await testLogin(page, BASE_URL);
@@ -367,7 +367,7 @@ async function run() {
     const criticalErrors = consoleErrors.filter(e =>
       !e.includes('favicon') && !e.includes('net::ERR') &&
       !e.includes('kro warning') && !e.includes('WebSocket') &&
-      !e.includes('429') &&
+      !e.includes('409') && !e.includes('429') &&
       // 404/500 from asset loading or backend resource watch RBAC startup are transient
       !e.includes('404') && !e.includes('500') && !e.includes('status of 404') && !e.includes('status of 500')
     );

--- a/tests/e2e/journeys/40-blog-post-generator.js
+++ b/tests/e2e/journeys/40-blog-post-generator.js
@@ -67,7 +67,7 @@ async function run() {
   const dName = `j40-${Date.now()}`;
   const consoleErrors = [];
   page.on('console', msg => {
-    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('400') && !msg.text().includes('429') && !msg.text().includes('502') && !msg.text().includes('504'))
+    if (msg.type() === 'error' && !msg.text().includes('WebSocket') && !msg.text().includes('404') && !msg.text().includes('net::ERR') && !msg.text().includes('400') && !msg.text().includes('409') && !msg.text().includes('429') && !msg.text().includes('502') && !msg.text().includes('504'))
       consoleErrors.push(msg.text());
   });
 

--- a/tests/e2e/journeys/41-workshop-kit.js
+++ b/tests/e2e/journeys/41-workshop-kit.js
@@ -44,7 +44,7 @@ async function run() {
       && !msg.text().includes('504')
       && !msg.text().includes('400')
       && !msg.text().includes('401')
-      && !msg.text().includes('429'))
+      && !msg.text().includes('409') && !msg.text().includes('429'))
       consoleErrors.push(msg.text());
   });
 

--- a/tests/e2e/journeys/helpers.js
+++ b/tests/e2e/journeys/helpers.js
@@ -220,7 +220,10 @@ async function testLogin(page, baseUrl) {
 async function gotoApp(page, url) {
   await testLogin(page, url.replace(/\/[^/]*$/, '') || url); // extract origin
   await page.goto(url, { timeout: 15000 });
-  await page.waitForTimeout(500);
+  // Wait for React authUser state to settle (loaded via /api/v1/me async call).
+  // Without this wait, the unauthenticated view renders briefly and blocks the
+  // dungeon creation form (it's only visible when logged in).
+  await page.waitForTimeout(2000);
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

- Journey 25 was failing with `❌ JS errors detected: Failed to load resource: the server responded with a status of 409 ()` due to rapid attack requests triggering the backend's stale-seq conflict guard
- The 409 Conflict response is handled gracefully by the frontend (`App.tsx:654`) — it refreshes dungeon state and shows a retry notice — but the browser logs it as a network error
- All other HTTP error codes that represent expected/transient conditions (404, 429, 504) were already filtered; 409 was missing
- Fixed console error filter in all 38 journey test files to exclude 409
- Also fixed 4 files where the sed replacement introduced `!msg.text()` in a `.filter(e => ...)` closure (should be `!e.includes(...)`)
- Also bumps `helpers.js` `gotoApp` wait from 500ms → 2000ms to give React time to settle auth state after login redirect

Closes #593