### PR TITLE
fix: enterRoom2Resolve one-shot guard — stop monsterHP/bossHP reset on equip (#594)

### DIFF
--- a/manifests/rgds/dungeon-graph.yaml
+++ b/manifests/rgds/dungeon-graph.yaml
@@ -922,16 +922,19 @@ spec:
         lastAction: "${''}"
 
     # ===================================================================
-    # enterRoom2Resolve: handles ONLY the array fields for room 2 transition.
-    # Kept separate from actionResolve because []string / []integer arrays
-    # with no default cause kro "data pending" errors when passed through
-    # as-is in a specPatch that fires on every action turn.
-    # Fires independently on its own sentinel (room2ProcessedSeq).
+     # enterRoom2Resolve: handles ONLY the array fields for room 2 transition.
+     # Kept separate from actionResolve because []string / []integer arrays
+     # with no default cause kro "data pending" errors when passed through
+     # as-is in a specPatch that fires on every action turn.
+      # Fires ONCE (one-shot): when currentRoom reaches 2 AND room2ProcessedSeq
+      # is still 0 (its default). After firing, room2ProcessedSeq is set to
+      # actionSeq (non-zero) so this node never fires again — preventing
+      # equip/item actions from resetting monsterHP/bossHP to initial values.
     # ===================================================================
     - id: enterRoom2Resolve
       type: specPatch
       includeWhen:
-        - "${schema.spec.currentRoom == 2 && schema.spec.actionSeq > schema.spec.room2ProcessedSeq}"
+        - "${schema.spec.currentRoom == 2 && schema.spec.room2ProcessedSeq == 0}"
       patch:
         monsterHP: >-
           ${cel.bind(diff, schema.spec.difficulty,
@@ -980,6 +983,7 @@ spec:
         monsterTypes: >-
           ${lists.range(schema.spec.monsters).map(i, i % 2 == 0 ? 'troll' : 'ghoul')}
 
-        # --- Room 2 sentinel ---
+        # --- Room 2 sentinel: set to actionSeq once so includeWhen (== 0) never fires again,
+        #     and the frontend can detect completion via room2ProcessedSeq >= actionSeq ---
         room2ProcessedSeq: "${schema.spec.actionSeq}"
 


### PR DESCRIPTION
## Root cause

`enterRoom2Resolve` (a `specPatch` node in `dungeon-graph.yaml`) was designed to fire once when entering Room 2, initialising `monsterHP`, `bossHP`, `room2MonsterHP`, `room2BossHP`, and `monsterTypes` to their Room 2 values.

Its `includeWhen` condition was:
```
schema.spec.currentRoom == 2 && schema.spec.actionSeq > schema.spec.room2ProcessedSeq
```

**The bug**: `actionResolve` (a separate `specPatch` node) increments `actionSeq` on every player action — attacks, equip, use-item. After Room 2 initialisation, `room2ProcessedSeq` equals `actionSeq`. Then the player equips an item → `actionResolve` fires → `actionSeq` advances by 1 → `actionSeq > room2ProcessedSeq` is `true` again → `enterRoom2Resolve` refires → `spec.monsterHP` and `spec.bossHP` are overwritten with brand-new full-health values → all Room 2 progress (damage dealt, monsters killed) is erased.

This manifests as two visible bugs:
1. **Dead monster sprites disappear** — a killed Room 2 monster's HP is reset to its full value, so `isDead = false` and the `dead` sprite is replaced by an `idle` sprite
2. **Monsters reset HP on equip** — the HP bars jump back to full after any equip or item-use action in Room 2

## Fix

Changed `includeWhen` to use a one-shot guard:
```
schema.spec.currentRoom == 2 && schema.spec.room2ProcessedSeq == 0
```

`room2ProcessedSeq` defaults to `0`. On first Room 2 entry, `enterRoom2Resolve` fires and sets `room2ProcessedSeq = actionSeq` (non-zero). The `== 0` guard is then permanently false — no subsequent action can trigger a reset.

The frontend's existing poll condition (`room2ProcessedSeq >= actionSeq`) still works correctly: after the one-shot fire, `room2ProcessedSeq == actionSeq` so the condition is satisfied and the frontend unblocks.

## Files changed

- `manifests/rgds/dungeon-graph.yaml` — `enterRoom2Resolve` `includeWhen` condition

Closes #594