### PR TITLE
fix: add get verb to rpg-backend-reconcile-watch ClusterRole for /resources endpoint

### DIFF
--- a/manifests/rbac/rbac.yaml
+++ b/manifests/rbac/rbac.yaml
@@ -67,15 +67,15 @@ kind: ClusterRole
 metadata:
   name: rpg-backend-reconcile-watch
 rules:
-  # Watch ConfigMaps in dungeon namespaces — kro-generated monster/hero/boss/game state CMs
+  # Watch/get ConfigMaps in dungeon namespaces — kro-generated monster/hero/boss/game state CMs
   - apiGroups: [""]
     resources: [configmaps]
-    verbs: [list, watch]
-  # Watch all kro-managed child game CRs (heroes, monsters, bosses, treasures, modifiers, loots)
+    verbs: [get, list, watch]
+  # Watch/get all kro-managed child game CRs (heroes, monsters, bosses, treasures, modifiers, loots)
   - apiGroups: [game.k8s.example]
     resources: [heroes, heroes/status, monsters, monsters/status, bosses, bosses/status,
                 treasures, treasures/status, modifiers, modifiers/status, loots, loots/status]
-    verbs: [list, watch]
+    verbs: [get, list, watch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary

- The `rpg-backend-reconcile-watch` ClusterRole granted `list, watch` on `configmaps` and child game CRs (`monsters`, `heroes`, etc.) but was missing `get`.
- The `/api/v1/dungeons/:namespace/:name/resources` endpoint fetches individual resources by name (single-object `get`), causing RBAC-forbidden 404s visible in CloudWatch logs.
- Fix: add `get` to both rules in the `rpg-backend-reconcile-watch` ClusterRole.

## What changed

`manifests/rbac/rbac.yaml` — `rpg-backend-reconcile-watch` ClusterRole rules updated:
- `configmaps`: `[list, watch]` → `[get, list, watch]`
- game CRs (monsters, heroes, etc.): `[list, watch]` → `[get, list, watch]`

## Guardrails

The RBAC guardrail checks (`tests/guardrails.sh`) are scoped to the `rpg-backend` ClusterRole/Role sections and are unaffected by this change to the separate `rpg-backend-reconcile-watch` ClusterRole.

Note: pre-existing integration test timeout failure (`test-core.sh` kro resolve timeout) exists on `main` and is unrelated to this change.