### PR TITLE
docs: second pass — fix remaining specPatch/spec.* references in teaching layer and docs (#600)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,12 +26,12 @@ A turn-based dungeon RPG where game state lives in Kubernetes Custom Resources o
   - `attack-graph`: defines the Attack CRD (no resources — CRD only)
   - `action-graph`: defines the Action CRD (no resources — CRD only)
 - **Argo CD** (EKS Managed Capability) — GitOps from `manifests/`. GitHub webhook for ~6s sync
-- **Go Backend** — REST API + WebSocket in `rpg-system`. For combat, the backend writes trigger fields only (`attackSeq`, `lastAttackTarget`, `lastAttackSeed`, `lastAttackIndex`, `lastAttackIsBoss`, `lastAttackIsBackstab`) then polls until kro's `combatResolve` specPatch fires — kro CEL is the authoritative combat engine. For actions (equip, use-item, abilities), the backend writes trigger fields only (`actionSeq`, `lastAction`, `lastAbility`) and kro's `actionResolve`/`abilityResolve` specPatch nodes compute the result. The backend computes: loot drop chance/selection (writes `lastLootDrop`), log text (reads kro's post-state diff, no math), XP delta, leaderboard entries, and room transition triggers (writes `enterRoom2` trigger; kro's `enterRoom2Resolve` computes the new HP values).
-- **React Frontend** — 8-bit pixel art with circular dungeon arena, Tibia-style equipment panel, combat modal with dice rolling. All state from Dungeon CR `spec` (not `status` — status can be stale after room transitions)
+- **Go Backend** — REST API + WebSocket in `rpg-system`. For combat, the backend writes trigger fields only (`attackSeq`, `lastAttackTarget`, `lastAttackSeed`, `lastAttackIndex`, `lastAttackIsBoss`, `lastAttackIsBackstab`) then polls until kro's `combatResolve` state node fires and writes results to `status.game` — kro CEL is the authoritative combat engine. For actions (equip, use-item, abilities), the backend writes trigger fields only (`actionSeq`, `lastAction`, `lastAbility`) and kro's `actionResolve`/`abilityResolve` state nodes compute the result and write to `status.game`. The backend computes: loot drop chance/selection (writes `lastLootDrop`), log text (reads kro's post-state diff from `status.game`, no math), XP delta, leaderboard entries, and room transition triggers (writes `enterRoom2` trigger; kro's `enterRoom2Resolve` computes the new HP values).
+- **React Frontend** — 8-bit pixel art with circular dungeon arena, Tibia-style equipment panel, combat modal with dice rolling. All game state from Dungeon CR `status.game` (via `getGame()` helper with spec fallback for old dungeons)
 
 ### What kro actually computes (authoritative — the game engine)
 
-| RGD / specPatch | What kro CEL computes |
+| RGD / state node | What kro CEL computes |
 |---|---|
 | `dungeon-graph` → `combatResolve` | All combat math: hero damage (dice, weapon, helmet, amulet, class multipliers, backstab), boss/monster counter-attack chains (armor, shield, class defense, pants dodge, taunt 60% reduction, one-shot floor), status effect infliction (poison/burn/stun), ring regen, monsterHP array mutation, heroHP mutation |
 | `dungeon-graph` → `abilityResolve` | Mage heal (heroHP clamp, mana cost), warrior taunt activation (tauntActive=1) |
@@ -54,13 +54,13 @@ A turn-based dungeon RPG where game state lives in Kubernetes Custom Resources o
 - Log text: reads kro's post-state diff (pre/post heroHP, monsterHP, bossHP) and generates `lastHeroAction`/`lastEnemyAction` strings — no math, kro's results are authoritative
 - XP delta: kill/boss-kill/victory/defeat outcomes from post-spec, writes `xpEarned`
 - Leaderboard: outcome derivation, turn counting, ConfigMap storage (`krombat-leaderboard` in `rpg-system` — plain ConfigMap, no kro interface)
-- Room 2 trigger: writes `enterRoom2` trigger field; kro's `enterRoom2Resolve` specPatch computes all the HP scaling, modifier adjustments, and state resets
-- Dungeon creation: writes initial spec fields; kro's `dungeonInit` specPatch computes monster HP arrays and all derived initial values
+- Room 2 trigger: writes `enterRoom2` trigger field; kro's `enterRoom2Resolve` state node computes all the HP scaling, modifier adjustments, and state resets
+- Dungeon creation: writes initial spec fields; kro's `dungeonInit` state node computes monster HP arrays and all derived initial values
 
 ### What the frontend computes (display + necessary spec re-derivation)
 
 - `gameOver`, `isVictory`, `bossState`, `allMonstersDead` — re-derived from `spec` fields (intentional: `status` is stale after room transitions)
-- `bossPhase` fallback — re-derives from `spec.bossHP / maxBossHP` when `status.bossPhase` is `phase1` (matches boss-graph thresholds: 50% / 25%)
+- `bossPhase` fallback — re-derives from `status.game.bossHP / maxBossHP` when `status.bossPhase` is `phase1` (matches boss-graph thresholds: 50% / 25%)
 - Achievement badges — 8 conditions derived client-side only, not persisted to K8s
 - `maxHeroHP` — read from `status.maxHeroHP` (from hero-graph); fallback is wrong (uses current HP, not class default)
 

--- a/Docs/demo/DEMO.md
+++ b/Docs/demo/DEMO.md
@@ -32,7 +32,7 @@ Open the game at `https://learn-kro.eks.aws.dev`. Click **New Dungeon**, fill in
 
 Open the **K8s Logs tab** in the event log panel. You can see the creation events flowing in.
 
-> "Here are the Kubernetes events as kro reconciles the Dungeon CR in real time. kro created 16 resources from that one CR: a Namespace, a Hero CR, Monster CRs, a Boss CR, a Treasure CR, 9 specPatch nodes. All from a single RGD — a ResourceGraphDefinition."
+> "Here are the Kubernetes events as kro reconciles the Dungeon CR in real time. kro created 16 resources from that one CR: a Namespace, a Hero CR, Monster CRs, a Boss CR, a Treasure CR, and state nodes that run the game engine. All from a single RGD — a ResourceGraphDefinition."
 
 ---
 

--- a/Docs/workshop/README.md
+++ b/Docs/workshop/README.md
@@ -26,7 +26,7 @@ By the end of this workshop you will be able to:
 
 - Explain what a ResourceGraphDefinition (RGD) is and why it exists
 - Read real production kro RGDs and understand every CEL expression
-- Use `readyWhen`, `includeWhen`, `forEach`, and `specPatch` in practice
+- Use `readyWhen`, `includeWhen`, `forEach`, and state nodes in practice
 - Write your first kro RGD from scratch and deploy it via ArgoCD
 - Describe the kro reconcile loop and how CEL expressions drive derived state
 

--- a/Docs/workshop/day-1-explore.md
+++ b/Docs/workshop/day-1-explore.md
@@ -126,7 +126,7 @@ Complete the five questions in [exercises/day-1-exercises.md](exercises/day-1-ex
 You have now:
 - Applied a real Kubernetes CR and watched kro orchestrate 16 resources from it
 - Observed kro reconciling the resource graph in real time during combat
-- Identified `forEach`, `readyWhen`, `specPatch`, and `status-aggregation` patterns in the wild
+- Identified `forEach`, `readyWhen`, state nodes, and `status-aggregation` patterns in the wild
 - Unlocked at least 15 of 27 kro concepts
 
 Proceed to [Day 2 — Read the RGDs](day-2-read-the-rgds.md).

--- a/Docs/workshop/day-2-read-the-rgds.md
+++ b/Docs/workshop/day-2-read-the-rgds.md
@@ -11,7 +11,7 @@ No local cluster required. You will read the RGD YAML files on GitHub and use th
 By the end of Day 2 you will be able to:
 
 - Read a kro RGD YAML file and explain what every section does
-- Explain `cel.bind()`, `readyWhen`, `includeWhen`, `specPatch`, and `forEach` from first principles
+- Explain `cel.bind()`, `readyWhen`, `includeWhen`, state nodes, and `forEach` from first principles
 - Trace a CEL expression from the RGD to its effect on game state
 - Use the CEL Playground to evaluate expressions interactively
 
@@ -29,7 +29,7 @@ Or browse them directly:
 
 | RGD | File | What it manages |
 |---|---|---|
-| `dungeon-graph` | `dungeon-graph.yaml` | Root graph: Namespace, all child CRs, GameConfig, specPatch nodes |
+| `dungeon-graph` | `dungeon-graph.yaml` | Root graph: Namespace, all child CRs, GameConfig, state nodes (write to `status.game`) |
 | `hero-graph` | `hero-graph.yaml` | Hero CR → ConfigMap with maxHP, maxMana, classNote |
 | `monster-graph` | `monster-graph.yaml` | Monster CR → ConfigMap with `entityState` (alive/dead) |
 | `boss-graph` | `boss-graph.yaml` | Boss CR → ConfigMap with `entityState`, `bossPhase`, `damageMultiplier` |
@@ -206,7 +206,7 @@ Complete the five questions in [exercises/day-2-exercises.md](exercises/day-2-ex
 
 You have now:
 - Read all 9 production kro RGDs
-- Understood `readyWhen`, `includeWhen`, `forEach`, and `specPatch` from real examples
+- Understood `readyWhen`, `includeWhen`, `forEach`, and state nodes from real examples
 - Used the CEL Playground to verify expressions interactively
 - Identified the real constraints of CEL (no `let` bindings, no stateful iteration)
 

--- a/Docs/workshop/exercises/day-1-exercises.md
+++ b/Docs/workshop/exercises/day-1-exercises.md
@@ -6,7 +6,7 @@ Answer these 5 questions using the live game at `https://learn-kro.eks.aws.dev`.
 
 ## Q1 — Resource count
 
-Create a dungeon with 3 monsters. Open the kro panel and count all nodes in the resource graph (including specPatch nodes).
+Create a dungeon with 3 monsters. Open the kro panel and count all nodes in the resource graph (including state nodes).
 
 **How many resources did kro create from your single Dungeon CR?**
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Each dungeon instance gets its own Namespace for isolation and clean teardown.
                                            └──────────┘
 ```
 
-- **Frontend** — 8-bit pixel art React SPA. All game state read from Dungeon CR `spec` (not `status`, which can be stale after room transitions). Nginx reverse-proxies `/api/` to the backend. Includes a kro teaching layer: InsightCards, KroGlossary, CelTrace, live resource graph (KroGraph), Inspector panel, and an in-browser CEL Playground.
-- **Backend** — Stateless Go service. Only touches Dungeon, Attack, and Action CRs — never reads Pods, Secrets, or Jobs directly. Writes trigger fields to the Dungeon CR spec and polls for kro's CEL specPatch results; computes loot drops, log text, XP, leaderboard entries, and room-transition triggers. Includes rate limiting (300 ms/dungeon), Prometheus metrics on `/metrics`, and a CEL eval endpoint.
+- **Frontend** — 8-bit pixel art React SPA. Game state read from Dungeon CR `status.game` (via `getGame()` with spec fallback for old dungeons). Nginx reverse-proxies `/api/` to the backend. Includes a kro teaching layer: InsightCards, KroGlossary, CelTrace, live resource graph (KroGraph), Inspector panel, and an in-browser CEL Playground.
+- **Backend** — Stateless Go service. Only touches Dungeon, Attack, and Action CRs — never reads Pods, Secrets, or Jobs directly. Writes trigger fields to the Dungeon CR spec and polls for kro's state-node results in `status.game`; computes loot drops, log text, XP, leaderboard entries, and room-transition triggers. Includes rate limiting (300 ms/dungeon), Prometheus metrics on `/metrics`, and a CEL eval endpoint.
 - **Kubernetes + kro** — Sole source of truth. Nine RGDs orchestrate the game via CR chaining. kro is self-installed via Helm (patched fork `cel-writeback-d`).
 - **Argo CD** — Runs as an [EKS Managed Capability](https://docs.aws.amazon.com/eks/latest/userguide/argocd.html). Continuously syncs all cluster manifests from this repo. GitHub webhook provides ~6 s sync latency.
 - **Observability** — CloudWatch Container Insights, structured JSON logs from the backend, CloudWatch dashboard and alarms. Prometheus metrics scraped from `/metrics`.
@@ -72,7 +72,7 @@ All nine ResourceGraphDefinitions live in `manifests/rgds/`:
 
 | RGD | File | What it creates |
 |---|---|---|
-| `dungeon-graph` | `dungeon-graph.yaml` | Namespace, Hero CR, Monster CRs (forEach), Boss CR, Treasure CR, Modifier CR, `gameConfig` CM, plus `specPatch` virtual nodes for combat/action/DoT/ability resolution |
+| `dungeon-graph` | `dungeon-graph.yaml` | Namespace, Hero CR, Monster CRs (forEach), Boss CR, Treasure CR, Modifier CR, `gameConfig` CM, plus state nodes for combat/action/DoT/ability resolution (write to `status.game`) |
 | `hero-graph` | `hero-graph.yaml` | `heroState` ConfigMap (entityState, maxHP, damageModifier, defense, dodgeChance) |
 | `monster-graph` | `monster-graph.yaml` | `monsterState` ConfigMap; conditional Loot CR on kill (includeWhen: HP=0) |
 | `boss-graph` | `boss-graph.yaml` | `bossState` ConfigMap with multi-phase derivation; conditional Loot CR on kill |

--- a/frontend/src/KroTeach.tsx
+++ b/frontend/src/KroTeach.tsx
@@ -189,7 +189,7 @@ The damage you just dealt was computed by CEL inside a state node in dungeon-gra
     body: `CEL does not have if/else blocks, but nested ternary expressions (\`condition ? a : b\`) create powerful state machines.
 The boss transitions between three states — pending, ready, and defeated — using a single two-level ternary. No controller code, no webhook: pure CEL evaluated by kro on every reconcile.`,
     snippet: `# boss-graph — entityState CEL ternary
-# Reads monstersAlive (computed by dungeon-graph, forwarded as spec field)
+# schema.spec.hp and schema.spec.monstersAlive are fields on the Boss CR spec (not Dungeon CR)
 data:
   entityState: >-
     \${schema.spec.hp > 0
@@ -264,12 +264,12 @@ resources:
     id: 'include-when-sibling',
     title: 'includeWhen — Sibling Resource References',
     tagline: 'Gate a resource on the live state of another resource in the same graph.',
-    body: `By default, \`includeWhen\` can only read \`schema.spec.*\` fields from the instance CR. kro now also supports referencing the **observed state of already-reconciled sibling resources** in the same RGD.
+    body: `By default, \`includeWhen\` reads \`schema.spec.*\` trigger fields and \`schema.status.game.*\` game state from the Dungeon CR. kro now also supports referencing the **observed state of already-reconciled sibling resources** in the same RGD.
 
-This means resource inclusion can be driven by real cluster data — not just what the operator wrote into the CR spec.
+This means resource inclusion can be driven by real cluster data — not just what the operator wrote into the CR.
 
-**Before (spec-only):**
-A dungeon specPatch fires because a counter field in spec was incremented by the backend.
+**Before (trigger field only):**
+A dungeon state node fires because a trigger counter in spec was incremented by the backend.
 
 **Now also valid (resource-backed):**
 A resource is conditionally created based on whether a sibling ConfigMap or CR has reached a specific state — without the backend having to write a trigger field.
@@ -393,7 +393,7 @@ resources:
     title: 'Empty RGD — CRD Factory Pattern',
     tagline: 'An RGD with resources:[] creates a CRD with no managed children.',
     body: `attack-graph and action-graph have \`resources: []\` — they manage no child resources at all. Their sole purpose is to define the Attack and Action custom resource types (CRDs).
-This is the "CRD factory" pattern: use kro to get a typed, validated CRD for free, without writing a controller. The actual logic lives in dungeon-graph's specPatch nodes (CEL expressions that fire on spec changes) and in the Go backend.`,
+This is the "CRD factory" pattern: use kro to get a typed, validated CRD for free, without writing a controller. The actual logic lives in dungeon-graph's state nodes (CEL expressions that fire when trigger fields in spec are incremented) and in the Go backend.`,
     snippet: `# attack-graph — empty RGD, defines Attack CRD only
 apiVersion: kro.run/v1alpha1
 kind: ResourceGraphDefinition
@@ -579,20 +579,21 @@ metadata:
 
   'spec-mutation': {
     id: 'spec-mutation',
-    title: 'Spec Mutation Triggers Full Reconcile',
-    tagline: 'One patch to spec → kro reconciles the entire resource graph.',
-    body: `When you enter Room 2, the Go backend calls the Kubernetes API to patch the Dungeon CR spec with \`lastAction: 'enter-room-2'\` and increments \`actionSeq\`. kro watches the Dungeon CR and immediately re-evaluates all CEL expressions in dungeon-graph.
-kro's \`enterRoom2Resolve\` specPatch node detects the action and computes the new \`monsterHP\`, \`bossHP\`, \`room2MonsterHP\`, \`room2BossHP\` values via CEL — writing them back to \`spec.*\` directly. New Monster CRs and an updated Boss CR are then created from those spec values. Kubernetes becomes the state machine.`,
+    title: 'Trigger Fields Drive Full Reconcile',
+    tagline: 'One patch to spec trigger fields → kro reconciles the entire resource graph.',
+    body: `When you enter Room 2, the Go backend patches the Dungeon CR spec with \`lastAction: 'enter-room-2'\` and increments \`actionSeq\`. kro watches the Dungeon CR and immediately re-evaluates all CEL expressions in dungeon-graph.
+kro's \`enterRoom2Resolve\` state node detects the action and computes the new \`monsterHP\`, \`bossHP\`, \`room2MonsterHP\`, \`room2BossHP\` values via CEL — writing them to \`status.game\`. New Monster CRs and an updated Boss CR are then reconciled from those state values. Kubernetes becomes the state machine.`,
     snippet: `# Backend writes only the trigger — kro does the rest
 patch := map[string]interface{}{
   "spec": map[string]interface{}{
     "lastAction": "enter-room-2",
     "actionSeq":  newSeq,
-    // kro's enterRoom2Resolve specPatch computes new HP values via CEL
+    // kro's enterRoom2Resolve state node computes new HP values via CEL
+    // and writes them to status.game
   },
 }
 // manifests/rgds/dungeon-graph.yaml reacts automatically`,
-    learnMore: 'manifests/rgds/dungeon-graph.yaml — enterRoom2Resolve specPatch node',
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — enterRoom2Resolve state node',
   },
 
   'cel-playground': {
@@ -756,7 +757,7 @@ This is a **3-state CEL counter** implemented entirely in kro state nodes writin
     tauntActive: "\${kstate(schema.status.game, 'tauntActive', 0) == 1 ? 2 : 0}"
 # combatResolve reads tauntActive == 2 to apply 60% damage reduction (2/5 of damage taken):
 # taunted: "\${tauntActive == 2 && pantsed > 0 ? pantsed * 2 / 5 : pantsed}"`,
-    learnMore: 'manifests/rgds/dungeon-graph.yaml — advanceTaunt and combatResolve specPatch nodes',
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — advanceTaunt and combatResolve state nodes',
   },
   'mana-lifecycle': {
     id: 'mana-lifecycle',
@@ -799,13 +800,13 @@ cel.bind(dodgeRoll, random.seededInt(0, 99, attackUID + "dodge"),
 The seed is the Attack CR UID concatenated with \`"dodge"\` — making every dodge roll **deterministic and reproducible** for a given attack. Re-running the same Attack CR with the same UID always produces the same dodge outcome. This is how kro implements game-quality randomness: seeded random, not cryptographic, but deterministic and auditable.
 
 The same pattern applies to backstab critical hits, boss status effect chances (poison/burn/stun), and loot rarity rolls throughout the RGDs.`,
-    snippet: `# dungeon-graph.yaml — combatResolve specPatch (rogue dodge)
+    snippet: `# dungeon-graph.yaml — combatResolve state node (rogue dodge)
 cel.bind(isRogue, schema.spec.heroClass == 'rogue',
   cel.bind(dodgeRoll, random.seededInt(0, 99, attackCR.metadata.uid + "dodge"),
     cel.bind(dodged, isRogue && dodgeRoll < 25,
       # dodged == true: hero takes 0 damage from this counter-attack
       dodged ? int(0) : int(baseDmg))))`,
-    learnMore: 'manifests/rgds/dungeon-graph.yaml — combatResolve specPatch, kro random.seededInt extension',
+    learnMore: 'manifests/rgds/dungeon-graph.yaml — combatResolve state node, kro random.seededInt extension',
   },
 }
 // ─── end KRO_CONCEPTS ────────────────────────────────────────────────────────
@@ -816,7 +817,7 @@ export function getInsightForEvent(event: string): InsightTrigger | null {
   if (event === 'spec-schema') return { conceptId: 'spec-schema', headline: 'kro validated your difficulty/heroClass fields against spec.schema enums' }
   if (event === 'schema-validated') return { conceptId: 'schema-validation', headline: 'kro compiled your spec.schema into a CRD — the API server now rejects invalid dungeons' }
   if (event === 'resource-chaining') return { conceptId: 'resource-chaining', headline: 'Hero CR status (maxHP, class) flowed up through dungeon-graph resource chaining' }
-   if (event === 'first-attack') return { conceptId: 'cel-basics', headline: 'Your damage was computed by a CEL expression in the combatResolve specPatch node' }
+   if (event === 'first-attack') return { conceptId: 'cel-basics', headline: 'Your damage was computed by a CEL expression in the combatResolve state node — result written to status.game' }
   if (event === 'monster-killed') return { conceptId: 'includeWhen', headline: 'A Loot CR appeared because monster HP hit 0 (includeWhen)' }
   if (event === 'boss-ready') return { conceptId: 'cel-ternary', headline: 'Boss transitioned pending → ready via a CEL ternary in boss-graph' }
   if (event === 'boss-killed') return { conceptId: 'cel-filter', headline: 'kro ran .filter() on all Monster CRs to re-aggregate livingMonsters to 0' }
@@ -835,11 +836,11 @@ export function getInsightForEvent(event: string): InsightTrigger | null {
    if (event === 'boots-equipped') return { conceptId: 'cel-has-macro', headline: 'has() lets CEL safely access optional spec fields — used throughout dungeon-graph readyWhen' }
   if (event === 'dungeon-deleted') return { conceptId: 'ownerReferences', headline: 'Deleting the Dungeon CR triggered cascading deletion of all 9 child resources via ownerReferences' }
   if (event === 'cel-playground-unlocked') return { conceptId: 'cel-playground', headline: 'Open the CEL Playground to write and evaluate live kro expressions against your dungeon' }
-  // #450: spec-patch concept fires on first DoT tick — most visible specPatch in action
-  if (event === 'dot-applied') return { conceptId: 'spec-patch', headline: 'tickDoT specPatch fired: CEL decremented heroHP and poisonTurns/burnTurns directly in spec' }
+  // #450: spec-patch concept fires on first DoT tick — most visible state node in action
+  if (event === 'dot-applied') return { conceptId: 'spec-patch', headline: 'tickDoT state node fired: CEL decremented status.game.heroHP and poisonTurns/burnTurns' }
   // #459: class-specific kro deep dives
-  if (event === 'warrior-taunt-used') return { conceptId: 'taunt-state-machine', headline: 'Taunt activated — advanceTaunt specPatch will count down tauntActive from 2→1→0 each turn' }
-  if (event === 'mage-heal-used') return { conceptId: 'mana-lifecycle', headline: 'Heal used — cel.bind() clamps heroMana and heroHP to their maxima in abilityResolve specPatch' }
+  if (event === 'warrior-taunt-used') return { conceptId: 'taunt-state-machine', headline: 'Taunt activated — advanceTaunt state node counts down status.game.tauntActive 2→1→0 each turn' }
+  if (event === 'mage-heal-used') return { conceptId: 'mana-lifecycle', headline: 'Heal used — cel.bind() clamps heroMana and heroHP to their maxima in abilityResolve state node' }
   if (event === 'rogue-dodge-fired') return { conceptId: 'cel-probability', headline: 'Dodge fired — random.seededInt(0,99,uid+"dodge") < 25: a 25% chance gate in pure CEL' }
   return null
 }
@@ -1340,7 +1341,7 @@ export function CelTrace({ data, onLearnMore }: { data: CelTraceData; onLearnMor
       </button>
       {open && (
         <div className="cel-trace-body">
-          <div className="cel-trace-header">dungeon-graph → combatResolve specPatch <span style={{ fontSize: 10, color: '#888', marginLeft: 6 }}>post-reconcile state</span></div>
+          <div className="cel-trace-header">dungeon-graph → combatResolve state node <span style={{ fontSize: 10, color: '#888', marginLeft: 6 }}>post-reconcile state</span></div>
           <table className="cel-trace-table">
             <thead>
               <tr>
@@ -1450,7 +1451,7 @@ spec:
   {
     title: 'kro Creates 16 Resources From One CR',
     // #451: updated from "7 resources + 2 ConfigMaps" to reflect current architecture
-    body: "kro's dungeon-graph RGD watches your Dungeon CR. The moment you apply it, kro automatically creates a Namespace, Hero CR, Monster CRs, Boss CR, Treasure CR, 1 GameConfig CM, and 9 specPatch nodes (combatResolve, actionResolve, etc.) that write CEL-computed values directly back to spec — all from a single CR.",
+    body: "kro's dungeon-graph RGD watches your Dungeon CR. The moment you apply it, kro automatically creates a Namespace, Hero CR, Monster CRs, Boss CR, Treasure CR, 1 GameConfig CM, and state nodes (combatResolve, actionResolve, etc.) that write CEL-computed values to status.game — all from a single CR.",
     snippet: `# dungeon-graph RGD orchestrates:
 resources:
   - id: ns           # Namespace

--- a/tests/e2e/journeys/31-kro-inspector-combat-modifier-cm.js
+++ b/tests/e2e/journeys/31-kro-inspector-combat-modifier-cm.js
@@ -9,7 +9,7 @@
 // modifier-cm: present only when dungeon has a modifier (includeWhen guard)
 //              — tested conditionally; warns if no modifier was assigned.
 //
-// NOTE: combatResolve and actionResolve are virtual specPatch nodes with no
+// NOTE: combatResolve and actionResolve are virtual state nodes with no
 // persistent K8s resource — the Inspector skips them by design. gameConfig is
 // the closest real ConfigMap that shows kro CEL output for every dungeon.
 const { chromium } = require('playwright');
@@ -134,7 +134,7 @@ async function run() {
       if (label && label.includes('modifierState')) modifierNodeFound = true;
     }
     combatNodeFound
-      ? ok('combatResolve (specPatch) node found in KroGraph')
+      ? ok('combatResolve (stateNode) node found in KroGraph')
       : fail('combatResolve node not found in KroGraph');
     gameConfigNodeFound
       ? ok('gameConfig (ConfigMap) node found in KroGraph')

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -112,7 +112,7 @@ submit_attack() {
 
 # Submit an action (non-combat) via the backend REST API and wait for kro to finish.
 # The backend writes trigger fields (lastAction, actionSeq) and kro's actionResolve
-# specPatch computes the actual state mutations, then clears lastAction.
+# state node computes the actual state mutations and writes them to status.game.
 # Usage: submit_action <dungeon-name> <action>
 submit_action() {
   local dname="$1" action="$2"


### PR DESCRIPTION
## Summary

Second pass cleanup after the initial PR #610 — catches remaining stale `specPatch` and `schema.spec.*` game-state references missed in the first sweep.

### Changes

**KroTeach.tsx** — concept cards and InsightCard headlines:
- `includeWhen` body: "spec-only" → "trigger field only"
- `empty-rgd` body: "specPatch nodes" → "state nodes"
- `cel-ternary` snippet comment: clarified boss-graph `schema.spec.*` refers to Boss CR's own spec (correct)
- `spec-mutation` concept: renamed "Spec Mutation Triggers Full Reconcile" → "Trigger Fields Drive Full Reconcile"; body and snippet updated for `status.game`
- `cel-probability` snippet/learnMore: `specPatch` → `state node`
- `taunt-state-machine` learnMore: `specPatch` → `state nodes`
- InsightCard headlines: all `specPatch` references updated
- CelTrace panel header: `combatResolve specPatch` → `combatResolve state node`
- Onboarding slide: "9 specPatch nodes" → "state nodes"
- `includeWhen`-sibling body: cleaned up

**AGENTS.md** — architecture description, table header, backend bullet points, frontend description, bossPhase fallback field path

**README.md** — frontend/backend descriptions and RGD table

**Docs/demo/DEMO.md** — minute-1 speaker cue

**Docs/workshop/** — day-2 objectives, RGD table, day-1 completion checklist, README, exercises Q1

**tests/helpers.sh** — submit_action comment

**tests/e2e/journeys/31-kro-inspector-combat-modifier-cm.js** — comment and ok() message

Closes #600